### PR TITLE
fix: use a reactive-var to reset cache after mutations

### DIFF
--- a/__tests__/screens/__snapshots__/send-bitcoin-confirmation-screen.spec.tsx.snap
+++ b/__tests__/screens/__snapshots__/send-bitcoin-confirmation-screen.spec.tsx.snap
@@ -54,10 +54,8 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
   >
     <View
       accessible={true}
-      collapsable={false}
       focusable={true}
       forwardedRef={[Function]}
-      nativeID="animatedComponent"
       onClick={[Function]}
       onResponderGrant={[Function]}
       onResponderMove={[Function]}
@@ -80,12 +78,10 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
       }
     />
     <View
-      collapsable={false}
       deviceHeight={null}
       deviceWidth={null}
       forwardedRef={[Function]}
       hideModalContentWhileAnimating={false}
-      nativeID="animatedComponent"
       onBackdropPress={[Function]}
       onModalHide={[Function]}
       onModalWillHide={[Function]}
@@ -252,9 +248,7 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
                 }
               }
               accessible={true}
-              collapsable={false}
               focusable={true}
-              nativeID="animatedComponent"
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -324,9 +318,7 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
                 }
               }
               accessible={true}
-              collapsable={false}
               focusable={true}
-              nativeID="animatedComponent"
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}
@@ -423,14 +415,6 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
         </View>
       </View>
       <View>
-        <View>
-          <Text>
-            Do you want to confirm this payment?
-          </Text>
-          <Text>
-            Payments are final.
-          </Text>
-        </View>
         <View
           style={
             Array [
@@ -450,14 +434,12 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
             accessibilityRole="button"
             accessibilityState={
               Object {
-                "busy": false,
+                "busy": true,
                 "disabled": false,
               }
             }
             accessible={true}
-            collapsable={false}
             focusable={true}
-            nativeID="animatedComponent"
             onClick={[Function]}
             onResponderGrant={[Function]}
             onResponderMove={[Function]}
@@ -485,18 +467,15 @@ exports[`SendBitcoinConfirmationScreen render matches snapshot 1`] = `
                 }
               }
             >
-              <Text
+              <ActivityIndicator
+                color="white"
+                size="small"
                 style={
                   Object {
-                    "color": "white",
-                    "fontSize": 18,
-                    "paddingVertical": 1,
-                    "textAlign": "center",
+                    "marginVertical": 2,
                   }
                 }
-              >
-                Confirm payment
-              </Text>
+              />
             </View>
           </View>
         </View>

--- a/__tests__/screens/send-bitcoin-confirmation-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-confirmation-screen.spec.tsx
@@ -195,7 +195,7 @@ describe("SendBitcoinConfirmationScreen", () => {
         />
       </MockedProvider>,
     )
-
+    await act(await waitForNextRender)
     const sendButton = getByText(
       translate("SendBitcoinConfirmationScreen.confirmPayment"),
     )
@@ -219,6 +219,7 @@ describe("SendBitcoinConfirmationScreen", () => {
         />
       </MockedProvider>,
     )
+    await act(await waitForNextRender)
     const sendButton = getByText(
       translate("SendBitcoinConfirmationScreen.confirmPayment"),
     )

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -88,6 +88,21 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
   loading = false,
   style,
 }: BalanceHeaderProps) => {
+  return (
+    <View style={[styles.header, style]}>
+      <Text style={styles.balanceText}>{translate("BalanceHeader.currentBalance")}</Text>
+      {loading ? (
+        <Loader />
+      ) : (
+        <BalanceHeaderDisplay showSecondaryCurrency={showSecondaryCurrency} />
+      )}
+    </View>
+  )
+}
+
+export const BalanceHeaderDisplay: React.FC<BalanceHeaderProps> = ({
+  showSecondaryCurrency = true,
+}: BalanceHeaderProps) => {
   const client = useApolloClient()
   const { satBalance, usdBalance } = useWalletBalance()
   const hideBalance = useHideBalance()
@@ -164,32 +179,28 @@ export const BalanceHeader: React.FC<BalanceHeaderProps> = ({
     return (
       <View style={styles.amount}>
         <View style={styles.container}>
-          {loading && <Loader />}
-          {!loading && (
-            <TouchableHighlight
-              underlayColor={styles.touchableHighlightColor}
-              onPress={() => {
-                if (hideBalance) {
-                  setHideBalance(true)
-                }
-              }}
-            >
-              <TextCurrency amount={usdBalance} currency={currency} style={styles.text} />
-            </TouchableHighlight>
-          )}
+          <TouchableHighlight
+            underlayColor={styles.touchableHighlightColor}
+            onPress={() => {
+              if (hideBalance) {
+                setHideBalance(true)
+              }
+            }}
+          >
+            <TextCurrency amount={usdBalance} currency={currency} style={styles.text} />
+          </TouchableHighlight>
         </View>
-        {!loading && subHeader}
+        {subHeader}
       </View>
     )
   }
 
   return (
-    <View style={[styles.header, style]}>
-      <Text style={styles.balanceText}>{translate("BalanceHeader.currentBalance")}</Text>
+    <>
       {!mHideBalance && defaultBalanceHeader()}
       <View style={styles.hiddenBalanceContainer}>
         {mHideBalance && hiddenBalanceSet()}
       </View>
-    </View>
+    </>
   )
 }

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -6,6 +6,8 @@ import type { INetwork } from "../types/network"
 import { loadString } from "../utils/storage"
 import { decodeToken, TOKEN_KEY } from "../utils/use-token"
 
+export const cacheIdVar = makeVar<number>(0)
+
 export const authTokenVar = makeVar<TokenPayload | null>(null)
 
 export const loadAuthToken = async (): Promise<void> => {

--- a/app/graphql/init.ts
+++ b/app/graphql/init.ts
@@ -3,6 +3,7 @@ import { gql } from "@apollo/client"
 export const INITWALLET = gql`
   query InitWallet {
     me {
+      id
       defaultAccount {
         id
         defaultWalletId
@@ -18,6 +19,7 @@ export const INITWALLET = gql`
 
 export const initQuery = {
   me: {
+    id: "guest",
     defaultAccount: {
       id: "BTC",
       defaultWalletId: "BTC",

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/display-name */
-import { useApolloClient, useQuery } from "@apollo/client"
+import { useApolloClient, useQuery, useReactiveVar } from "@apollo/client"
 import PushNotificationIOS from "@react-native-community/push-notification-ios"
 import messaging from "@react-native-firebase/messaging"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
@@ -61,6 +61,7 @@ import {
 import type { NavigatorType } from "../types/jsx"
 
 import PushNotification from "react-native-push-notification"
+import { cacheIdVar } from "../graphql/client-only-query"
 
 // Must be outside of any component LifeCycle (such as `componentDidMount`).
 PushNotification.configure({
@@ -480,6 +481,10 @@ type TabProps = {
 export const PrimaryNavigator: NavigatorType = () => {
   const { tokenNetwork } = useToken()
 
+  // The cacheId is updated after every mutation that affects current user data (balanace, contacts, ...)
+  // It's used to re-mount this component and thus reset what's cached in Apollo (and React)
+  const cacheId = useReactiveVar<number>(cacheIdVar)
+
   React.useEffect(() => {
     if (tokenNetwork) {
       analytics().setUserProperties({ network: tokenNetwork })
@@ -488,6 +493,7 @@ export const PrimaryNavigator: NavigatorType = () => {
 
   return (
     <Tab.Navigator
+      key={cacheId}
       initialRouteName="MoveMoney"
       screenOptions={{
         tabBarActiveTintColor:

--- a/app/screens/contacts-screen/contacts-detail.tsx
+++ b/app/screens/contacts-screen/contacts-detail.tsx
@@ -15,6 +15,7 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { RouteProp } from "@react-navigation/native"
 import type { ScreenType } from "../../types/jsx"
 import { ContactTransactionsDataInjected } from "./contact-transactions"
+import { cacheIdVar } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({
   actionsContainer: { paddingBottom: 18 },
@@ -86,7 +87,7 @@ export const ContactsDetailScreenJSX: ScreenType = ({
   `
 
   const [updateNameMutation] = useMutation(UPDATE_NAME, {
-    refetchQueries: ["contacts"],
+    onCompleted: () => cacheIdVar(Date.now()),
   })
 
   const updateName = async () => {

--- a/app/screens/contacts-screen/contacts.tsx
+++ b/app/screens/contacts-screen/contacts.tsx
@@ -1,5 +1,4 @@
 import { gql, useQuery } from "@apollo/client"
-import { useFocusEffect } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import * as React from "react"
 import { useCallback, useMemo, useState } from "react"
@@ -99,12 +98,12 @@ export const ContactsScreen: ScreenType = ({ navigation }: Props) => {
   const { hasToken } = useToken()
   const [matchingContacts, setMatchingContacts] = useState([])
   const [searchText, setSearchText] = useState("")
-  const [isRefreshed, setIsRefreshed] = useState(false)
 
-  const { loading, data, error, refetch } = useQuery(
+  const { loading, data, error } = useQuery(
     gql`
       query contacts {
         me {
+          id
           contacts {
             username
             alias
@@ -113,15 +112,11 @@ export const ContactsScreen: ScreenType = ({ navigation }: Props) => {
         }
       }
     `,
-    { skip: !hasToken },
+    {
+      skip: !hasToken,
+      fetchPolicy: "cache-and-network",
+    },
   )
-
-  useFocusEffect(() => {
-    if (!isRefreshed) {
-      setIsRefreshed(true)
-      refetch()
-    }
-  })
 
   if (error) {
     toastShow(error.message)

--- a/app/screens/earns-screen/earns-section.tsx
+++ b/app/screens/earns-screen/earns-section.tsx
@@ -21,6 +21,7 @@ import useToken from "../../utils/use-token"
 import { SVGs } from "./earn-svg-factory"
 import { getCardsFromSection, remainingSatsOnSection } from "./earns-utils"
 import { getQuizQuestions } from "../../graphql/query"
+import { cacheIdVar } from "../../graphql/client-only-query"
 
 const { width: screenWidth } = Dimensions.get("window")
 
@@ -140,7 +141,7 @@ export const EarnSection: ScreenType = ({ route, navigation }: Props) => {
       }
     `,
     {
-      refetchQueries: ["mainQuery"],
+      onCompleted: () => cacheIdVar(Date.now()),
     },
   )
 

--- a/app/screens/receive-bitcoin-screen/qr-view.tsx
+++ b/app/screens/receive-bitcoin-screen/qr-view.tsx
@@ -247,7 +247,6 @@ const styles = EStyleSheet.create({
   },
 
   lottie: {
-    color: palette.darkGrey,
     height: "200rem",
     width: "200rem",
   },

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -18,6 +18,7 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { PaymentConfirmationInformation } from "./payment-confirmation-information"
 import useFee from "./use-fee"
 import { palette } from "../../theme/palette"
+import { cacheIdVar } from "../../graphql/client-only-query"
 
 export const LN_PAY = gql`
   mutation lnInvoicePaymentSend($input: LnInvoicePaymentInput!) {
@@ -120,21 +121,21 @@ export const SendBitcoinConfirmationScreen = ({
   })
 
   const [lnPay] = useMutation(LN_PAY, {
-    refetchQueries: ["mainQuery"],
+    onCompleted: () => cacheIdVar(Date.now()),
   })
 
   const [lnNoAmountPay] = useMutation(LN_NO_AMOUNT_PAY, {
-    refetchQueries: ["mainQuery"],
+    onCompleted: () => cacheIdVar(Date.now()),
   })
 
   const [intraLedgerPay] = useMutation(INTRA_LEDGER_PAY, {
-    refetchQueries: ["mainQuery"],
+    onCompleted: () => cacheIdVar(Date.now()),
   })
 
   // TODO: add user automatically to cache
 
   const [onchainPay] = useMutation(ONCHAIN_PAY, {
-    refetchQueries: ["mainQuery"],
+    onCompleted: () => cacheIdVar(Date.now()),
   })
 
   const handlePaymentReturn = (status, errors) => {

--- a/app/screens/settings-screen/language-screen.tsx
+++ b/app/screens/settings-screen/language-screen.tsx
@@ -9,6 +9,7 @@ import { MAIN_QUERY } from "../../graphql/query"
 import { palette } from "../../theme/palette"
 import type { ScreenType } from "../../types/jsx"
 import useToken from "../../utils/use-token"
+import { cacheIdVar } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({
   screenStyle: {
@@ -40,7 +41,7 @@ export const LanguageScreen: ScreenType = () => {
       }
     `,
     {
-      refetchQueries: ["mainQuery"],
+      onCompleted: () => cacheIdVar(Date.now()),
     },
   )
 

--- a/app/screens/settings-screen/username-screen.tsx
+++ b/app/screens/settings-screen/username-screen.tsx
@@ -13,6 +13,7 @@ import { UsernameValidation } from "../../utils/validation"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import { USERNAME_AVAILABLE } from "../../graphql/query"
+import { cacheIdVar } from "../../graphql/client-only-query"
 
 const styles = EStyleSheet.create({
   activity: { marginTop: 12 },
@@ -65,7 +66,6 @@ export const UsernameScreen: ScreenType = ({ navigation }: Props) => {
   const inputForm = React.createRef<TextInput>()
 
   const [updateUsername, { loading: updatingUsername }] = useMutation(UPDATE_USERNAME, {
-    refetchQueries: ["mainQuery"],
     onError: (error) => {
       console.error(error)
       setInputStatus({ message: translate("errors.generic"), status: "error" })
@@ -81,6 +81,8 @@ export const UsernameScreen: ScreenType = ({ navigation }: Props) => {
       if (errorMessage) {
         setInputStatus({ message: errorMessage, status: "error" })
       }
+
+      cacheIdVar(Date.now())
 
       Alert.alert(translate("UsernameScreen.success", { input }), null, [
         {


### PR DESCRIPTION
Include refactoring of BalanceHeader to not invoke its hooks
while the main query is loading, and a few other minor fixes

This commit also fixes the Balance 0 problem after navigating to
contacts screen. This was an Apollo cache missing field problem
because the contacts screen was querying the me field without and id
