### PR TITLE
Query main outside of component

### DIFF
--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -254,3 +254,14 @@ export const MAIN_QUERY = gql`
     }
   }
 `
+
+export const queryMain = async (
+  client: ApolloClient<unknown>,
+  variables: { logged: boolean },
+): Promise<void> => {
+  await client.query({
+    query: WALLET,
+    variables,
+    fetchPolicy: "network-only",
+  })
+}

--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -11,13 +11,7 @@ import {
   View,
 } from "react-native"
 import { Input } from "react-native-elements"
-import {
-  FetchResult,
-  gql,
-  useApolloClient,
-  useLazyQuery,
-  useMutation,
-} from "@apollo/client"
+import { FetchResult, gql, useApolloClient, useMutation } from "@apollo/client"
 import EStyleSheet from "react-native-extended-stylesheet"
 import PhoneInput from "react-native-phone-input"
 import analytics from "@react-native-firebase/analytics"

--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -26,7 +26,7 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { CloseCross } from "../../components/close-cross"
 import { Screen } from "../../components/screen"
 import { translate } from "../../i18n"
-import { MAIN_QUERY } from "../../graphql/query"
+import { queryMain } from "../../graphql/query"
 import { color } from "../../theme"
 import { palette } from "../../theme/palette"
 import { Token } from "../../utils/token"
@@ -181,10 +181,6 @@ export const WelcomePhoneValidationScreenDataInjected: ScreenType = ({
     fetchPolicy: "no-cache",
   })
 
-  const [reloadMainQuery] = useLazyQuery(MAIN_QUERY, {
-    fetchPolicy: "network-only",
-  })
-
   const onSuccess = async ({ token }) => {
     analytics().logLogin({ method: "phone" })
     await Token.getInstance().save(token)
@@ -196,7 +192,7 @@ export const WelcomePhoneValidationScreenDataInjected: ScreenType = ({
 
     // console.log("succesfully update earns id")
 
-    reloadMainQuery({ variables: { logged: Token.getInstance().has() } })
+    queryMain(client, { logged: Token.getInstance().has() })
 
     console.log("sending device token for notifications")
     addDeviceToken(client)


### PR DESCRIPTION
Mostly fixes #97. 

This doesn't change the logic for what to do if a user reaches the home screen without the main query data. It also doesn't force the main query data to load before reaching the home screen. But similarly to #142 it takes the networking call in phone-auth out of the component, so that the response data is cached if the request completes after leaving the phone-auth component.

This will make the problem much less noticeable, so it might not be worth the added complexity to do more.