### PR TITLE
fix: translation

### DIFF
--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -44,7 +44,7 @@
     "email": "Correo electrónico",
     "error": "Error",
     "fee": "Cuota",
-    "Fee": "La Cuota",
+    "Fee": "Tarifa",
     "fees": "\nTarifa",
     "feeSats": "Tarifas (sats)",
     "feesUsd": "Tarifas (USD) ",


### PR DESCRIPTION
This will remove the line break in the 'send screen' when using ES translation