### PR TITLE
Cap amount digits and custom margins for currencies

### DIFF
--- a/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
+++ b/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
@@ -385,6 +385,7 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
           "justifyContent": "space-between",
         }
       }
+      keyboardShouldPersistTaps="always"
     >
       <View>
         <View>
@@ -397,7 +398,10 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                   Array [
                     undefined,
                     undefined,
-                    undefined,
+                    Object {
+                      "marginLeft": "0%",
+                      "width": "100%",
+                    },
                   ]
                 }
               >
@@ -452,6 +456,7 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                   </View>
                   <TextInput
                     allowFontScaling={true}
+                    autoCorrect={false}
                     autoFocus={true}
                     contextMenuHidden={true}
                     editable={true}
@@ -534,14 +539,7 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                 </View>
               </RNGestureHandlerButton>
             </View>
-            <Text
-              style={
-                Array [
-                  undefined,
-                  undefined,
-                ]
-              }
-            >
+            <Text>
               0
                
               sats

--- a/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
+++ b/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
@@ -397,6 +397,7 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                   Array [
                     undefined,
                     undefined,
+                    undefined,
                   ]
                 }
               >
@@ -533,7 +534,14 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                 </View>
               </RNGestureHandlerButton>
             </View>
-            <Text>
+            <Text
+              style={
+                Array [
+                  undefined,
+                  undefined,
+                ]
+              }
+            >
               0
                
               sats

--- a/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
+++ b/__tests__/screens/__snapshots__/send-bitcoin-screen.spec.tsx.snap
@@ -399,8 +399,8 @@ exports[`SendBitcoinScreen render matches snapshot 1`] = `
                     undefined,
                     undefined,
                     Object {
-                      "marginLeft": "0%",
-                      "width": "100%",
+                      "marginLeft": "1.5%",
+                      "width": "98.5%",
                     },
                   ]
                 }

--- a/app/components/input-payment/input-payment.tsx
+++ b/app/components/input-payment/input-payment.tsx
@@ -38,20 +38,6 @@ const styles = EStyleSheet.create({
     position: "absolute",
   },
 
-  inputMaskPositioningBTC: {
-    marginRight: "10%",
-    width: "90%",
-  },
-
-  inputMaskPositioningDefault: {
-    width: "100%",
-  },
-
-  inputMaskPositioningUSD: {
-    marginLeft: "10%",
-    width: "90%",
-  },
-
   inputText: {
     opacity: 0,
   },
@@ -65,18 +51,11 @@ const styles = EStyleSheet.create({
   subCurrencyText: {
     color: palette.midGrey,
     fontSize: "16rem",
+    marginRight: "10%",
     marginTop: 0,
     paddingTop: 0,
     textAlign: "center",
-  },
-
-  subCurrencyTextBTC: {
-    marginRight: "20%",
-    width: "80%",
-  },
-
-  subCurrencyTextUSD: {
-    width: "100%",
+    width: "90%",
   },
 
   textStyle: {
@@ -166,7 +145,7 @@ export const InputPayment: ComponentType = ({
 
   React.useEffect(() => {
     // TODO: show "an amount is needed" in red
-    if (forceKeyboard && +amountInput == 0) {
+    if (forceKeyboard && +amountInput === 0) {
       inputRef?.current.focus()
     }
   }, [forceKeyboard, amountInput])
@@ -234,22 +213,20 @@ export const InputPayment: ComponentType = ({
 
   const inputMaskPositioningStyle = () => {
     if (currency === CurrencyType.USD) {
-      return styles.inputMaskPositioningUSD
+      return {
+        marginLeft: `${displayValue.replace(/[^0-9]/g, "").length - 3}%`,
+        width: `${103 - displayValue.replace(/[^0-9]/g, "").length}%`,
+      }
     } else if (currency === CurrencyType.BTC || currency === "sats") {
-      return styles.inputMaskPositioningBTC
+      return {
+        marginRight: `${displayValue.replace(/[^0-9]/g, "").length}%`,
+        width: `${100 - displayValue.replace(/[^0-9]/g, "").length}%`,
+      }
     }
 
-    return styles.inputMaskPositioningDefault
-  }
-
-  const subCurrencyTextStyle = () => {
-    if (currency === CurrencyType.USD) {
-      return styles.subCurrencyTextUSD
-    } else if (currency === CurrencyType.BTC || currency === "sats") {
-      return styles.subCurrencyTextBTC
+    return {
+      width: "100%",
     }
-
-    return null
   }
 
   return (
@@ -268,6 +245,7 @@ export const InputPayment: ComponentType = ({
         </Text>
         <Input
           ref={inputRef}
+          autoCorrect={false}
           autoFocus={forceKeyboard}
           value={displayValue}
           leftIcon={leftIcon()}
@@ -294,7 +272,7 @@ export const InputPayment: ComponentType = ({
         <TextCurrency
           amount={mapping[prefCurrency].secondaryConversion(amount)}
           currency={mapping[prefCurrency].secondary}
-          style={[styles.subCurrencyText, subCurrencyTextStyle()]}
+          style={styles.subCurrencyText}
         />
       )}
     </View>

--- a/app/components/input-payment/input-payment.tsx
+++ b/app/components/input-payment/input-payment.tsx
@@ -212,16 +212,17 @@ export const InputPayment: ComponentType = ({
   }
 
   const inputMaskPositioningStyle = () => {
-    const numberOfDigits = displayValue.replace(/[^0-9]/g, "").length
+    const additionalMargin = displayValue.replace(/[^0-9]/g, "").length * 1.5
+
     if (currency === CurrencyType.USD) {
       return {
-        marginLeft: `${numberOfDigits - 3}%`,
-        width: `${103 - numberOfDigits}%`,
+        marginLeft: `${additionalMargin - 3}%`,
+        width: `${103 - additionalMargin}%`,
       }
     } else if (currency === CurrencyType.BTC || currency === "sats") {
       return {
-        marginRight: `${numberOfDigits}%`,
-        width: `${100 - numberOfDigits}%`,
+        marginRight: `${additionalMargin}%`,
+        width: `${100 - additionalMargin}%`,
       }
     }
 

--- a/app/components/input-payment/input-payment.tsx
+++ b/app/components/input-payment/input-payment.tsx
@@ -212,15 +212,16 @@ export const InputPayment: ComponentType = ({
   }
 
   const inputMaskPositioningStyle = () => {
+    const numberOfDigits = displayValue.replace(/[^0-9]/g, "").length
     if (currency === CurrencyType.USD) {
       return {
-        marginLeft: `${displayValue.replace(/[^0-9]/g, "").length - 3}%`,
-        width: `${103 - displayValue.replace(/[^0-9]/g, "").length}%`,
+        marginLeft: `${numberOfDigits - 3}%`,
+        width: `${103 - numberOfDigits}%`,
       }
     } else if (currency === CurrencyType.BTC || currency === "sats") {
       return {
-        marginRight: `${displayValue.replace(/[^0-9]/g, "").length}%`,
-        width: `${100 - displayValue.replace(/[^0-9]/g, "").length}%`,
+        marginRight: `${numberOfDigits}%`,
+        width: `${100 - numberOfDigits}%`,
       }
     }
 

--- a/app/components/input-payment/input-payment.tsx
+++ b/app/components/input-payment/input-payment.tsx
@@ -19,6 +19,8 @@ import {
 import { CurrencyType } from "../../utils/enum"
 import { TextCurrency } from "../text-currency/text-currency"
 
+const digitLimit = 10
+
 const styles = EStyleSheet.create({
   container: {
     alignItems: "center",
@@ -33,9 +35,21 @@ const styles = EStyleSheet.create({
   },
 
   inputMaskPositioning: {
-    marginHorizontal: "15%",
     position: "absolute",
-    width: "70%",
+  },
+
+  inputMaskPositioningBTC: {
+    marginRight: "10%",
+    width: "90%",
+  },
+
+  inputMaskPositioningDefault: {
+    width: "100%",
+  },
+
+  inputMaskPositioningUSD: {
+    marginLeft: "10%",
+    width: "90%",
   },
 
   inputText: {
@@ -53,6 +67,16 @@ const styles = EStyleSheet.create({
     fontSize: "16rem",
     marginTop: 0,
     paddingTop: 0,
+    textAlign: "center",
+  },
+
+  subCurrencyTextBTC: {
+    marginRight: "20%",
+    width: "80%",
+  },
+
+  subCurrencyTextUSD: {
+    width: "100%",
   },
 
   textStyle: {
@@ -76,6 +100,7 @@ type InputPaymentDataInjectedProps = {
   forceKeyboard: boolean
   initAmount?: number
   prefCurrency: string
+  maxLength: number
   nextPrefCurrency: () => void
   currencyPreference?: string // "sats" | "BTC" | "usd"
   sub?: boolean
@@ -117,7 +142,9 @@ export const InputPayment: ComponentType = ({
   const currency = mapping[prefCurrency].primary
 
   const handleTextInputChange = (text) => {
-    setInput(textToCurrency(text, currency))
+    setInput(
+      textToCurrency(text.replace(/[^0-9]/g, "").substring(0, digitLimit), currency),
+    )
   }
 
   React.useEffect(() => {
@@ -205,13 +232,37 @@ export const InputPayment: ComponentType = ({
     return null
   }
 
+  const inputMaskPositioningStyle = () => {
+    if (currency === CurrencyType.USD) {
+      return styles.inputMaskPositioningUSD
+    } else if (currency === CurrencyType.BTC || currency === "sats") {
+      return styles.inputMaskPositioningBTC
+    }
+
+    return styles.inputMaskPositioningDefault
+  }
+
+  const subCurrencyTextStyle = () => {
+    if (currency === CurrencyType.USD) {
+      return styles.subCurrencyTextUSD
+    } else if (currency === CurrencyType.BTC || currency === "sats") {
+      return styles.subCurrencyTextBTC
+    }
+
+    return null
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.main}>
         <Text
           ellipsizeMode="middle"
           numberOfLines={1}
-          style={[styles.textStyle, styles.inputMaskPositioning]}
+          style={[
+            styles.textStyle,
+            styles.inputMaskPositioning,
+            inputMaskPositioningStyle(),
+          ]}
         >
           {displayValue}
         </Text>
@@ -243,7 +294,7 @@ export const InputPayment: ComponentType = ({
         <TextCurrency
           amount={mapping[prefCurrency].secondaryConversion(amount)}
           currency={mapping[prefCurrency].secondary}
-          style={styles.subCurrencyText}
+          style={[styles.subCurrencyText, subCurrencyTextStyle()]}
         />
       )}
     </View>

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -488,7 +488,7 @@ export const PrimaryNavigator: NavigatorType = () => {
       initialRouteName="MoveMoney"
       tabBarOptions={{
         activeTintColor: network === "mainnet" ? palette.lightBlue : palette.orange,
-        inactiveTintColor: palette.lightGrey,
+        inactiveTintColor: palette.midGrey,
         style: styles.bottomNavigatorStyle,
         labelStyle: { paddingBottom: 6 },
         keyboardHidesTabBar: true,

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -489,7 +489,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
 
   return (
     <Screen backgroundColor={palette.lighterGrey} style={styles.screen} preset="fixed">
-      <ScrollView>
+      <ScrollView keyboardShouldPersistTaps="always">
         <View style={styles.section}>
           <InputPaymentDataInjected
             onUpdateAmount={setAmount}

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -649,6 +649,7 @@ export const SendBitcoinScreenJSX: ScreenType = ({
       <ScrollView
         style={styles.mainView}
         contentContainerStyle={{ justifyContent: "space-between" }}
+        keyboardShouldPersistTaps="always"
       >
         <View style={styles.section}>
           <InputPayment

--- a/app/utils/currencyConversion.ts
+++ b/app/utils/currencyConversion.ts
@@ -90,7 +90,11 @@ export const currencyToText = (
         maximumFractionDigits: 2,
         minimumFractionDigits: 2,
       })
-    : value
+    : Number(value).toLocaleString(locale, {
+        style: "decimal",
+        maximumFractionDigits: 0,
+        minimumFractionDigits: 0,
+      })
 
 const getDigitsFromValue = (value = "") => value.replace(/(-(?!\d))|[^0-9|-]/g, "") || ""
 


### PR DESCRIPTION
Fixes issue #151. But there is a catch. This PR causes the text to center differently betweens `sats` and `$`.


https://user-images.githubusercontent.com/35902932/129268102-889b30b7-b4b1-40ab-b597-72761720f846.mp4

This is because the margins to avoid the unit symbols are different.

If the change of text positioning is unacceptable we can either:

1. Leave the margins the same between currencies. This requires using the strictest margins for all currencies. This leaves unused white space (`$` space for an amount in sats and `sats` space for an amount in dollars). This is what the current version of the app does.
2. Dynamically alter the margins as more text is added so that the amount starts in the center, but can fill in the blank space as more digits are added. The downside is that this is complex, and I am not sure if the end product will look good.