### PR TITLE
feat: Add error boundary

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,7 +45,8 @@
     "no-param-reassign": "error",
     "no-sequences": "error",
     "no-throw-literal": "error",
-    "no-void": "error"
+    "no-void": "error",
+    "react-native/sort-styles": "off"
   },
   "settings": {
     "react-native/style-sheet-object-names": ["EStyleSheet"],

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -43,6 +43,8 @@ import useToken, { getAuthorizationHeader } from "./utils/use-token"
 import { getGraphQLUri, loadNetwork } from "./utils/network"
 import { loadAuthToken, networkVar } from "./graphql/client-only-query"
 import { INetwork } from "./types/network"
+import ErrorBoundary from "react-native-error-boundary"
+import { ErrorScreen } from "./screens/error-screen"
 
 export const BUILD_VERSION = "build_version"
 
@@ -247,27 +249,29 @@ export const App = (): JSX.Element => {
 
   return (
     <ApolloProvider client={apolloClient}>
-      <NavigationContainer
-        key={token}
-        linking={linking}
-        // fallback={<Text>Loading...</Text>}
-        onStateChange={(state) => {
-          const currentRouteName = getActiveRouteName(state)
+      <ErrorBoundary FallbackComponent={ErrorScreen}>
+        <NavigationContainer
+          key={token}
+          linking={linking}
+          // fallback={<Text>Loading...</Text>}
+          onStateChange={(state) => {
+            const currentRouteName = getActiveRouteName(state)
 
-          if (routeName !== currentRouteName) {
-            analytics().logScreenView({
-              screen_name: currentRouteName,
-              screen_class: currentRouteName,
-            })
-            setRouteName(currentRouteName)
-          }
-        }}
-      >
-        <RootSiblingParent>
-          <GlobalErrorToast />
-          <RootStack />
-        </RootSiblingParent>
-      </NavigationContainer>
+            if (routeName !== currentRouteName) {
+              analytics().logScreenView({
+                screen_name: currentRouteName,
+                screen_class: currentRouteName,
+              })
+              setRouteName(currentRouteName)
+            }
+          }}
+        >
+          <RootSiblingParent>
+            <GlobalErrorToast />
+            <RootStack />
+          </RootSiblingParent>
+        </NavigationContainer>
+      </ErrorBoundary>
     </ApolloProvider>
   )
 }

--- a/app/components/global-error/global-error.tsx
+++ b/app/components/global-error/global-error.tsx
@@ -6,44 +6,6 @@ import { NetworkErrorCode } from "./network-error-code"
 import useLogout from "../../hooks/use-logout"
 import { translate } from "../../i18n"
 import Toast from "react-native-root-toast"
-import { setJSExceptionHandler } from "react-native-exception-handler"
-import { Alert } from "react-native"
-import crashlytics from "@react-native-firebase/crashlytics"
-import RNRestart from "react-native-restart"
-import { openWhatsApp } from "../../utils/external"
-import { WHATSAPP_CONTACT_NUMBER } from "../../constants/support"
-
-setJSExceptionHandler((e) => {
-  crashlytics().log("Caught a fatal javascript error.")
-  crashlytics().recordError(e)
-  Alert.alert(
-    translate("errors.unexpectedError"),
-    `
-${translate("common.error")}: ${e.name}
-
-${translate("errors.restartApp")}
-
-${translate("errors.problemPersists")}
-        `,
-    [
-      {
-        text: translate("common.restart"),
-        onPress: () => {
-          RNRestart.Restart()
-        },
-      },
-      {
-        text: translate("whatsapp.contactSupport"),
-        onPress: () => {
-          openWhatsApp(
-            WHATSAPP_CONTACT_NUMBER,
-            translate("whatsapp.defaultSupportMessage"),
-          )
-        },
-      },
-    ],
-  )
-})
 
 export const GlobalErrorToast: ComponentType = () => {
   const status = useApolloNetworkStatus()

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -681,7 +681,7 @@
     "to": "To",
     "transactions": "Transactions",
     "transactionsError": "Error loading transactions",
-    "tryAgain": "Try again",
+    "tryAgain": "Try Again",
     "type": "Type",
     "username": "Username",
     "usernameRequired": "Username is required"
@@ -699,7 +699,8 @@
     "unexpectedError": "Unexpected error occurred",
     "restartApp": "Please restart the application.",
     "problemPersists": "If problem persists contact support.",
-    "fatalError": "Sorry we appear to be having issues loading the application data.  If problems persist please contact support."
+    "fatalError": "Sorry we appear to be having issues loading the application data.  If problems persist please contact support.",
+    "showError": "Show Error"
   },
   "notifications": {
     "payment": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -715,7 +715,7 @@
     "syncing": "Sincronizando datos",
     "to": "Para",
     "transactions": "\nLas transacciones",
-    "tryAgain": "Inténtalo de nuevo",
+    "tryAgain": "Inténtalo de Nuevo",
     "type": "tipo",
     "username": "Nombre de usuario",
     "usernameRequired": "El nombre de usuario es requerido"
@@ -733,7 +733,8 @@
     "unexpectedError": "Ocurrió un error inesperado",
     "restartApp": "Reinicie la aplicación.",
     "problemPersists": "Si el problema persiste, comuníquese con el soporte técnico.",
-    "fatalError": "Lo sentimos, parece que estamos teniendo problemas para cargar la aplicación por usted. Si los problemas persisten, comuníquese con el soporte técnico."
+    "fatalError": "Lo sentimos, parece que estamos teniendo problemas para cargar la aplicación por usted. Si los problemas persisten, comuníquese con el soporte técnico.",
+    "showError": "Mostrar error"
   },
   "notifications": {
     "payment": {

--- a/app/screens/error-screen/error-screen.tsx
+++ b/app/screens/error-screen/error-screen.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable react-native/no-color-literals */
+/* eslint-disable react-native/no-unused-styles */
+import React from "react"
+import { WHATSAPP_CONTACT_NUMBER } from "@app/constants/support"
+import { color, palette } from "@app/theme"
+import { openWhatsApp } from "@app/utils/external"
+import { Alert, KeyboardAvoidingView, StatusBar, Text, View } from "react-native"
+import { Button } from "react-native-elements"
+import EStyleSheet from "react-native-extended-stylesheet"
+import HoneyBadgerShovel from "../welcome-screens/honey-badger-shovel-01.svg"
+import { translate } from "@app/i18n"
+import { SafeAreaView } from "react-native-safe-area-context"
+import { isIos } from "@app/utils/helper"
+import { offsets, presets } from "@app/components/screen/screen.presets"
+import crashlytics from "@react-native-firebase/crashlytics"
+
+const styles = EStyleSheet.create({
+  $color: palette.white,
+  $paddingHorizontal: "20rem",
+  $textAlign: "center",
+
+  buttonContainer: {
+    alignSelf: "center",
+    marginVertical: 12,
+    paddingBottom: 48,
+    width: "60%",
+  },
+
+  buttonStyle: {
+    backgroundColor: palette.white,
+    borderRadius: 24,
+  },
+
+  buttonTitle: {
+    color: color.primary,
+    fontWeight: "bold",
+  },
+  container: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "center",
+  },
+  header: {
+    fontSize: 40,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  image: {
+    alignSelf: "center",
+    margin: 20,
+  },
+  text: {
+    color: "$color",
+    fontSize: "15rem",
+    paddingHorizontal: "$paddingHorizontal",
+    paddingTop: "24rem",
+    paddingBottom: "24rem",
+    textAlign: "$textAlign",
+  },
+})
+export const ErrorScreen = ({ error, resetError }) => {
+  crashlytics().recordError(error)
+  return (
+    <KeyboardAvoidingView
+      style={[presets.fixed.outer, { backgroundColor: palette.lightBlue }]}
+      behavior={isIos ? "padding" : null}
+      keyboardVerticalOffset={offsets["none"]}
+    >
+      <StatusBar barStyle={"dark-content"} backgroundColor={palette.lightBlue} />
+      <SafeAreaView style={presets.fixed.inner}>
+        <Text style={styles.header}>{translate("common.error")}</Text>
+        <View style={styles.container}>
+          <HoneyBadgerShovel style={styles.image} />
+          <Text style={styles.text}>{translate("errors.fatalError")}</Text>
+          <Button
+            title={translate("errors.showError")}
+            onPress={() => Alert.alert(translate("common.error"), error)}
+            containerStyle={styles.buttonContainer}
+            buttonStyle={styles.buttonStyle}
+            titleStyle={styles.buttonTitle}
+          />
+          <Button
+            title={translate("whatsapp.contactSupport")}
+            onPress={() =>
+              openWhatsApp(
+                WHATSAPP_CONTACT_NUMBER,
+                translate("whatsapp.defaultSupportMessage"),
+              )
+            }
+            containerStyle={styles.buttonContainer}
+            buttonStyle={styles.buttonStyle}
+            titleStyle={styles.buttonTitle}
+          />
+          <Button
+            title={translate("common.tryAgain")}
+            onPress={() => {
+              resetError()
+            }}
+            containerStyle={styles.buttonContainer}
+            buttonStyle={styles.buttonStyle}
+            titleStyle={styles.buttonTitle}
+          />
+        </View>
+      </SafeAreaView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/app/screens/error-screen/index.ts
+++ b/app/screens/error-screen/index.ts
@@ -1,0 +1,1 @@
+export * from "./error-screen"

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,7 @@ module.exports = {
       "|@react-navigation" +
       "|react-native-exception-handler" +
       "|@react-native-community" +
+      "|react-native-error-boundary" +
       ")/)",
   ],
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-native-camera": "^4.2.1",
     "react-native-device-info": "^8.4.8",
     "react-native-elements": "^3.4.2",
-    "react-native-exception-handler": "^2.10.10",
+    "react-native-error-boundary": "^1.1.12",
     "react-native-extended-stylesheet": "^0.12.0",
     "react-native-fingerprint-scanner": "^6.0.0",
     "react-native-fs": "^2.16.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13574,10 +13574,10 @@ react-native-elements@^3.4.2:
     react-native-ratings "8.0.4"
     react-native-size-matters "^0.3.1"
 
-react-native-exception-handler@^2.10.10:
-  version "2.10.10"
-  resolved "https://registry.yarnpkg.com/react-native-exception-handler/-/react-native-exception-handler-2.10.10.tgz#b6bfe2b7e6ea4a4deb1f518f48ce2ee1d4843497"
-  integrity sha512-otAXGoZDl1689OoUJWN/rXxVbdoZ3xcmyF1uq/CsizdLwwyZqVGd6d+p/vbYvnF996FfEyAEBnHrdFxulTn51w==
+react-native-error-boundary@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/react-native-error-boundary/-/react-native-error-boundary-1.1.12.tgz#80773d8f52bf7354f9776b022a57081a7ecafb8c"
+  integrity sha512-YVM7DOY6TbCrtYc87CqABGntnxQRMWSkzcF6+tB9QBUs4sWOWIfeeN4yJGF2eYJAGVnaym5ys9GqcYDu8mjE2g==
 
 react-native-extended-stylesheet@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Me and @samerbuna paired up and found out the library I was trying to use just wasn't compatible with react-native.  @samerbuna found this library which has a very similar API but works for react-native.  This should mean that users are no longer presented with the _white screen of death_.  Example of error screen shown below.

![image](https://user-images.githubusercontent.com/3502409/147595642-5dab2f24-cd0f-4ab3-8741-dd99c34c2653.png)