### PR TITLE
Add restriction on username start characters

### DIFF
--- a/__tests__/username-validation.spec.ts
+++ b/__tests__/username-validation.spec.ts
@@ -72,4 +72,49 @@ describe("Username validation", () => {
     expect(hasValidCharacters).toBeFalsy()
     expect(isValid).toBeFalsy()
   })
+
+  it("is invalid for a username beginning with bc1", () => {
+    const username = "bc1hello"
+
+    const hasValidLength = UsernameValidation.hasValidLength(username)
+    const hasValidCharacters = UsernameValidation.hasValidCharacters(username)
+    const hasNoRestictedStartCharacters =
+      UsernameValidation.hasNoRestictedStartCharacters(username)
+    const isValid = UsernameValidation.isValid(username)
+
+    expect(hasValidLength).toBeTruthy()
+    expect(hasValidCharacters).toBeTruthy()
+    expect(hasNoRestictedStartCharacters).toBeFalsy()
+    expect(isValid).toBeFalsy()
+  })
+
+  it("is invalid for a username beginning with 1", () => {
+    const username = "1hello"
+
+    const hasValidLength = UsernameValidation.hasValidLength(username)
+    const hasValidCharacters = UsernameValidation.hasValidCharacters(username)
+    const hasNoRestictedStartCharacters =
+      UsernameValidation.hasNoRestictedStartCharacters(username)
+    const isValid = UsernameValidation.isValid(username)
+
+    expect(hasValidLength).toBeTruthy()
+    expect(hasValidCharacters).toBeTruthy()
+    expect(hasNoRestictedStartCharacters).toBeFalsy()
+    expect(isValid).toBeFalsy()
+  })
+
+  it("is invalid for a username beginning with 3", () => {
+    const username = "3hello"
+
+    const hasValidLength = UsernameValidation.hasValidLength(username)
+    const hasValidCharacters = UsernameValidation.hasValidCharacters(username)
+    const hasNoRestictedStartCharacters =
+      UsernameValidation.hasNoRestictedStartCharacters(username)
+    const isValid = UsernameValidation.isValid(username)
+
+    expect(hasValidLength).toBeTruthy()
+    expect(hasValidCharacters).toBeTruthy()
+    expect(hasNoRestictedStartCharacters).toBeFalsy()
+    expect(isValid).toBeFalsy()
+  })
 })

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -587,8 +587,8 @@
     "available": "✅  %{input} is available",
     "confirmSubtext": "The username is permanent and can not be changed later",
     "confirmTitle": "Set %{input} as your username?",
-    "letterAndNumber": "Only lowercase letter, number and underscore (_) are accepted",
     "forbiddenStart": "Cannot start with bc1, 1, or 3",
+    "letterAndNumber": "Only lowercase letter, number and underscore (_) are accepted",
     "notAvailable": "❌  %{input} is not available",
     "success": "%{input} is now your username!",
     "usernameToUse": "What username do you want to use?"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -588,6 +588,7 @@
     "confirmSubtext": "The username is permanent and can not be changed later",
     "confirmTitle": "Set %{input} as your username?",
     "letterAndNumber": "Only lowercase letter, number and underscore (_) are accepted",
+    "forbiddenStart": "Cannot start with bc1, 1, or 3",
     "notAvailable": "❌  %{input} is not available",
     "success": "%{input} is now your username!",
     "usernameToUse": "What username do you want to use?"

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -626,6 +626,7 @@
     "confirmSubtext": "Este nombre de usuario es permanente y no se podrá cambiar más adelante.",
     "confirmTitle": "¿Desea establecer %{input} como su nombre de usuario?",
     "letterAndNumber": "Solo se aceptan letras en minúscula, números y guiones bajos (_)",
+    "forbiddenStart": "No se puede empezar con bc1, 1, o 3 ",
     "notAvailable": "❌  %{input} no está disponible",
     "success": "¡%{input} es ahora su nombre de usuario!",
     "usernameToUse": "¿Qué nombre de usuario desea usar?"

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -625,8 +625,8 @@
     "available": "✅  %{input} está disponible",
     "confirmSubtext": "Este nombre de usuario es permanente y no se podrá cambiar más adelante.",
     "confirmTitle": "¿Desea establecer %{input} como su nombre de usuario?",
+    "forbiddenStart": "No debe empezar con bc1, 1 o 3",
     "letterAndNumber": "Solo se aceptan letras en minúscula, números y guiones bajos (_)",
-    "forbiddenStart": "No se puede empezar con bc1, 1, o 3 ",
     "notAvailable": "❌  %{input} no está disponible",
     "success": "¡%{input} es ahora su nombre de usuario!",
     "usernameToUse": "¿Qué nombre de usuario desea usar?"

--- a/app/screens/settings-screen/username-screen.tsx
+++ b/app/screens/settings-screen/username-screen.tsx
@@ -95,6 +95,12 @@ export const UsernameScreen: ScreenType = ({ navigation }: Props) => {
       return
     }
 
+    if (!UsernameValidation.hasNoRestictedStartCharacters(input)) {
+      setMessage(translate("UsernameScreen.forbiddenStart"))
+      setMessageIsError(true)
+      return
+    }
+
     if (usernameExists) {
       setMessage(translate("UsernameScreen.notAvailable", { input }))
       setMessageIsError(true)

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -7,10 +7,15 @@ export class UsernameValidation {
     return new RegExp(/^[0-9a-z_]+$/i).test(username)
   }
 
+  public static hasNoRestictedStartCharacters = (username: string): boolean => {
+    return new RegExp(/^(?!bc1|1|3).+$/i).test(username)
+  }
+
   public static isValid = (username: string): boolean => {
     return (
       UsernameValidation.hasValidLength(username) &&
-      UsernameValidation.hasValidCharacters(username)
+      UsernameValidation.hasValidCharacters(username) &&
+      UsernameValidation.hasNoRestictedStartCharacters(username)
     )
   }
 }


### PR DESCRIPTION
Fixes https://github.com/GaloyMoney/galoy-mobile/issues/196

Worth noting someone might need a proper Spanish translation as this was just a quick Google Translate, thanks!

**Changes**
Now shows an error message when trying to create a username beginning with 'bc1', '1', or '3'.
<img width="491" alt="Screenshot 2021-09-23 at 4 31 57 pm" src="https://user-images.githubusercontent.com/864576/134537818-c267ba0c-5efc-426b-9e27-bca7b0bab986.png">


