### PR TITLE
fetch wallet updates separate from useLazyQuery

### DIFF
--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -97,6 +97,15 @@ export const balanceUsd = (client: ApolloClient<unknown>): number =>
 export const balanceBtc = (client: ApolloClient<unknown>): number =>
   _.find(getWallet(client), { id: "BTC" }).balance
 
+export const getWalletNetworkOnly = async (
+  client: ApolloClient<unknown>,
+): Promise<void> => {
+  await client.query({
+    query: WALLET,
+    fetchPolicy: "network-only",
+  })
+}
+
 export const getPubKey = (client: MockableApolloClient): string => {
   const { nodeStats } = client.readQuery({
     query: gql`

--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, gql, makeVar } from "@apollo/client"
+import { ApolloClient, FetchPolicy, gql, makeVar } from "@apollo/client"
 import _ from "lodash"
 import { MockableApolloClient } from "../types/mockable"
 import { wallet_wallet } from "./__generated__/wallet"
@@ -97,12 +97,13 @@ export const balanceUsd = (client: ApolloClient<unknown>): number =>
 export const balanceBtc = (client: ApolloClient<unknown>): number =>
   _.find(getWallet(client), { id: "BTC" }).balance
 
-export const getWalletNetworkOnly = async (
+export const queryWallet = async (
   client: ApolloClient<unknown>,
+  fetchPolicy: FetchPolicy,
 ): Promise<void> => {
   await client.query({
     query: WALLET,
-    fetchPolicy: "network-only",
+    fetchPolicy,
   })
 }
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -17,6 +17,7 @@ import {
   balanceBtc,
   btc_price,
   getPubKey,
+  getWalletNetworkOnly,
   QUERY_TRANSACTIONS,
   USERNAME_EXIST,
   WALLET,
@@ -29,7 +30,6 @@ import { palette } from "../../theme/palette"
 import type { ScreenType } from "../../types/jsx"
 import { textCurrencyFormatting } from "../../utils/currencyConversion"
 import { IPaymentType, validPayment } from "../../utils/parsing"
-import { sleep } from "../../utils/sleep"
 import { Token } from "../../utils/token"
 import { UsernameValidation } from "../../utils/validation"
 
@@ -224,8 +224,6 @@ export const SendBitcoinScreen: React.FC<SendBitcoinScreenProps> = ({
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [getOnchainFees, { loading: onchainFeeLoading }] = useMutation(ONCHAIN_FEES)
-
-  const [updateWallet] = useLazyQuery(WALLET, { fetchPolicy: "network-only" })
 
   // TODO use a debouncer to avoid flickering https://github.com/helfer/apollo-link-debounce
   const [
@@ -446,10 +444,8 @@ export const SendBitcoinScreen: React.FC<SendBitcoinScreenProps> = ({
       }
 
       if (success) {
-        updateWallet()
+        getWalletNetworkOnly(client)
         setStatus("success")
-        await sleep(1000)
-        updateWallet()
       } else if (pending) {
         setStatus("pending")
       } else {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -20,7 +20,6 @@ import {
   getWalletNetworkOnly,
   QUERY_TRANSACTIONS,
   USERNAME_EXIST,
-  WALLET,
 } from "../../graphql/query"
 import { usePrefCurrency } from "../../hooks/usePrefCurrency"
 import { translate } from "../../i18n"

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -17,7 +17,7 @@ import {
   balanceBtc,
   btc_price,
   getPubKey,
-  getWalletNetworkOnly,
+  queryWallet,
   QUERY_TRANSACTIONS,
   USERNAME_EXIST,
 } from "../../graphql/query"
@@ -443,7 +443,7 @@ export const SendBitcoinScreen: React.FC<SendBitcoinScreenProps> = ({
       }
 
       if (success) {
-        getWalletNetworkOnly(client)
+        queryWallet(client, "network-only")
         setStatus("success")
       } else if (pending) {
         setStatus("pending")


### PR DESCRIPTION
Fixes #141. I am not sure exactly how useQuery and useLazyQuery work, but it seems if you leave the component before they complete, the data retrieved from them will not update in the cache. By separating the updateWallet query from the component we ensure that the cache is updated when the query completes.