### PR TITLE
Alert user not to leave while payment is processing

### DIFF
--- a/__tests__/screens/send-bitcoin-confirmation-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-confirmation-screen.spec.tsx
@@ -79,6 +79,7 @@ const usernameRouteParams = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mNavigation: any = {
+  addListener: jest.fn(),
   goBack: jest.fn(),
   navigate: jest.fn(),
   pop: jest.fn(),

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -544,6 +544,8 @@
     "feeLabel": "Fee:",
     "memoLabel": "Note:",
     "paymentFinal": "Payments are final.",
+    "paymentProcessing": "Payment Processing",
+    "processingDescription": "Your payment is currently process. Are you sure you want to leave the screen?",
     "stalePrice": "Your bitcoin price is old and was last updated {{timePeriod}} ago. Please restart the app before making a payment.",
     "title": "Confirm Payment",
     "totalLabel": "Total:",
@@ -673,7 +675,8 @@
     "tryAgain": "Try again",
     "type": "Type",
     "username": "Username",
-    "usernameRequired": "Username is required"
+    "usernameRequired": "Username is required",
+    "yes": "Yes"
   },
   "errors": {
     "generic": "There was an error. Please try again later",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -583,6 +583,8 @@
     "feeLabel": "Tarifa de red:",
     "memoLabel": "Nota:",
     "paymentFinal": "Recuerde que los pagos son definitivos y una vez realizados son irreversibles.",
+    "paymentProcessing": "Procesando pago",
+    "processingDescription": "Su pago está en proceso. ¿Está seguro que desea salir?",
     "stalePrice": "El precio de bitcoin está desactualizado, se actualizó por última vez hace {{timePeriod}}. Por favor reinicie la aplicación antes de realizar el pago.",
     "title": "Confirmar pago",
     "totalLabel": "Total:",
@@ -708,7 +710,8 @@
     "tryAgain": "Inténtalo de nuevo",
     "type": "tipo",
     "username": "Nombre de usuario",
-    "usernameRequired": "El nombre de usuario es requerido"
+    "usernameRequired": "El nombre de usuario es requerido",
+    "yes": "Si"
   },
   "errors": {
     "generic": "Hubo un error inesperado. Por favor intente más tarde\n",

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { Text, View } from "react-native"
+import { Alert, Text, View } from "react-native"
 import { Button } from "react-native-elements"
 import EStyleSheet from "react-native-extended-stylesheet"
 import { gql, useApolloClient, useMutation } from "@apollo/client"
@@ -277,6 +277,30 @@ export const SendBitcoinConfirmationScreen = ({
     refetchQueries: ["gql_main_query", "transactionsList"],
   })
 
+  useEffect(
+    () =>
+      navigation.addListener("beforeRemove", (e) => {
+        if (status !== Status.LOADING) {
+          return
+        }
+
+        e.preventDefault()
+        Alert.alert(
+          translate("SendBitcoinConfirmationScreen.paymentProcessing"),
+          translate("SendBitcoinConfirmationScreen.processingDescription"),
+          [
+            { text: translate("common.cancel"), style: "cancel" },
+            {
+              text: translate("common.yes"),
+              style: "destructive",
+              onPress: () => navigation.dispatch(e.data.action),
+            },
+          ],
+        )
+      }),
+    [navigation, status],
+  )
+
   const pay = async () => {
     if ((amountless || paymentType === "onchain") && paymentSatAmount === 0) {
       setStatus(Status.ERROR)
@@ -363,7 +387,7 @@ export const SendBitcoinConfirmationScreen = ({
   }
 
   useEffect(() => {
-    if (status === "loading" || status === "idle") {
+    if (status === Status.LOADING || status === Status.IDLE) {
       return
     }
 
@@ -504,7 +528,7 @@ export const SendBitcoinConfirmationScreen = ({
           )}
           <Button
             buttonStyle={styles.buttonStyle}
-            loading={status === "loading"}
+            loading={status === Status.LOADING}
             onPress={() => {
               if (hasCompletedPayment) {
                 navigation.pop(2)


### PR DESCRIPTION
When a user makes a payment we don't want them to leave the screen while the mutation hasn't concluded because they may try to make the payment again and end up sending two payments.