### PR TITLE
Fix storybook

### DIFF
--- a/app/components/input-payment/input-payment.story.tsx
+++ b/app/components/input-payment/input-payment.story.tsx
@@ -15,6 +15,10 @@ storiesOf("InputPayment", module)
           price={0.00011}
           onUpdateAmount={() => true}
           editable
+          primaryAmount={{
+            value: 100,
+            currency: "USD"
+          }}
         />
       </UseCase>
       <UseCase text="Non editable" usage="Loading">
@@ -24,6 +28,10 @@ storiesOf("InputPayment", module)
           initAmount={12345}
           onUpdateAmount={() => true}
           editable={false}
+          primaryAmount={{
+            value: 100,
+            currency: "BTC"
+          }}
         />
       </UseCase>
     </Story>

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.story.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.story.tsx
@@ -7,6 +7,7 @@ import { AccountType } from "../../utils/enum"
 
 const route = {
   params: {
+    tx:{
     currency: "BTC",
     account: AccountType.Bitcoin,
     amount: 100,
@@ -15,6 +16,11 @@ const route = {
     type: "invoice",
     description: "This is my description",
     destination: "0d1ea4c256cd50a2a7ccbfd22b3d9959f6fd30bd840b9ff3c7c65ee4e21df06d",
+    usd: 100,
+    feeUsd: 0.1,
+    fee: 5,
+    date_format: "10/06/2021"
+    }
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "patch": "patch-package",
     "postinstall": "jetify && if which pod >/dev/null; then (cd ios; pod install); fi",
     "prepare": "npm-run-all patch hack:*",
-    "storybook": "storybook start -p 9001 --skip-packager",
+    "storybook": "start-storybook -p 9001",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:4000 tcp:4000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081"
   },
   "dependencies": {
@@ -175,6 +175,7 @@
     "jetifier": "^1.6.6",
     "metro-config": "^0.66.2",
     "metro-react-native-babel-preset": "^0.64.0",
+    "mock-apollo-client": "^1.2.0",
     "npm-run-all": "4.1.5",
     "patch-package": "6.2.2",
     "postinstall-prepare": "1.0.1",

--- a/storybook/views/story-screen.tsx
+++ b/storybook/views/story-screen.tsx
@@ -1,15 +1,18 @@
 import * as React from "react"
 import { ViewStyle, KeyboardAvoidingView, Platform } from "react-native"
-
+import { ApolloProvider } from '@apollo/client';
+import { createMockClient } from 'mock-apollo-client';
 const ROOT: ViewStyle = { backgroundColor: "#f0f0f0", flex: 1 }
 
 export interface StoryScreenProps {
   children?: React.ReactNode
 }
-
+const mockClient = createMockClient();
 const behavior = Platform.OS === "ios" ? "padding" : null
 export const StoryScreen = (props) => (
   <KeyboardAvoidingView style={ROOT} behavior={behavior} keyboardVerticalOffset={50}>
+    <ApolloProvider client={mockClient}>
     {props.children}
+    </ApolloProvider>
   </KeyboardAvoidingView>
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -11922,6 +11922,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mock-apollo-client@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mock-apollo-client/-/mock-apollo-client-1.2.0.tgz#72543df0d74577d29be1b34cecba8898c7e71451"
+  integrity sha512-zCVHv3p7zvUmen9zce9l965ZrI6rMbrm2/oqGaTerVYOaYskl/cVgTG/L7iIToTIpI7onk/f6tu8hxPXZdyy/g==
+
 moment@^2.19.3, moment@^2.24.0:
   version "2.29.1"
   resolved "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz"


### PR DESCRIPTION
I've fixed storybook so it now runs for me on device.  The PR contains the following changes:
- Added `mock-apollo-client` lib so we can mock the graphql responses as shown [here](https://www.npmjs.com/package/mock-apollo-client)
- Updated the start command for storybook
- Fixed up a few of the stories so they actually render

If there are any visual issues in any of the stories then I suggest we fix those in a separate PR.

![image](https://user-images.githubusercontent.com/3502409/134799912-6ba3d2d0-27d4-49e4-b3c9-01761ba3e37e.png)
