### PR TITLE
Setting encryption use to false

### DIFF
--- a/ios/GaloyApp/Info.plist
+++ b/ios/GaloyApp/Info.plist
@@ -142,6 +142,6 @@
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
The iOS build is failing with an error regarding the status of `ITSAppUsesNonExemptEncryption` key value.  I had added this because otherwise it asks us in the App Store connect to define whether the app uses encryption.  There is some conflicting information online as to whether our app should be marked as using encryption or not.  For now I'm marking it as not using it.