### PR TITLE
Hide balance security setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This repository is the mobile application of Galoy. It is build with [React Native](https://reactnative.dev/), and compatible on iOS and Android.
 
 ## Start
+
 Prerequisite -- Follow the instruction [getting started](https://reactnative.dev/docs/getting-started) to have the correct setup.
 
 Clone into the project

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -1,16 +1,19 @@
 import * as React from "react"
 import ContentLoader, { Rect } from "react-content-loader/native"
-import {StyleProp, Text, TouchableHighlight, View, ViewStyle} from "react-native"
+import { StyleProp, Text, TouchableHighlight, View, ViewStyle } from "react-native"
 import EStyleSheet from "react-native-extended-stylesheet"
 import { translate } from "../../i18n"
 import { palette } from "../../theme/palette"
 import { CurrencyType } from "../../utils/enum"
 import { TextCurrency } from "../text-currency/text-currency"
-import {useState, useEffect} from "react";
-import { useIsFocused } from '@react-navigation/native';
-import {load, remove} from "../../utils/storage";
-import {HIDE_BALANCE, WALKTHROUGH_TOOLTIP} from "../../screens/settings-screen/security-screen";
-import Tooltip from "react-native-walkthrough-tooltip";
+import { useState, useEffect } from "react"
+import { useIsFocused } from "@react-navigation/native"
+import { load, remove } from "../../utils/storage"
+import {
+  HIDE_BALANCE,
+  WALKTHROUGH_TOOLTIP,
+} from "../../screens/settings-screen/security-screen"
+import Tooltip from "react-native-walkthrough-tooltip"
 import Icon from "react-native-vector-icons/Entypo"
 
 const styles = EStyleSheet.create({
@@ -81,70 +84,76 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   const [showToolTip, setShowToolTip] = useState(null)
   const isFocused = useIsFocused()
 
-  const checkHideBalanceSettings = async() => {
-        setHideBalance(await load(HIDE_BALANCE) )
-        setShowToolTip(await load(WALKTHROUGH_TOOLTIP))
+  const checkHideBalanceSettings = async () => {
+    setHideBalance(await load(HIDE_BALANCE))
+    setShowToolTip(await load(WALKTHROUGH_TOOLTIP))
   }
 
-  useEffect( () => {
+  useEffect(() => {
     checkHideBalanceSettings()
-  },[isFocused])
-
+  }, [isFocused])
 
   const otherCurrency = currency === CurrencyType.BTC ? CurrencyType.USD : "sats"
 
   const hiddenBalanceSet = () => {
     return (
-        <>
-          <Tooltip
-            isVisible={showToolTip}
-            content={<Text>{translate("BalanceHeader.toolTipHiddenBalance")}</Text>}
-            placement="top"
-            onClose={async() => {
-                setShowToolTip( await remove(WALKTHROUGH_TOOLTIP))
+      <>
+        <Tooltip
+          isVisible={showToolTip}
+          content={<Text>{translate("BalanceHeader.toolTipHiddenBalance")}</Text>}
+          placement="top"
+          onClose={async () => {
+            setShowToolTip(await remove(WALKTHROUGH_TOOLTIP))
+          }}
+        >
+          <TouchableHighlight
+            onPress={() => {
+              setHideBalance(null)
             }}
           >
-          <TouchableHighlight onPress={ ()=> { setHideBalance(null) }}>
-              <Icon style={styles.subCurrencyText} name="eye" />
+            <Icon style={styles.subCurrencyText} name="eye" />
           </TouchableHighlight>
-          </Tooltip>
-        </>
+        </Tooltip>
+      </>
     )
   }
 
   const defaultBalanceHeader = () => {
     const subHeader =
-        amountOtherCurrency !== null ? (
-            <TextCurrency
-                amount={amountOtherCurrency}
-                currency={otherCurrency}
-                style={styles.subCurrencyText}
-            />
-        ) : null
+      amountOtherCurrency !== null ? (
+        <TextCurrency
+          amount={amountOtherCurrency}
+          currency={otherCurrency}
+          style={styles.subCurrencyText}
+        />
+      ) : null
     return (
-          <View style={styles.amount}>
-            <View style={styles.container}>
-              {loading && <Loader/>}
-              {!loading && (
-                  <TouchableHighlight onPress={ ()=> { setHideBalance(true) }}>
-                  <TextCurrency
-                      amount={amount}
-                      currency={currency === CurrencyType.BTC ? "sats" : CurrencyType.USD}
-                      style={styles.text}
-                  />
-                  </TouchableHighlight>
-              )}
-            </View>
-            {!loading && subHeader}
-          </View>
+      <View style={styles.amount}>
+        <View style={styles.container}>
+          {loading && <Loader />}
+          {!loading && (
+            <TouchableHighlight
+              onPress={() => {
+                setHideBalance(true)
+              }}
+            >
+              <TextCurrency
+                amount={amount}
+                currency={currency === CurrencyType.BTC ? "sats" : CurrencyType.USD}
+                style={styles.text}
+              />
+            </TouchableHighlight>
+          )}
+        </View>
+        {!loading && subHeader}
+      </View>
     )
   }
   return (
-       <View style={[styles.header, style]}>
-          <Text style={styles.balanceText}>{translate("BalanceHeader.currentBalance")}</Text>
-         { hideBalance && ( hiddenBalanceSet() ) }
-         { !hideBalance && ( defaultBalanceHeader() ) }
-       </View>
+    <View style={[styles.header, style]}>
+      <Text style={styles.balanceText}>{translate("BalanceHeader.currentBalance")}</Text>
+      {hideBalance && hiddenBalanceSet()}
+      {!hideBalance && defaultBalanceHeader()}
+    </View>
   )
-
 }

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -6,22 +6,24 @@ import { translate } from "../../i18n"
 import { palette } from "../../theme/palette"
 import { CurrencyType } from "../../utils/enum"
 import { TextCurrency } from "../text-currency/text-currency"
-import { useState, useEffect } from "react"
-import {useIsFocused} from "@react-navigation/native"
+import { useState, useLayoutEffect } from "react"
+import { useIsFocused } from "@react-navigation/native"
 import {
   saveWalkThroughToolTipSettings,
-  HIDE_BALANCE,
-  WALKTHROUGH_TOOL_TIP
+  WALKTHROUGH_TOOL_TIP,
 } from "../../graphql/client-only-query"
 import Tooltip from "react-native-walkthrough-tooltip"
 import Icon from "react-native-vector-icons/Entypo"
-import {useQuery} from "@apollo/client";
+import { useQuery } from "@apollo/client"
 
 const styles = EStyleSheet.create({
   amount: {
     alignItems: "center",
     flexDirection: "column",
     height: 42, // FIXME should be dynamic?
+    position: "absolute",
+    top: "25rem",
+    width: "250rem",
   },
 
   balanceText: {
@@ -61,6 +63,7 @@ export interface BalanceHeaderProps {
   amountOtherCurrency?: number
   loading?: boolean
   style?: StyleProp<ViewStyle>
+  securitySettings?: object
 }
 
 const Loader = () => (
@@ -82,23 +85,24 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   amountOtherCurrency = null,
   loading = false,
   style,
+  securitySettings,
 }: BalanceHeaderProps) => {
-  const { data: balanceSettings } = useQuery(HIDE_BALANCE)
   const { data: toolTipSettings } = useQuery(WALKTHROUGH_TOOL_TIP)
-  const [hideBalance, setHideBalance] = useState<boolean | null>(null)
-  const [showToolTip, setShowToolTip] = useState<boolean | null>( null)
+  const [hideBalance, setHideBalance] = useState<boolean | string>(
+    securitySettings?.hideBalanceSettings,
+  )
+  const [showToolTip, setShowToolTip] = useState<boolean | null>(null)
   const isFocused = useIsFocused()
 
   const checkHideBalanceSettings = async () => {
-      setHideBalance(balanceSettings?.hideBalanceSettings)
-      if(toolTipSettings?.walkThroughToolTipSettings) {
-        setTimeout(function () {
-          setShowToolTip(toolTipSettings?.walkThroughToolTipSettings)
-        }, 1000);
-      }
+    setHideBalance(securitySettings?.hideBalanceSettings)
+    if (toolTipSettings?.walkThroughToolTipSettings) {
+      setTimeout(function () {
+        setShowToolTip(toolTipSettings?.walkThroughToolTipSettings)
+      }, 1000)
+    }
   }
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     checkHideBalanceSettings()
   }, [isFocused])
 
@@ -114,7 +118,7 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
           isVisible={showToolTip}
           content={<Text>{translate("BalanceHeader.toolTipHiddenBalance")}</Text>}
           placement="top"
-          onClose={ handleToolTipClose }
+          onClose={handleToolTipClose}
         >
           <TouchableHighlight
             underlayColor={styles.touchableHighlightColor}
@@ -164,8 +168,8 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   return (
     <View style={[styles.header, style]}>
       <Text style={styles.balanceText}>{translate("BalanceHeader.currentBalance")}</Text>
-      {hideBalance && isFocused && hiddenBalanceSet()}
-      {!hideBalance && isFocused && defaultBalanceHeader()}
+      {hideBalance && hiddenBalanceSet()}
+      {!hideBalance && defaultBalanceHeader()}
     </View>
   )
 }

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -45,9 +45,13 @@ const styles = EStyleSheet.create({
     minHeight: "75rem",
   },
 
+  hiddenBalanceIcon: {
+    fontSize: "25rem"
+  },
+
   subCurrencyText: {
     color: palette.darkGrey,
-    fontSize: "25rem",
+    fontSize: "16rem",
   },
 
   text: {
@@ -63,7 +67,7 @@ export interface BalanceHeaderProps {
   amountOtherCurrency?: number
   loading?: boolean
   style?: StyleProp<ViewStyle>
-  securitySettings?: object
+  securitySettings?: boolean
 }
 
 const Loader = () => (
@@ -89,13 +93,13 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
 }: BalanceHeaderProps) => {
   const { data: toolTipSettings } = useQuery(WALKTHROUGH_TOOL_TIP)
   const [hideBalance, setHideBalance] = useState<boolean | string>(
-    securitySettings?.hideBalanceSettings,
+    securitySettings,
   )
   const [showToolTip, setShowToolTip] = useState<boolean | null>(null)
   const isFocused = useIsFocused()
 
   const checkHideBalanceSettings = async () => {
-    setHideBalance(securitySettings?.hideBalanceSettings)
+    setHideBalance(securitySettings)
     if (toolTipSettings?.walkThroughToolTipSettings) {
       setTimeout(function () {
         setShowToolTip(toolTipSettings?.walkThroughToolTipSettings)
@@ -126,7 +130,7 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
               setHideBalance(null)
             }}
           >
-            <Icon style={styles.subCurrencyText} name="eye" />
+            <Icon style={styles.hiddenBalanceIcon} name="eye" />
           </TouchableHighlight>
         </Tooltip>
       </>

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -6,7 +6,7 @@ import { translate } from "../../i18n"
 import { palette } from "../../theme/palette"
 import { CurrencyType } from "../../utils/enum"
 import { TextCurrency } from "../text-currency/text-currency"
-import { useState, useLayoutEffect } from "react"
+import { useState } from "react"
 import { useIsFocused } from "@react-navigation/native"
 import {
   saveWalkThroughToolTipSettings,
@@ -99,17 +99,17 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   const [showToolTip, setShowToolTip] = useState<boolean | null>(null)
   const isFocused = useIsFocused()
 
-  const checkHideBalanceSettings = async () => {
-    setHideBalance(securitySettings)
-    if (toolTipSettings?.walkThroughToolTipSettings) {
+  React.useEffect(() => {
       setTimeout(function () {
-        setShowToolTip(toolTipSettings?.walkThroughToolTipSettings)
+        setShowToolTip( toolTipSettings?.walkThroughToolTipSettings )
       }, 1000)
-    }
-  }
-  useLayoutEffect(() => {
-    checkHideBalanceSettings()
-  }, [isFocused])
+    // note: using the toolTipSettings dependency will cause this to fire too early. Need to wait for component to be in focus
+    // eslint-disable-next-line
+  },[isFocused])
+
+  React.useEffect(() => {
+      setHideBalance(securitySettings)
+  }, [isFocused, securitySettings])
 
   const handleToolTipClose = async () => {
     setShowToolTip(await saveWalkThroughToolTipSettings(false))

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -4,7 +4,6 @@ import { StyleProp, Text, TouchableHighlight, View, ViewStyle } from "react-nati
 import EStyleSheet from "react-native-extended-stylesheet"
 import { translate } from "../../i18n"
 import { palette } from "../../theme/palette"
-import { CurrencyType } from "../../utils/enum"
 import { TextCurrency } from "../text-currency/text-currency"
 import { useState } from "react"
 import { useIsFocused } from "@react-navigation/native"
@@ -113,7 +112,8 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
     setShowToolTip(await saveWalkThroughToolTipSettings(false))
   }
 
-  const otherCurrency = currency === CurrencyType.BTC ? CurrencyType.USD : "sats"
+  const otherCurrency = currency === "BTC" ? "USD" : "BTC"
+
   const hiddenBalanceSet = () => {
     return (
       <>
@@ -158,7 +158,7 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
             >
               <TextCurrency
                 amount={amount}
-                currency={currency === CurrencyType.BTC ? "sats" : CurrencyType.USD}
+                currency={otherCurrency}
                 style={styles.text}
               />
             </TouchableHighlight>

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -93,22 +93,20 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   securitySettings,
 }: BalanceHeaderProps) => {
   const { data: toolTipSettings } = useQuery(WALKTHROUGH_TOOL_TIP)
-  const [hideBalance, setHideBalance] = useState<boolean | string>(
-    securitySettings,
-  )
+  const [hideBalance, setHideBalance] = useState<boolean | string>(securitySettings)
   const [showToolTip, setShowToolTip] = useState<boolean | null>(null)
   const isFocused = useIsFocused()
 
   React.useEffect(() => {
-      setTimeout(function () {
-        setShowToolTip( toolTipSettings?.walkThroughToolTipSettings )
-      }, 1000)
+    setTimeout(function () {
+      setShowToolTip(toolTipSettings?.walkThroughToolTipSettings)
+    }, 1000)
     // note: using the toolTipSettings dependency will cause this to fire too early. Need to wait for component to be in focus
     // eslint-disable-next-line
-  },[isFocused])
+  }, [isFocused])
 
   React.useEffect(() => {
-      setHideBalance(securitySettings)
+    setHideBalance(securitySettings)
   }, [isFocused, securitySettings])
 
   const handleToolTipClose = async () => {

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -46,7 +46,8 @@ const styles = EStyleSheet.create({
   },
 
   hiddenBalanceIcon: {
-    fontSize: "25rem"
+    fontSize: "25rem",
+    marginTop: "13rem",
   },
 
   subCurrencyText: {

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -39,6 +39,7 @@ const styles = EStyleSheet.create({
     alignItems: "center",
     marginBottom: "32rem",
     marginTop: "32rem",
+    minHeight: "75rem",
   },
 
   subCurrencyText: {
@@ -50,6 +51,7 @@ const styles = EStyleSheet.create({
     color: palette.darkGrey,
     fontSize: 32,
   },
+  touchableHighlightColor: "#ffffff00",
 })
 
 export interface BalanceHeaderProps {
@@ -107,6 +109,7 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
           }}
         >
           <TouchableHighlight
+            underlayColor={styles.touchableHighlightColor}
             onPress={() => {
               setHideBalance(null)
             }}
@@ -133,6 +136,7 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
           {loading && <Loader />}
           {!loading && (
             <TouchableHighlight
+              underlayColor={styles.touchableHighlightColor}
               onPress={() => {
                 setHideBalance(true)
               }}

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -10,9 +10,70 @@ export const nextPrefCurrency = (): void => {
 }
 
 export const modalClipboardVisibleVar = makeVar(false)
+import { gql } from "@apollo/client"
+import { remove, save } from "../utils/storage"
+import { cache } from "./cache"
 
 export const LAST_CLIPBOARD_PAYMENT = gql`
   query LastClipboardPayment {
     lastClipboardPayment @client
   }
 `
+
+export const HIDE_BALANCE = gql`
+  query HideBalance {
+    hideBalanceSettings @client
+  }
+`
+
+export const WALKTHROUGH_TOOL_TIP = gql`
+  query WalkThroughToolTip {
+    walkThroughToolTipSettings @client
+  }
+`
+
+export const saveHideBalanceSettings = (status: boolean): boolean => {
+  try {
+    cache.writeQuery({
+      query: HIDE_BALANCE,
+      data: {
+        hideBalanceSettings: save("HIDE_BALANCE", true) ? status : remove("HIDE_BALANCE"),
+      },
+    })
+    if (!status) {
+      cache.evict({
+        id: "HideBalance",
+        fieldName: "hideBalanceSettings",
+        broadcast: false,
+      })
+      cache.gc()
+    }
+    return status
+  } catch {
+    return false
+  }
+}
+
+export const saveWalkThroughToolTipSettings = (status: boolean): boolean => {
+  try {
+    cache.writeQuery({
+      query: WALKTHROUGH_TOOL_TIP,
+      data: {
+        walkThroughToolTipSettings: save("WALKTHROUGH_TOOL_TIP", true)
+          ? status
+          : remove("WALKTHROUGH_TOOL_TIP"),
+      },
+    })
+    if (!status) {
+      cache.evict({
+        id: "WalkThroughToolTip",
+        fieldName: "walkThroughToolTipSettings",
+        broadcast: false,
+      })
+      cache.gc()
+    }
+    return status
+  } catch {
+    return false
+  }
+}

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -1,5 +1,7 @@
 import { gql, makeVar } from "@apollo/client"
 import indexOf from "lodash.indexof"
+import { remove, save } from "../utils/storage"
+import { cache } from "./cache"
 
 export const prefCurrencyVar = makeVar<CurrencyType>("USD")
 
@@ -10,9 +12,6 @@ export const nextPrefCurrency = (): void => {
 }
 
 export const modalClipboardVisibleVar = makeVar(false)
-import { gql } from "@apollo/client"
-import { remove, save } from "../utils/storage"
-import { cache } from "./cache"
 
 export const LAST_CLIPBOARD_PAYMENT = gql`
   query LastClipboardPayment {

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -8,7 +8,8 @@
     "usePin": "Use PIN"
   },
   "BalanceHeader": {
-    "currentBalance": "Current Balance"
+    "currentBalance": "Current Balance",
+    "toolTipHiddenBalance": "Touch to reveal/hide your balance info"
   },
   "BankTransferScreen": {
     "title": "Bank Transfer"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -527,7 +527,10 @@
     "pinDescription": "PIN is used as the backup authentication method for biometric authentication.",
     "pinSubtitle": "Enable PIN",
     "pinTitle": "PIN Code",
-    "setPin": "Set PIN"
+    "setPin": "Set PIN",
+    "hideBalanceDescription": "Hides the currency amounts on the home screen by default so you don't reveal your balance to anyone who can see your screen",
+    "hideBalanceSubtitle": "Enable hide balance feature",
+    "hideBalanceTitle": "Hide Balance"
   },
   "SendBitcoinScreen": {
     "amount": "Amount",

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -65,8 +65,9 @@ export type MoveMoneyStackParamList = {
   Profile: undefined
   phoneValidation: undefined
   priceDetail: {
-    account: AccountType;
-    hideBalanceSettings: boolean | null }
+    account: AccountType
+    hideBalanceSettings: boolean | null
+  }
   settings: undefined
   security: {
     mIsBiometricsEnabled: boolean

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -40,7 +40,6 @@ export type RootStackParamList = {
     tx: query_transactions_wallet_transactions
   }
   transactionHistory: undefined
-  priceDetail: { account: AccountType }
   Earn: undefined
 }
 
@@ -54,7 +53,9 @@ export type ContactStackParamList = {
 }
 
 export type MoveMoneyStackParamList = {
-  moveMoney: undefined
+  moveMoney: {
+    mHideBalanceEnabled: boolean | null
+  }
   scanningQRCode: undefined
   sendBitcoin: {
     username: string | null
@@ -63,8 +64,14 @@ export type MoveMoneyStackParamList = {
   receiveBitcoin: undefined
   Profile: undefined
   phoneValidation: undefined
-  priceDetail: { account: AccountType }
+  priceDetail: {
+    account: AccountType;
+    hideBalanceSettings: boolean | null }
   settings: undefined
+  security: {
+    mIsBiometricsEnabled: boolean
+    mIsPinEnabled: boolean
+  }
   transactionDetail: {
     tx: query_transactions_wallet_transactions
   }

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -69,10 +69,6 @@ export type MoveMoneyStackParamList = {
     hideBalanceSettings: boolean | null
   }
   settings: undefined
-  security: {
-    mIsBiometricsEnabled: boolean
-    mIsPinEnabled: boolean
-  }
   transactionDetail: {
     tx: query_transactions_wallet_transactions
   }

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -34,7 +34,13 @@ import { isIos } from "../../utils/helper"
 import { Token } from "../../utils/token"
 import { ScreenType } from "../../types/jsx"
 import { StackNavigationProp } from "@react-navigation/stack"
+<<<<<<< HEAD
 import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
+=======
+import {
+  MoveMoneyStackParamList,
+} from "../../navigation/stack-param-lists"
+>>>>>>> 8255d77d (remove unused and incorrect imports as well as unused initialized variables. Update navigation.setOptions render to fix component displayName error)
 import { HIDE_BALANCE } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -34,9 +34,7 @@ import { isIos } from "../../utils/helper"
 import { Token } from "../../utils/token"
 import { ScreenType } from "../../types/jsx"
 import { StackNavigationProp } from "@react-navigation/stack"
-import {
-  MoveMoneyStackParamList,
-} from "../../navigation/stack-param-lists"
+import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
 import { HIDE_BALANCE } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({
@@ -344,7 +342,7 @@ export const MoveMoneyScreen: ScreenType = ({
           onPress={() =>
             navigation.navigate("priceDetail", {
               account: AccountType.Bitcoin,
-              securitySettings: balanceSettings?.hideBalanceSettings
+              securitySettings: balanceSettings?.hideBalanceSettings,
             })
           }
           icon={<Icon name="ios-trending-up-outline" size={32} />}

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -32,9 +32,13 @@ import { palette } from "../../theme/palette"
 import { AccountType } from "../../utils/enum"
 import { isIos } from "../../utils/helper"
 import { Token } from "../../utils/token"
-import type { ScreenType } from "../../types/jsx"
+import { ScreenType } from "../../types/jsx"
 import { StackNavigationProp } from "@react-navigation/stack"
-import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
+import {
+  MoveMoneyStackParamList,
+  RootStackParamList,
+} from "../../navigation/stack-param-lists"
+import { HIDE_BALANCE } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({
   bottom: {
@@ -223,7 +227,7 @@ export const MoveMoneyScreenDataInjected: ScreenType = ({
 
 type MoveMoneyScreenProps = {
   walletIsActive: boolean
-  navigation: StackNavigationProp<MoveMoneyStackParamList, "moveMoney">
+  navigation: StackNavigationProp<RootStackParamList, "priceDetail">
   loading: boolean
   error: ApolloError
   transactions: []
@@ -244,9 +248,10 @@ export const MoveMoneyScreen: ScreenType = ({
   amountOtherCurrency,
   isUpdateAvailable,
 }: MoveMoneyScreenProps) => {
+  const { data: balanceSettings } = useQuery(HIDE_BALANCE)
   const [modalVisible, setModalVisible] = useState(false)
-
   const [secretMenuCounter, setSecretMenuCounter] = useState(0)
+
   React.useEffect(() => {
     if (secretMenuCounter > 2) {
       navigation.navigate("Profile")
@@ -338,7 +343,10 @@ export const MoveMoneyScreen: ScreenType = ({
           buttonStyle={styles.buttonStyleTime}
           containerStyle={styles.separator}
           onPress={() =>
-            navigation.navigate("priceDetail", { account: AccountType.Bitcoin })
+            navigation.navigate("priceDetail", {
+              account: AccountType.Bitcoin,
+              securitySettings: balanceSettings,
+            })
           }
           icon={<Icon name="ios-trending-up-outline" size={32} />}
         />
@@ -348,6 +356,7 @@ export const MoveMoneyScreen: ScreenType = ({
           amount={amount}
           amountOtherCurrency={amountOtherCurrency}
           style={{}}
+          securitySettings={balanceSettings}
         />
         <Button
           buttonStyle={styles.buttonStyleTime}

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -227,7 +227,7 @@ export const MoveMoneyScreenDataInjected: ScreenType = ({
 
 type MoveMoneyScreenProps = {
   walletIsActive: boolean
-  navigation: StackNavigationProp<RootStackParamList, "priceDetail">
+  navigation: StackNavigationProp<MoveMoneyStackParamList, "moveMoney">
   loading: boolean
   error: ApolloError
   transactions: []
@@ -345,7 +345,7 @@ export const MoveMoneyScreen: ScreenType = ({
           onPress={() =>
             navigation.navigate("priceDetail", {
               account: AccountType.Bitcoin,
-              securitySettings: balanceSettings,
+              securitySettings: balanceSettings?.hideBalanceSettings
             })
           }
           icon={<Icon name="ios-trending-up-outline" size={32} />}
@@ -356,7 +356,7 @@ export const MoveMoneyScreen: ScreenType = ({
           amount={amount}
           amountOtherCurrency={amountOtherCurrency}
           style={{}}
-          securitySettings={balanceSettings}
+          securitySettings={balanceSettings?.hideBalanceSettings}
         />
         <Button
           buttonStyle={styles.buttonStyleTime}

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -34,13 +34,7 @@ import { isIos } from "../../utils/helper"
 import { Token } from "../../utils/token"
 import { ScreenType } from "../../types/jsx"
 import { StackNavigationProp } from "@react-navigation/stack"
-<<<<<<< HEAD
 import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
-=======
-import {
-  MoveMoneyStackParamList,
-} from "../../navigation/stack-param-lists"
->>>>>>> 8255d77d (remove unused and incorrect imports as well as unused initialized variables. Update navigation.setOptions render to fix component displayName error)
 import { HIDE_BALANCE } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -36,7 +36,6 @@ import { ScreenType } from "../../types/jsx"
 import { StackNavigationProp } from "@react-navigation/stack"
 import {
   MoveMoneyStackParamList,
-  RootStackParamList,
 } from "../../navigation/stack-param-lists"
 import { HIDE_BALANCE } from "../../graphql/client-only-query"
 

--- a/app/screens/price-screen/price-screen.tsx
+++ b/app/screens/price-screen/price-screen.tsx
@@ -21,7 +21,7 @@ export const PriceScreen: ScreenType = ({ route }: Props) => {
     // eslint-disable-next-line react-native/no-inline-styles
     <Screen backgroundColor={palette.white} preset="scroll" style={{ flex: 1 }}>
       <BalanceHeader
-        currency={CurrencyType.BTC}
+        currency={"BTC"}
         amount={balanceBtc(client)}
         securitySettings={securitySettings}
       />

--- a/app/screens/price-screen/price-screen.tsx
+++ b/app/screens/price-screen/price-screen.tsx
@@ -1,7 +1,6 @@
 import { useApolloClient } from "@apollo/client"
 import { RouteProp } from "@react-navigation/native"
 import * as React from "react"
-import { Text } from "react-native"
 import { BalanceHeader } from "../../components/balance-header"
 import { PriceGraphDataInjected } from "../../components/price-graph"
 import { Screen } from "../../components/screen"
@@ -16,7 +15,7 @@ type Props = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const PriceScreen: ScreenType = ({ route }: Props) => {
-  const { securitySettings, account } = route.params
+  const { securitySettings } = route.params
   const client = useApolloClient()
   return (
     // eslint-disable-next-line react-native/no-inline-styles

--- a/app/screens/price-screen/price-screen.tsx
+++ b/app/screens/price-screen/price-screen.tsx
@@ -1,6 +1,7 @@
 import { useApolloClient } from "@apollo/client"
 import { RouteProp } from "@react-navigation/native"
 import * as React from "react"
+import { Text } from "react-native"
 import { BalanceHeader } from "../../components/balance-header"
 import { PriceGraphDataInjected } from "../../components/price-graph"
 import { Screen } from "../../components/screen"
@@ -15,11 +16,16 @@ type Props = {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const PriceScreen: ScreenType = ({ route }: Props) => {
+  const { securitySettings, account } = route.params
   const client = useApolloClient()
-
   return (
     // eslint-disable-next-line react-native/no-inline-styles
     <Screen backgroundColor={palette.white} preset="scroll" style={{ flex: 1 }}>
+      <BalanceHeader
+        currency={CurrencyType.BTC}
+        amount={balanceBtc(client)}
+        securitySettings={securitySettings}
+      />
       <BalanceHeader currency={"BTC"} amount={balanceBtc(client)} />
       <PriceGraphDataInjected />
     </Screen>

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin-screen.tsx
@@ -10,8 +10,6 @@ import {
   Keyboard,
   Platform,
   ScrollView,
-  Share,
-  Text,
   TextInput,
   View,
 } from "react-native"

--- a/app/screens/settings-screen/security-screen.tsx
+++ b/app/screens/settings-screen/security-screen.tsx
@@ -20,7 +20,7 @@ import {
   saveHideBalanceSettings,
   saveWalkThroughToolTipSettings,
 } from "../../graphql/client-only-query"
-import { useQuery} from "@apollo/client";
+import { useQuery } from "@apollo/client"
 
 const styles = EStyleSheet.create({
   button: {
@@ -90,7 +90,9 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
 
   const [isBiometricsEnabled, setIsBiometricsEnabled] = useState(mIsBiometricsEnabled)
   const [isPinEnabled, setIsPinEnabled] = useState(mIsPinEnabled)
-  const [isHideBalanceEnabled, setIsHideBalanceEnabled] = useState(data?.hideBalanceSettings ? data?.hideBalanceSettings : null)
+  const [isHideBalanceEnabled, setIsHideBalanceEnabled] = useState(
+    data?.hideBalanceSettings ? data?.hideBalanceSettings : null,
+  )
 
   useFocusEffect(() => {
     getIsBiometricsEnabled()

--- a/app/screens/settings-screen/security-screen.tsx
+++ b/app/screens/settings-screen/security-screen.tsx
@@ -18,6 +18,7 @@ import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import {load, remove, save} from "../../utils/storage";
 
 export const HIDE_BALANCE = "HIDE_BALANCE"
+export const WALKTHROUGH_TOOLTIP = "WALKTHROUGH_TOOLTIP"
 
 const styles = EStyleSheet.create({
   button: {
@@ -151,6 +152,7 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
   const onHideBalanceValueChanged = async (value) => {
     if (value) {
       setIsHideBalanceEnabled(await save(HIDE_BALANCE, true))
+      await save(WALKTHROUGH_TOOLTIP, true)
     } else {
       await remove(HIDE_BALANCE)
       setIsHideBalanceEnabled(null)

--- a/app/screens/settings-screen/security-screen.tsx
+++ b/app/screens/settings-screen/security-screen.tsx
@@ -15,6 +15,9 @@ import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import { PinScreenPurpose } from "../../utils/enum"
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
+import {load, remove, save} from "../../utils/storage";
+
+export const HIDE_BALANCE = "HIDE_BALANCE"
 
 const styles = EStyleSheet.create({
   button: {
@@ -83,10 +86,12 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
 
   const [isBiometricsEnabled, setIsBiometricsEnabled] = useState(mIsBiometricsEnabled)
   const [isPinEnabled, setIsPinEnabled] = useState(mIsPinEnabled)
+  const [isHideBalanceEnabled, setIsHideBalanceEnabled] = useState(null)
 
   useFocusEffect(() => {
     getIsBiometricsEnabled()
     getIsPinEnabled()
+    getIsHideBalanceEnabled()
   })
 
   const getIsBiometricsEnabled = async () => {
@@ -95,6 +100,10 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
 
   const getIsPinEnabled = async () => {
     setIsPinEnabled(await KeyStoreWrapper.getIsPinEnabled())
+  }
+
+  const getIsHideBalanceEnabled = async () => {
+    setIsHideBalanceEnabled(await load(HIDE_BALANCE))
   }
 
   const onBiometricsValueChanged = async (value) => {
@@ -136,6 +145,15 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
       navigation.navigate("pin", { screenPurpose: PinScreenPurpose.SetPin })
     } else {
       removePin()
+    }
+  }
+
+  const onHideBalanceValueChanged = async (value) => {
+    if (value) {
+      setIsHideBalanceEnabled(await save(HIDE_BALANCE, true))
+    } else {
+      await remove(HIDE_BALANCE)
+      setIsHideBalanceEnabled(null)
     }
   }
 
@@ -189,6 +207,23 @@ export const SecurityScreen: ScreenType = ({ route, navigation }: Props) => {
             navigation.navigate("pin", { screenPurpose: PinScreenPurpose.SetPin })
           }
         />
+      </View>
+      <View style={styles.settingContainer}>
+        <View style={styles.textContainer}>
+          <Text style={styles.title}>{translate("SecurityScreen.hideBalanceTitle")}</Text>
+          <Text style={styles.subtitle}>{translate("SecurityScreen.hideBalanceSubtitle")}</Text>
+          <Text style={styles.description}>
+            {translate("SecurityScreen.hideBalanceDescription")}
+          </Text>
+        </View>
+        <Switch
+          style={styles.switch}
+          value={isHideBalanceEnabled}
+          color={palette.lightBlue}
+          onValueChange={(value) => onHideBalanceValueChanged(value)}
+        />
+      </View>
+      <View style={styles.settingContainer}>
       </View>
     </Screen>
   )

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
-import { Alert, View } from "react-native"
+import { Alert, BackHandler, Button, TouchableOpacity, View } from "react-native"
 import Share from "react-native-share"
 import { Divider, Icon, ListItem } from "react-native-elements"
-import { StackNavigationProp } from "@react-navigation/stack"
+import { HeaderBackButton, StackNavigationProp } from "@react-navigation/stack"
 import {
   ApolloClient,
   gql,
@@ -27,6 +27,8 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
+import { useIsFocused } from "@react-navigation/core"
+import { useEffect } from "react"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -137,7 +139,7 @@ export const SettingsScreen: ScreenType = ({ navigation }: Props) => {
 type SettingsScreenProps = {
   client: ApolloClient<unknown>
   walletIsActive: boolean
-  navigation: StackNavigationProp<RootStackParamList, "settings">
+  navigation: StackNavigationProp<RootStackParamList, "settings" | "moveMoney">
   username: string
   notificationsEnabled: boolean
   csvAction: (options?: QueryLazyOptions<OperationVariables>) => void
@@ -156,6 +158,18 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     securityAction,
     resetDataStore,
   } = params
+  const isFocused = useIsFocused()
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton
+          label={"Home"}
+          onPress={() => navigation.navigate("moveMoney")}
+        ></HeaderBackButton>
+      ),
+    })
+  }, [isFocused])
 
   const list = [
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -27,8 +27,6 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
-import { useIsFocused } from "@react-navigation/native"
-import { useEffect } from "react"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -158,19 +156,18 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     securityAction,
     resetDataStore,
   } = params
-  const isFocused = useIsFocused()
 
-  useEffect(() => {
-     navigation.setOptions({
-        headerLeft: function HeaderBackOverRider() {
-          return  ( <HeaderBackButton
-              label={"Home"}
-              onPress={() => navigation.navigate("moveMoney")}
-          ></HeaderBackButton>
-          )
-        }
+ React.useEffect(() => {
+    navigation.setOptions({
+      headerLeft: function HeaderBackOverRider() {
+        return  ( <HeaderBackButton
+                label={"Home"}
+                onPress={() => navigation.navigate("moveMoney")}
+            ></HeaderBackButton>
+        )
+      }
     })
-  }, [isFocused])
+  })
 
   const list = [
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -157,15 +157,16 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     resetDataStore,
   } = params
 
- React.useEffect(() => {
+  React.useEffect(() => {
     navigation.setOptions({
       headerLeft: function HeaderBackOverRider() {
-        return  ( <HeaderBackButton
-                label={"Home"}
-                onPress={() => navigation.navigate("moveMoney")}
-            ></HeaderBackButton>
+        return (
+          <HeaderBackButton
+            label={"Home"}
+            onPress={() => navigation.navigate("moveMoney")}
+          ></HeaderBackButton>
         )
-      }
+      },
     })
   })
 

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -139,7 +139,7 @@ export const SettingsScreen: ScreenType = ({ navigation }: Props) => {
 type SettingsScreenProps = {
   client: ApolloClient<unknown>
   walletIsActive: boolean
-  navigation: StackNavigationProp<RootStackParamList, "settings" | "moveMoney">
+  navigation: StackNavigationProp<RootStackParamList, "settings">
   username: string
   notificationsEnabled: boolean
   csvAction: (options?: QueryLazyOptions<OperationVariables>) => void

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -170,7 +170,6 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     })
   })
 
-
   const list = [
     {
       category: translate("common.phoneNumber"),

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Alert, BackHandler, Button, TouchableOpacity, View } from "react-native"
+import { Alert, View } from "react-native"
 import Share from "react-native-share"
 import { Divider, Icon, ListItem } from "react-native-elements"
 import { HeaderBackButton, StackNavigationProp } from "@react-navigation/stack"
@@ -27,7 +27,7 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
-import { useIsFocused } from "@react-navigation/core"
+import { useIsFocused } from "@react-navigation/native"
 import { useEffect } from "react"
 
 type Props = {
@@ -161,13 +161,14 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
   const isFocused = useIsFocused()
 
   useEffect(() => {
-    navigation.setOptions({
-      headerLeft: () => (
-        <HeaderBackButton
-          label={"Home"}
-          onPress={() => navigation.navigate("moveMoney")}
-        ></HeaderBackButton>
-      ),
+     navigation.setOptions({
+        headerLeft: function HeaderBackOverRider() {
+          return  ( <HeaderBackButton
+              label={"Home"}
+              onPress={() => navigation.navigate("moveMoney")}
+          ></HeaderBackButton>
+          )
+        }
     })
   }, [isFocused])
 

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -27,8 +27,6 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
-import { useIsFocused } from "@react-navigation/native"
-import { useEffect } from "react"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -158,19 +156,18 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     securityAction,
     resetDataStore,
   } = params
-  const isFocused = useIsFocused()
 
-  useEffect(() => {
-     navigation.setOptions({
-        headerLeft: function HeaderBackOverRider() {
-          return  ( <HeaderBackButton
-              label={"Home"}
-              onPress={() => navigation.navigate("moveMoney")}
-          ></HeaderBackButton>
-          )
-        }
+ React.useEffect(() => {
+    navigation.setOptions({
+      headerLeft: function HeaderBackOverRider() {
+        return  ( <HeaderBackButton
+                label={"Home"}
+                onPress={() => navigation.navigate("moveMoney")}
+            ></HeaderBackButton>
+        )
+      }
     })
-  }, [isFocused])
+  })
 
   React.useEffect(() => {
     navigation.setOptions({

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -170,18 +170,6 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     })
   })
 
-  React.useEffect(() => {
-    navigation.setOptions({
-      headerLeft: function HeaderBackOverRider() {
-        return (
-          <HeaderBackButton
-            label={"Home"}
-            onPress={() => navigation.navigate("moveMoney")}
-          ></HeaderBackButton>
-        )
-      },
-    })
-  })
 
   const list = [
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Alert, View } from "react-native"
+import { Alert, BackHandler, Button, TouchableOpacity, View } from "react-native"
 import Share from "react-native-share"
 import { Divider, Icon, ListItem } from "react-native-elements"
 import { HeaderBackButton, StackNavigationProp } from "@react-navigation/stack"
@@ -27,6 +27,8 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
+import { useIsFocused } from "@react-navigation/core"
+import { useEffect } from "react"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -137,7 +139,7 @@ export const SettingsScreen: ScreenType = ({ navigation }: Props) => {
 type SettingsScreenProps = {
   client: ApolloClient<unknown>
   walletIsActive: boolean
-  navigation: StackNavigationProp<RootStackParamList, "settings">
+  navigation: StackNavigationProp<RootStackParamList, "settings" | "moveMoney">
   username: string
   notificationsEnabled: boolean
   csvAction: (options?: QueryLazyOptions<OperationVariables>) => void
@@ -156,6 +158,18 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     securityAction,
     resetDataStore,
   } = params
+  const isFocused = useIsFocused()
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerLeft: () => (
+        <HeaderBackButton
+          label={"Home"}
+          onPress={() => navigation.navigate("moveMoney")}
+        ></HeaderBackButton>
+      ),
+    })
+  }, [isFocused])
 
   React.useEffect(() => {
     navigation.setOptions({

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -663,7 +663,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 49af259315248df108d3144509353caec1d96a1d
+  FBReactNativeSpec: 88bc50e5ab981f046612972ee4b1205317109a6d
   Firebase: e1e089d9aac215a52442583f818ab61de3c4581b
   FirebaseAnalytics: 9f8f4feab1f3fddf4e4515f8f022fe6aa9e51043
   FirebaseCore: 0a43b7f1c5b36f3358cd703011ca4c7e0df55870
@@ -742,4 +742,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 9452286fe8fd98fc112c1f8fc1fbf80a59af1476
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "react-native-swiper": "^1.6.0-rc.3",
     "react-native-vector-icons": "^7.0.0",
     "react-native-version-number": "^0.3.6",
+    "react-native-walkthrough-tooltip": "^1.2.0",
     "react-native-youtube": "^2.0.0",
     "tempy": "^1.0.0",
     "url": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13311,9 +13311,9 @@ react-error-overlay@^6.0.3, react-error-overlay@^6.0.9:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-fast-compare@^2.0.0:
+react-fast-compare@^2.0.0, react-fast-compare@^2.0.4:
   version "2.0.4"
-  resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
@@ -13703,6 +13703,14 @@ react-native-version-number@*, react-native-version-number@^0.3.6:
   version "0.3.6"
   resolved "https://registry.npmjs.org/react-native-version-number/-/react-native-version-number-0.3.6.tgz"
   integrity sha512-TdyXiK90NiwmSbmAUlUBOV6WI1QGoqtvZZzI5zQY4fKl67B3ZrZn/h+Wy/OYIKKFMfePSiyfeIs8LtHGOZ/NgA==
+
+react-native-walkthrough-tooltip@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-walkthrough-tooltip/-/react-native-walkthrough-tooltip-1.2.0.tgz#4d9781d2e3231bbe5d6ab154c6cf3cbbe4040e6d"
+  integrity sha512-M4/dg8PuYKslitHXaCQ/JLudvGEVqI2tJLKv34AQ3X0tLTtNXvAvyCPlDZ+Bg2l9qJ5PQOz8iMt6dyqLn1ed+w==
+  dependencies:
+    prop-types "^15.6.1"
+    react-fast-compare "^2.0.4"
 
 react-native-youtube@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Had some issues with my IDE will re-basing my branch so I closed this original [Pull Request](https://github.com/GaloyMoney/galoy-mobile/pull/144)

In summary- These changes implement the security feature to hide the user's balance on the home and send screens, replacing the balance with an eye icon that can be toggled between hidden and shown if touched. 

![Simulator Screen Shot - iPhone 12 - 2021-09-01 at 08 55 21](https://user-images.githubusercontent.com/17483038/131685374-2a6c3104-a25a-47ec-9ef1-4aad23f5a290.png)

![Simulator Screen Shot - iPhone 12 - 2021-09-01 at 08 55 35](https://user-images.githubusercontent.com/17483038/131685385-6b8246fd-9fc9-4d0e-9144-300cbd5ce2fe.png)

![Simulator Screen Shot - iPhone 12 - 2021-09-01 at 08 56 21](https://user-images.githubusercontent.com/17483038/131685394-8efa8049-72d8-48fe-be09-8f007dc00092.png)

