### PR TITLE
Possible fix for a pico amount of btc from Phoenix lightning invoice

### DIFF
--- a/app/utils/parsing.ts
+++ b/app/utils/parsing.ts
@@ -168,7 +168,7 @@ export const validPayment = (
     let amountless
 
     if (payReq.satoshis || payReq.millisatoshis) {
-      amount = payReq.satoshis ?? Number(payReq.millisatoshis) * 1000
+      amount = payReq.satoshis ?? Number(payReq.millisatoshis) / 1000
       amountless = false
     } else {
       amount = 0


### PR DESCRIPTION
I'm not sure if this fixes #114  because I don't know an easy way to generate a valid lightning address with pico btc yet (my Phoenix wallet used nano), but it seems likely that it will.