### PR TITLE
add masking to transaction items if balances are hidden in user settings

### DIFF
--- a/app/components/transaction-item/transaction-item.tsx
+++ b/app/components/transaction-item/transaction-item.tsx
@@ -1,13 +1,15 @@
+import * as React from "react"
+import { useState, useEffect } from "react"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { ListItem } from "react-native-elements"
-import * as React from "react"
 import { Text } from "react-native"
 import EStyleSheet from "react-native-extended-stylesheet"
+import Icon from "react-native-vector-icons/Ionicons"
 import { IconTransaction } from "../icon-transactions"
 import { palette } from "../../theme/palette"
 import { ParamListBase } from "@react-navigation/native"
 import { prefCurrencyVar as primaryCurrencyVar } from "../../graphql/client-only-query"
-
+import { useHideBalance } from "../../hooks"
 import * as currency_fmt from "currency.js"
 import i18n from "i18n-js"
 import moment from "moment"
@@ -15,6 +17,10 @@ import moment from "moment"
 const styles = EStyleSheet.create({
   container: {
     paddingVertical: 9,
+  },
+
+  hiddenBalanceContainer: {
+    fontSize: "16rem",
   },
 
   pending: {
@@ -95,11 +101,20 @@ export const TransactionItem: React.FC<TransactionItemProps> = ({
   subtitle = false,
 }: TransactionItemProps) => {
   const primaryCurrency = primaryCurrencyVar()
+  const hideBalance = useHideBalance()
 
   const isReceive = tx.direction === "RECEIVE"
   const isPending = tx.status === "PENDING"
   const description = descriptionDisplay(tx)
   const usdAmount = computeUsdAmount(tx)
+
+  const [txHideBalance, setTxHideBalance] = useState(hideBalance)
+
+  useEffect(() => {
+    setTxHideBalance(hideBalance)
+  }, [hideBalance])
+
+  const pressTxAmount = () => setTxHideBalance((prev) => !prev)
 
   return (
     <ListItem
@@ -119,9 +134,16 @@ export const TransactionItem: React.FC<TransactionItemProps> = ({
         <ListItem.Title>{description}</ListItem.Title>
         <ListItem.Subtitle>{subtitle ? dateDisplay(tx) : undefined}</ListItem.Subtitle>
       </ListItem.Content>
-      <Text style={amountDisplayStyle({ isReceive, isPending })}>
-        {amountDisplay({ ...tx, usdAmount, primaryCurrency })}
-      </Text>
+      {txHideBalance ? (
+        <Icon style={styles.hiddenBalanceContainer} name="eye" onPress={pressTxAmount} />
+      ) : (
+        <Text
+          style={amountDisplayStyle({ isReceive, isPending })}
+          onPress={hideBalance ? pressTxAmount : undefined}
+        >
+          {amountDisplay({ ...tx, usdAmount, primaryCurrency })}
+        </Text>
+      )}
     </ListItem>
   )
 }


### PR DESCRIPTION
User can click on amount to toggle visibility for that specific tx.

![image](https://user-images.githubusercontent.com/53627801/145067968-9b4e70bd-7db0-4d7d-87b1-5df7d547735b.png)

![image](https://user-images.githubusercontent.com/53627801/145068004-8e74806a-ad2a-4217-b850-0844e1f381ee.png)

![image](https://user-images.githubusercontent.com/53627801/145068042-0bbe4d21-c9e0-4cf0-957c-d643164634fd.png)

Resolves #319 