### PR TITLE
fix: Add param to get full uri without prefix

### DIFF
--- a/app/screens/receive-bitcoin-screen/ReceiveBitcoinScreenTypes.d.ts
+++ b/app/screens/receive-bitcoin-screen/ReceiveBitcoinScreenTypes.d.ts
@@ -1,0 +1,5 @@
+interface IGetFullUri {
+  input: string
+  uppercase?: boolean
+  prefix?: boolean
+}

--- a/app/screens/receive-bitcoin-screen/ReceiveBitcoinScreenTypes.d.ts
+++ b/app/screens/receive-bitcoin-screen/ReceiveBitcoinScreenTypes.d.ts
@@ -1,4 +1,4 @@
-interface IGetFullUri {
+type GetFullUriInput = {
   input: string
   uppercase?: boolean
   prefix?: boolean

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -352,7 +352,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
     const isReady =
       type === "lightning" ? !loading && data != "" && !keyboardIsShown : true
 
-    const getFullUri = ({ input, uppercase = false, prefix = true }: IGetFullUri) => {
+    const getFullUri = ({ input, uppercase = false, prefix = true }: GetFullUriInput) => {
       if (type === "lightning") {
         // TODO add lightning:
         return uppercase ? input.toUpperCase() : input

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -28,9 +28,9 @@ import Icon from "react-native-vector-icons/Ionicons"
 import { InputPaymentDataInjected } from "../../components/input-payment"
 import { Screen } from "../../components/screen"
 import { translate } from "../../i18n"
-import type { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
+import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
 import { palette } from "../../theme/palette"
-import type { ScreenType } from "../../types/jsx"
+import { ScreenType } from "../../types/jsx"
 import { getHashFromInvoice } from "../../utils/bolt11"
 import { isIos } from "../../utils/helper"
 import { hasFullPermissions, requestPermission } from "../../utils/notifications"
@@ -128,7 +128,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
   const [addInvoice] = useMutation(ADD_INVOICE)
   const [updatePendingInvoice] = useMutation(UPDATE_PENDING_INVOICE)
 
-  let lastOnChainAddress
+  let lastOnChainAddress: string
   try {
     ;({
       getLastOnChainAddress: { id: lastOnChainAddress },
@@ -341,7 +341,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
   }
 
   const QRView = ({ type }: { type: string }) => {
-    let data
+    let data: string
 
     if (type === "lightning") {
       data = invoice
@@ -352,12 +352,15 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
     const isReady =
       type === "lightning" ? !loading && data != "" && !keyboardIsShown : true
 
-    const getFullUri = (input, uppercase = false) => {
+    const getFullUri = ({ input, uppercase = false, prefix = true }: IGetFullUri) => {
       if (type === "lightning") {
         // TODO add lightning:
         return uppercase ? input.toUpperCase() : input
       }
-      const uri = uppercase ? `bitcoin:${input}`.toUpperCase() : `bitcoin:${input}`
+      const uriPrefix = prefix ? "bitcoin:" : ""
+      const uri = uppercase
+        ? `${uriPrefix}${input}`.toUpperCase()
+        : `${uriPrefix}${input}`
       const params = new URLSearchParams()
       if (amount) params.append("amount", `${amount / 10 ** 8}`)
       if (memo) {
@@ -369,7 +372,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
     }
 
     const copyToClipboard = () => {
-      Clipboard.setString(getFullUri(data))
+      Clipboard.setString(getFullUri({ input: data, prefix: false }))
 
       if (Platform.OS === "ios") {
         const sringToShow =
@@ -392,7 +395,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
     const share = async () => {
       try {
         const result = await Share.share({
-          message: getFullUri(data),
+          message: getFullUri({ input: data, prefix: false }),
         })
 
         if (result.action === Share.sharedAction) {
@@ -432,7 +435,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
               <Pressable onPress={copyToClipboard}>
                 <QRCode
                   size={280}
-                  value={getFullUri(data, true)}
+                  value={getFullUri({ input: data, uppercase: true })}
                   logoBackgroundColor="white"
                   ecl="L"
                   // __DEV__ workaround for https://github.com/facebook/react-native/issues/26705


### PR DESCRIPTION
Fixes #155

Added an extra param to be able to get the full uri with (default) or without the `bitcoin:` prefix.