### PR TITLE
Fix missing hash in lightning transactions

### DIFF
--- a/app/graphql/graphql.types.d.ts
+++ b/app/graphql/graphql.types.d.ts
@@ -42,6 +42,11 @@ type WalletTransaction = {
     | SettlementViaIntraLedger
     | SettlementViaLn
     | SettlementViaOnChain
+    
+  readonly initiationVia:
+    | InitiationViaIntraLedger
+    | InititationViaLn
+    | InitiationViaOnChain
 }
 
 type MutationError = {

--- a/app/graphql/graphql.types.d.ts
+++ b/app/graphql/graphql.types.d.ts
@@ -42,7 +42,7 @@ type WalletTransaction = {
     | SettlementViaIntraLedger
     | SettlementViaLn
     | SettlementViaOnChain
-    
+
   readonly initiationVia:
     | InitiationViaIntraLedger
     | InititationViaLn

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -109,6 +109,7 @@ export const TransactionDetailScreen: ScreenType = ({ route, navigation }: Props
     usdAmount,
 
     settlementVia,
+    initiationVia,
 
     isReceive,
     isPending,
@@ -172,6 +173,9 @@ export const TransactionDetailScreen: ScreenType = ({ route, navigation }: Props
           entry={translate("common.type")}
           value={typeDisplay(settlementVia.__typename)}
         />
+        {settlementVia.__typename === "SettlementViaLn" && (
+          <Row entry="Hash" value={initiationVia.paymentHash} />
+        )}
         {settlementVia.__typename === "SettlementViaOnChain" && (
           <Row entry="Hash" value={settlementVia.transactionHash} />
         )}


### PR DESCRIPTION
Salim noticed that lightning payment hashes were missing from the transaction details screen.  This was removed by mistake because we were looking for it in the wrong place in the server response.  We should be getting the hash from the `initiationVia` field.