### PR TITLE
Edited README for storybook config in app/index.js, not app/app.tsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ To run the app fully locally the backend must also be set up by following the in
 From the command line in your generated app's root directory, enter `yarn storybook`
 This starts up the storybook server.
 
-In `app/index.tsx`, change `SHOW_STORYBOOK` to `true` and reload the app and run `yarn storybook`.
+In `index.js`, change `SHOW_STORYBOOK` to `true` and reload the app and run `yarn storybook`.
 
 For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ To run the app fully locally the backend must also be set up by following the in
 From the command line in your generated app's root directory, enter `yarn storybook`
 This starts up the storybook server.
 
-In `app/app.tsx`, change `SHOW_STORYBOOK` to `true` and reload the app.
+In `app/index.tsx`, change `SHOW_STORYBOOK` to `true` and reload the app and run `yarn storybook`.
 
 For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.


### PR DESCRIPTION
The storybook config in the README directed devs to edit SHOW_STORYBOOK in app/app.tsx when it is actually in app/index.js﻿
