### PR TITLE
Fixed race condition for user balance

### DIFF
--- a/app/hooks/use-wallet-balance.ts
+++ b/app/hooks/use-wallet-balance.ts
@@ -7,11 +7,17 @@ export const useWalletBalance = (): {
   walletId?: string
   satBalance: number
   usdBalance: number | string
+  loading: boolean
 } => {
-  const { convertCurrencyAmount, currentBalance } = useMySubscription()
+  const { convertCurrencyAmount, currentBalance, mySubscriptionLoading } =
+    useMySubscription()
   const { hasToken } = useToken()
 
-  const { data, refetch } = useQuery(MAIN_QUERY, {
+  const {
+    data,
+    refetch,
+    loading: mainQueryLoading,
+  } = useQuery(MAIN_QUERY, {
     variables: { hasToken },
     fetchPolicy: "cache-only",
   })
@@ -22,6 +28,7 @@ export const useWalletBalance = (): {
     return {
       satBalance: 0,
       usdBalance: 0,
+      loading: false,
     }
   }
 
@@ -39,5 +46,6 @@ export const useWalletBalance = (): {
       satBalance > 0
         ? convertCurrencyAmount({ amount: satBalance, from: "BTC", to: "USD" })
         : 0,
+    loading: mySubscriptionLoading && mainQueryLoading,
   }
 }

--- a/app/hooks/user-hooks.ts
+++ b/app/hooks/user-hooks.ts
@@ -30,6 +30,7 @@ type UseMyUpdates = {
     amount: number
     usdPerSat: number
   }
+  mySubscriptionLoading: boolean
 }
 
 const MY_UPDATES_SUBSCRIPTION = gql`
@@ -113,7 +114,7 @@ export const useMyCurrencies = (): {
 }
 
 export const useMySubscription = (): UseMyUpdates => {
-  const { data } = useSubscription(MY_UPDATES_SUBSCRIPTION)
+  const { data, loading } = useSubscription(MY_UPDATES_SUBSCRIPTION)
 
   const [cachedPrice, updatePriceCach] = usePriceCache()
 
@@ -180,9 +181,10 @@ export const useMySubscription = (): UseMyUpdates => {
     convertCurrencyAmount,
     formatCurrencyAmount,
     usdPerSat: (priceRef.current / 100).toFixed(8),
-    currentBalance: data?.myUpdates?.me?.defaultAccount?.wallets?.[0].balance,
+    currentBalance: data?.myUpdates?.me?.defaultAccount?.wallets?.[0]?.balance,
     intraLedgerUpdate: intraLedgerUpdate.current,
     lnUpdate: lnUpdate.current,
     onChainUpdate: onChainUpdate.current,
+    mySubscriptionLoading: loading,
   }
 }

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -83,7 +83,7 @@ export const SendBitcoinConfirmationScreen = ({
 }: SendBitcoinConfirmationScreenProps): JSX.Element => {
   const client = useApolloClient()
   const { convertCurrencyAmount, formatCurrencyAmount } = useMySubscription()
-  const { walletId: myDefaultWalletId, satBalance } = useWalletBalance()
+  const { walletId: myDefaultWalletId, satBalance, loading } = useWalletBalance()
 
   const {
     address,
@@ -296,6 +296,14 @@ export const SendBitcoinConfirmationScreen = ({
       return
     }
   }
+
+  useEffect(() => {
+    if (loading) {
+      setStatus(Status.LOADING)
+    } else {
+      setStatus(Status.IDLE)
+    }
+  }, [loading])
 
   useEffect(() => {
     if (status === "loading" || status === "idle") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1821,7 +1821,7 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/create-cache-key-function@^27.0.1", "@jest/create-cache-key-function@^27.2.3":
+"@jest/create-cache-key-function@^27.0.1":
   version "27.2.4"
   resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-27.2.4.tgz#5d3350ba32f1bd07145054601bac7a8d5c47bf0c"
   integrity sha512-Cd9A6ugtkkHiQHDNbifdFrBBTgsKHp1KgCAjyAGMCrxFudR2icTKIPkXN2R2/IoMAMObUidMRBLDJy/RgX7uDQ==


### PR DESCRIPTION
There was a race condition whereby the send bitcoin confirmation screen would momentarily flash up an error saying that the user did not have sufficient balance to process the transaction.  I have added a workaround for now to include a loading indicator for 2 of the queries we are using.  I think we need to refactor this code into a better design as right now it's hard to work out the relationships which components have as our hooks are relying on each other.