### PR TITLE
Increase bitcoin address qr code ECL

### DIFF
--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -438,7 +438,7 @@ export const ReceiveBitcoinScreen: ScreenType = ({ navigation }: Props) => {
                   size={280}
                   value={getFullUri({ input: data, uppercase: true })}
                   logoBackgroundColor="white"
-                  ecl="L"
+                  ecl={type === "lightning" ? "L" : "M"}
                   // __DEV__ workaround for https://github.com/facebook/react-native/issues/26705
                   logo={
                     !__DEV__ &&


### PR DESCRIPTION
Increased the error correction level from low to medium when generating a qr code for onchain in the receive screen. Lightning remains at low. If onchain scanning remains an issue, there are two more levels of redundancy: quartile then high.