### PR TITLE
value of qrcode to uppercase to simplify qr code image

### DIFF
--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -350,18 +350,17 @@ export const ReceiveBitcoinScreen = ({ navigation }: Props) => {
     const getFullUri = (input) => {
       if (type === "lightning") {
         // TODO add lightning:
-        return input
+        return input.toUpperCase()
       }
       const uri = `bitcoin:${input}`
       const params = new URLSearchParams()
-      if (amount) {
-        params.append("amount", `${amount / 10 ** 8}`)
-      }
+      if (amount) params.append("amount", `${amount / 10 ** 8}`)
       if (memo) {
         params.append("message", encodeURI(memo))
+        return `${uri}?${params.toString()}`
       }
       const fullUri = params.toString() ? `${uri}?${params.toString()}` : `${uri}`
-      return fullUri
+      return fullUri.toUpperCase()
     }
 
     const copyToClipboard = () => {

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -347,12 +347,12 @@ export const ReceiveBitcoinScreen = ({ navigation }: Props) => {
     const isReady =
       type === "lightning" ? !loading && data != "" && !keyboardIsShown : true
 
-    const getFullUri = (input) => {
+    const getFullUri = (input, uppercase = false) => {
       if (type === "lightning") {
         // TODO add lightning:
-        return input.toUpperCase()
+        return uppercase ? input.toUpperCase() : input
       }
-      const uri = `bitcoin:${input}`
+      const uri = uppercase ? `bitcoin:${input}`.toUpperCase() : `bitcoin:${input}`
       const params = new URLSearchParams()
       if (amount) params.append("amount", `${amount / 10 ** 8}`)
       if (memo) {
@@ -360,7 +360,7 @@ export const ReceiveBitcoinScreen = ({ navigation }: Props) => {
         return `${uri}?${params.toString()}`
       }
       const fullUri = params.toString() ? `${uri}?${params.toString()}` : `${uri}`
-      return fullUri.toUpperCase()
+      return fullUri
     }
 
     const copyToClipboard = () => {
@@ -427,7 +427,7 @@ export const ReceiveBitcoinScreen = ({ navigation }: Props) => {
               <Pressable onPress={copyToClipboard}>
                 <QRCode
                   size={280}
-                  value={getFullUri(data)}
+                  value={getFullUri(data, true)}
                   logoBackgroundColor="white"
                   ecl="L"
                   // __DEV__ workaround for https://github.com/facebook/react-native/issues/26705

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -663,7 +663,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 49af259315248df108d3144509353caec1d96a1d
+  FBReactNativeSpec: 467941a0c0734778d1a7b4dd057e48e6016d9a05
   Firebase: e1e089d9aac215a52442583f818ab61de3c4581b
   FirebaseAnalytics: 9f8f4feab1f3fddf4e4515f8f022fe6aa9e51043
   FirebaseCore: 0a43b7f1c5b36f3358cd703011ca4c7e0df55870


### PR DESCRIPTION
PR relates to [issue 13](https://github.com/GaloyMoney/galoy-mobile/issues/13).

Most of the changes are prettier, with the only relevant change being on line 419.

The value used in QR codes have been converted to uppercase to simplify the QR image. I have opted to not uppercase the value that is displayed below the QR code for viewability purposes, but I can change this too if thought to be neccessary. 

