### PR TITLE
Check for null when reading clipboard cache

### DIFF
--- a/app/graphql/__generated__/LastClipboardPayment.ts
+++ b/app/graphql/__generated__/LastClipboardPayment.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: LastClipboardPayment
+// ====================================================
+
+export interface LastClipboardPayment {
+  lastClipboardPayment: string | null;
+}

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -9,3 +9,7 @@ extend type Transaction {
 extend type Contact {
   prettyName: String!
 }
+
+extend type Query {
+  lastClipboardPayment: String
+}

--- a/app/utils/clipboard.ts
+++ b/app/utils/clipboard.ts
@@ -19,8 +19,7 @@ export const showModalClipboardIfValidPayment = async (
   }
 
   const data = cache.readQuery<LastClipboardPayment>({ query: LAST_CLIPBOARD_PAYMENT })
-  const lastClipboardPayment = data?.lastClipboardPayment ?? ""
-  if (clipboard === lastClipboardPayment) {
+  if (clipboard === data?.lastClipboardPayment) {
     return
   }
 

--- a/app/utils/clipboard.ts
+++ b/app/utils/clipboard.ts
@@ -6,6 +6,7 @@ import { modalClipboardVisibleVar, walletIsActive } from "../graphql/query"
 import { Token } from "./token"
 import { cache } from "../graphql/cache"
 import { LAST_CLIPBOARD_PAYMENT } from "../graphql/client-only-query"
+import { LastClipboardPayment } from "../graphql/__generated__/LastClipboardPayment"
 
 export const showModalClipboardIfValidPayment = async (
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -17,7 +18,8 @@ export const showModalClipboardIfValidPayment = async (
     return
   }
 
-  const { lastClipboardPayment } = cache.readQuery({ query: LAST_CLIPBOARD_PAYMENT })
+  const data = cache.readQuery<LastClipboardPayment>({ query: LAST_CLIPBOARD_PAYMENT })
+  const lastClipboardPayment = data?.lastClipboardPayment ?? ""
   if (clipboard === lastClipboardPayment) {
     return
   }


### PR DESCRIPTION
Fixes a bug when reading `lastClipboardPayment` from apollo cache when the value is null.