### PR TITLE
Feature advertise copy tip link

### DIFF
--- a/app/constants/support.ts
+++ b/app/constants/support.ts
@@ -1,1 +1,2 @@
 export const WHATSAPP_CONTACT_NUMBER = "+50369835117"
+export const LN_PAGE_DOMAIN = "https://ln.bitcoinbeach.com/"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -664,6 +664,10 @@
     "other": "{{formatted_number}} sats",
     "zero": "0 sats"
   },
+  "tippingLink": {
+    "title": "Want to receive tips? Share your tipping link!",
+    "copied": "{{data}} saved to clipboard"
+  },
   "whatsapp": {
     "contactUs": "Need help? Talk to us on WhatsApp!",
     "defaultSupportMessage": "Hey there! I need some help with Bitcoin Beach Wallet"

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -694,8 +694,8 @@
     "zero": "‪{{formatted_number}}‬ Satoshi"
   },
   "tippingLink": {
-  "title": "¿Quiere recibir propinas? ¡Comparta su enlace!",
-  "copied": "{{data}} se ha guardado al portapapeles"
+    "title": "¿Quiere recibir propinas? ¡Comparta su enlace!",
+    "copied": "{{data}} se ha guardado al portapapeles"
   },
   "whatsapp": {
     "contactUs": "¿Necesita ayuda? Contáctenos por WhatsApp",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -693,6 +693,10 @@
   "sat": {
     "zero": "‪{{formatted_number}}‬ Satoshi"
   },
+  "tippingLink": {
+  "title": "¿Quiere recibir propinas? ¡Comparta su enlace!",
+  "copied": "{{data}} se ha guardado al portapapeles"
+  },
   "whatsapp": {
     "contactUs": "¿Necesita ayuda? Contáctenos por WhatsApp",
     "defaultSupportMessage": "¡Hola! Necesito ayuda con Bitcoin Beach Wallet"

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -695,7 +695,7 @@
   },
   "tippingLink": {
     "title": "¿Quiere recibir propinas? ¡Comparta su enlace!",
-    "copied": "{{data}} se ha guardado al portapapeles"
+    "copied": "{{data}} se ha copiado en el portapapeles"
   },
   "whatsapp": {
     "contactUs": "¿Necesita ayuda? Contáctenos por WhatsApp",

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -222,7 +222,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       id: "tippingLink",
       action: () => copyToClipBoard(username),
       enabled: walletIsActive && username !== null,
-      greyed: !walletIsActive || !username,
+      greyed: !walletIsActive || username === null,
     },
     {
       category: translate("whatsapp.contactUs"),

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -158,7 +158,6 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     securityAction,
     resetDataStore,
   } = params
-
   const copyToClipBoard = (username) => {
     Clipboard.setString(LN_PAGE_DOMAIN + username)
     Clipboard.getString().then((data) =>
@@ -222,7 +221,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       icon: "cash-outline",
       id: "tippingLink",
       action: () => copyToClipBoard(username),
-      enabled: walletIsActive && typeof username !== null,
+      enabled: walletIsActive && username !== null,
       greyed: !walletIsActive || !username,
     },
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -161,7 +161,9 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
   const copyToClipBoard = (username) => {
     Clipboard.setString(LN_PAGE_DOMAIN + username)
     Clipboard.getString().then((data) =>
-      toastShow(translate("tippingLink.copied", { data })),
+      toastShow(translate("tippingLink.copied", { data }), {
+        backgroundColor: palette.lightBlue,
+      }),
     )
   }
 

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -222,8 +222,8 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       icon: "cash-outline",
       id: "tippingLink",
       action: () => copyToClipBoard(username),
-      enabled: walletIsActive,
-      greyed: !walletIsActive,
+      enabled: walletIsActive && username,
+      greyed: !walletIsActive || !username,
     },
     {
       category: translate("whatsapp.contactUs"),

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -27,7 +27,7 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
-import { Clipboard } from "@react-native-community/clipboard/dist/Clipboard"
+import Clipboard from "@react-native-community/clipboard"
 import { toastShow } from "../../utils/toast"
 
 type Props = {
@@ -162,8 +162,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
 
   const copyToClipBoard = (username) => {
     Clipboard.setString(LN_PAGE_DOMAIN + username)
-    if (Clipboard.hasURL())
-      Clipboard.getString().then((data) => (toastShow(translate("tippingLink.copied", {data}))))
+    Clipboard.getString().then((data) => (toastShow(translate("tippingLink.copied", {data}))))
   }
 
   const list = [

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import {Alert, Platform, View} from "react-native"
+import { Alert, View } from "react-native"
 import Share from "react-native-share"
 import { Divider, Icon, ListItem } from "react-native-elements"
 import { StackNavigationProp } from "@react-navigation/stack"
@@ -159,10 +159,11 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     resetDataStore,
   } = params
 
-
   const copyToClipBoard = (username) => {
     Clipboard.setString(LN_PAGE_DOMAIN + username)
-    Clipboard.getString().then((data) => (toastShow(translate("tippingLink.copied", {data}))))
+    Clipboard.getString().then((data) =>
+      toastShow(translate("tippingLink.copied", { data })),
+    )
   }
 
   const list = [

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -222,7 +222,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       icon: "cash-outline",
       id: "tippingLink",
       action: () => copyToClipBoard(username),
-      enabled: walletIsActive && username,
+      enabled: walletIsActive && typeof username !== null,
       greyed: !walletIsActive || !username,
     },
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Alert, View } from "react-native"
+import {Alert, Platform, View} from "react-native"
 import Share from "react-native-share"
 import { Divider, Icon, ListItem } from "react-native-elements"
 import { StackNavigationProp } from "@react-navigation/stack"
@@ -18,7 +18,7 @@ import { Screen } from "../../components/screen"
 import { VersionComponent } from "../../components/version"
 import { language_mapping } from "./language-screen"
 import { palette } from "../../theme/palette"
-import { WHATSAPP_CONTACT_NUMBER } from "../../constants/support"
+import { LN_PAGE_DOMAIN, WHATSAPP_CONTACT_NUMBER } from "../../constants/support"
 import { translate } from "../../i18n"
 import { walletIsActive } from "../../graphql/query"
 import { openWhatsApp } from "../../utils/external"
@@ -27,6 +27,8 @@ import { hasFullPermissions, requestPermission } from "../../utils/notifications
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
+import { Clipboard } from "@react-native-community/clipboard/dist/Clipboard"
+import { toastShow } from "../../utils/toast"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -157,6 +159,13 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     resetDataStore,
   } = params
 
+
+  const copyToClipBoard = (username) => {
+    Clipboard.setString(LN_PAGE_DOMAIN + username)
+    if (Clipboard.hasURL())
+      Clipboard.getString().then((data) => (toastShow(translate("tippingLink.copied", {data}))))
+  }
+
   const list = [
     {
       category: translate("common.phoneNumber"),
@@ -205,6 +214,14 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
       icon: "ios-download",
       id: "csv",
       action: () => csvAction(),
+      enabled: walletIsActive,
+      greyed: !walletIsActive,
+    },
+    {
+      category: translate("tippingLink.title"),
+      icon: "cash-outline",
+      id: "tippingLink",
+      action: () => copyToClipBoard(username),
       enabled: walletIsActive,
       greyed: !walletIsActive,
     },

--- a/app/utils/toast.ts
+++ b/app/utils/toast.ts
@@ -1,8 +1,8 @@
-import Toast from "react-native-root-toast"
+import Toast, { ToastOptions } from "react-native-root-toast"
 import { palette } from "../theme/palette"
 
-export const toastShow = (message: string): void => {
-  Toast.show(message, {
+export const toastShow = (message: string, options?: ToastOptions): void => {
+  const toastShowOptions = {
     duration: Toast.durations.LONG,
     shadow: false,
     animation: true,
@@ -11,5 +11,12 @@ export const toastShow = (message: string): void => {
     position: 50,
     opacity: 1,
     backgroundColor: palette.red,
-  })
+  }
+
+  if (options) {
+    Object.entries(options).map(([key, value]) => {
+      toastShowOptions[key] = value
+    })
+  }
+  Toast.show(message, toastShowOptions)
 }


### PR DESCRIPTION
Added the settings menu item to advertise sharing of user's tip links. Copies the tip link to their clipboard and uses Toast to display that they copied their link so they can share. This PR is an attempt to satisfy [Issue #182](https://github.com/GaloyMoney/galoy-mobile/issues/182)