### PR TITLE
Use hooks for btc price and usd balance

### DIFF
--- a/app/components/input-payment/input-payment.tsx
+++ b/app/components/input-payment/input-payment.tsx
@@ -6,8 +6,8 @@ import { TextInput } from "react-native-vector-icons/node_modules/@types/react-n
 import EStyleSheet from "react-native-extended-stylesheet"
 import { TouchableOpacity } from "react-native-gesture-handler"
 import Icon from "react-native-vector-icons/Ionicons"
-import { btc_price } from "../../graphql/query"
 import { usePrefCurrency } from "../../hooks/usePrefCurrency"
+import { useBTCPrice } from "../../hooks/usePrice"
 import { palette } from "../../theme/palette"
 import type { ComponentType } from "../../types/jsx"
 import {
@@ -87,14 +87,13 @@ type InputPaymentDataInjectedProps = {
 export const InputPaymentDataInjected: ComponentType = (
   props: InputPaymentDataInjectedProps,
 ) => {
-  const client = useApolloClient()
-  const price = btc_price(client)
+  const btcPrice = useBTCPrice()
 
   const [prefCurrency, nextPrefCurrency] = usePrefCurrency()
 
   return (
     <InputPayment
-      price={price}
+      price={btcPrice}
       prefCurrency={prefCurrency}
       nextPrefCurrency={nextPrefCurrency}
       {...props}

--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -92,8 +92,6 @@ export const getWallet = (client: ApolloClient<unknown>): wallet_wallet[] => {
   return wallet
 }
 
-export const balanceUsd = (client: ApolloClient<unknown>): number =>
-  _.find(getWallet(client), { id: "BTC" }).balance * btc_price(client)
 export const balanceBtc = (client: ApolloClient<unknown>): number =>
   _.find(getWallet(client), { id: "BTC" }).balance
 
@@ -140,18 +138,6 @@ export const USERNAME_EXIST = gql`
     usernameExists(username: $username)
   }
 `
-
-export const btc_price = (client: ApolloClient<unknown>): number => {
-  const price_default = NaN
-  try {
-    const result = client.readQuery({ query: QUERY_PRICE })
-    const { prices } = result
-    return prices[0].o ?? price_default
-  } catch (err) {
-    console.warn({ err }, "no price has been set")
-    return price_default
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export const walletIsActive = (client: ApolloClient<unknown>): boolean => {

--- a/app/hooks/useBalance.ts
+++ b/app/hooks/useBalance.ts
@@ -1,0 +1,9 @@
+import { ApolloClient } from "@apollo/client"
+import _ from "lodash"
+import { getWallet } from "../graphql/query"
+import { useBTCPrice } from "./usePrice"
+
+export const useUSDBalance = (client: ApolloClient<unknown>): number => {
+  const btcPrice = useBTCPrice()
+  return _.find(getWallet(client), { id: "BTC" }).balance * btcPrice
+}

--- a/app/hooks/usePrice.ts
+++ b/app/hooks/usePrice.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "@apollo/client"
+import { QUERY_PRICE } from "../graphql/query"
+import { prices } from "../graphql/__generated__/prices"
+
+export const useBTCPrice = (): number => {
+  const { data } = useQuery<prices>(QUERY_PRICE)
+  return data?.prices?.[0]?.o ?? NaN
+}

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -24,7 +24,8 @@ import { IconTransaction } from "../../components/icon-transactions"
 import { LargeButton } from "../../components/large-button"
 import { Screen } from "../../components/screen"
 import { TransactionItem } from "../../components/transaction-item"
-import { balanceBtc, balanceUsd, MAIN_QUERY, walletIsActive } from "../../graphql/query"
+import { balanceBtc, MAIN_QUERY, walletIsActive } from "../../graphql/query"
+import { useUSDBalance } from "../../hooks/useBalance"
 import { translate } from "../../i18n"
 import { color } from "../../theme"
 import { palette } from "../../theme/palette"
@@ -128,6 +129,7 @@ export const MoveMoneyScreenDataInjected: ScreenType = ({
   navigation,
 }: MoveMoneyScreenDataInjectedProps) => {
   const client = useApolloClient()
+  const balanceUsd = useUSDBalance(client)
 
   const {
     loading: loadingMain,
@@ -208,7 +210,7 @@ export const MoveMoneyScreenDataInjected: ScreenType = ({
       walletIsActive={walletIsActive(client)}
       loading={loadingMain}
       error={error}
-      amount={balanceUsd(client)}
+      amount={balanceUsd}
       amountOtherCurrency={balanceBtc(client)}
       refetch={refetch}
       isUpdateAvailable={

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -16,7 +16,6 @@ import { GaloyInput } from "../../components/galoy-input"
 import { Screen } from "../../components/screen"
 import {
   balanceBtc,
-  btc_price,
   getPubKey,
   queryWallet,
   QUERY_TRANSACTIONS,
@@ -32,6 +31,7 @@ import { textCurrencyFormatting } from "../../utils/currencyConversion"
 import { IPaymentType, validPayment } from "../../utils/parsing"
 import { Token } from "../../utils/token"
 import { UsernameValidation } from "../../utils/validation"
+import { useBTCPrice } from "../../hooks/usePrice"
 
 const successLottie = require("../move-money-screen/success_lottie.json")
 const errorLottie = require("../move-money-screen/error_lottie.json")
@@ -167,6 +167,7 @@ type SendBitcoinScreenProps = {
 export const SendBitcoinScreen: ScreenType = ({ route }: SendBitcoinScreenProps) => {
   const client = useApolloClient()
   const { goBack, navigate } = useNavigation()
+  const btcPrice = useBTCPrice()
 
   const [errs, setErrs] = useState([])
   const [invoiceError, setInvoiceError] = useState("")
@@ -493,9 +494,7 @@ export const SendBitcoinScreen: ScreenType = ({ route }: SendBitcoinScreenProps)
     ReactNativeHapticFeedback.trigger(notificationType, optionsHaptic)
   }, [status])
 
-  const price = btc_price(client)
-
-  const feeTextFormatted = textCurrencyFormatting(fee ?? 0, price, prefCurrency)
+  const feeTextFormatted = textCurrencyFormatting(fee ?? 0, btcPrice, prefCurrency)
 
   const feeText =
     fee === null && !usernameExists
@@ -503,7 +502,7 @@ export const SendBitcoinScreen: ScreenType = ({ route }: SendBitcoinScreenProps)
       : fee > 0 && !!amount
       ? `${feeTextFormatted}, ${translate("common.Total")}: ${textCurrencyFormatting(
           fee + amount,
-          price,
+          btcPrice,
           prefCurrency,
         )}`
       : fee === -1 || fee === undefined
@@ -515,7 +514,7 @@ export const SendBitcoinScreen: ScreenType = ({ route }: SendBitcoinScreenProps)
     invoiceError ||
     (!!totalAmount && balance && totalAmount > balance && status !== "success"
       ? translate("SendBitcoinScreen.totalExceed", {
-          balance: textCurrencyFormatting(balance, price, prefCurrency),
+          balance: textCurrencyFormatting(balance, btcPrice, prefCurrency),
         })
       : null)
 
@@ -535,7 +534,7 @@ export const SendBitcoinScreen: ScreenType = ({ route }: SendBitcoinScreenProps)
       goBack={goBack}
       navigate={navigate}
       pay={pay}
-      price={price}
+      price={btcPrice}
       fee={feeText}
       setMemo={setMemo}
       setDestination={setDestination}


### PR DESCRIPTION
Using hooks and useQuery causes the components to re-render with the updated price when the price is updated in the cache. It will be important to add having usd as a possible reference price (instead of always using sats for the amount variable) for the best user experience. This will be done in another pr.