### PR TITLE
fix: Change default dev network

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,4 @@
 rootProject.name = 'GaloyApp'
-include ':react-native-exception-handler'
-project(':react-native-exception-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-exception-handler/android')
 include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 include ':react-native-secure-key-store'

--- a/app/utils/network.ts
+++ b/app/utils/network.ts
@@ -24,7 +24,7 @@ export const loadNetwork = async (): Promise<INetwork> => {
   let network = await loadString(NETWORK_STRING)
 
   if (!network) {
-    network = __DEV__ ? "regtest" : "mainnet"
+    network = __DEV__ ? "testnet" : "mainnet"
   }
 
   return network as INetwork

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -21,8 +21,6 @@ target 'GaloyApp' do
 
   pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'
 
-  pod 'ReactNativeExceptionHandler', :path => '../node_modules/react-native-exception-handler'
-
   post_install do |installer|
     installer.pods_project.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -423,8 +423,6 @@ PODS:
     - React-jsi (= 0.66.3)
     - React-logger (= 0.66.3)
     - React-perflogger (= 0.66.3)
-  - ReactNativeExceptionHandler (2.10.10):
-    - React-Core
   - RNCAsyncStorage (1.15.11):
     - React-Core
   - RNCClipboard (1.5.1):
@@ -559,7 +557,6 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - ReactNativeExceptionHandler (from `../node_modules/react-native-exception-handler`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
@@ -695,8 +692,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
-  ReactNativeExceptionHandler:
-    :path: "../node_modules/react-native-exception-handler"
   RNCAsyncStorage:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
@@ -807,7 +802,6 @@ SPEC CHECKSUMS:
   React-RCTVibration: 50cfe7049167cfc7e83ac5542c6fff0c76791a9b
   React-runtimeexecutor: bbbdb3d8fcf327c6e2249ee71b6ef1764b7dc266
   ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
-  ReactNativeExceptionHandler: b11ff67c78802b2f62eed0e10e75cb1ef7947c60
   RNCAsyncStorage: eb05c0284dd6b50b32f92fad55e2a41e03358c43
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
@@ -836,6 +830,6 @@ SPEC CHECKSUMS:
   Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa
   YoutubePlayer-in-WKWebView: 4fca3b4f6f09940077bfbae7bddb771f2b43aacd
 
-PODFILE CHECKSUM: 69463ae5e2519d85c6de470fc0f8f9d222694531
+PODFILE CHECKSUM: 39f8fc62e38e298d1b995b027d119f51a7196972
 
 COCOAPODS: 1.11.2

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,6 @@ module.exports = {
       "|@react-native-firebase/auth" +
       "|@react-native-firebase" +
       "|@react-navigation" +
-      "|react-native-exception-handler" +
       "|@react-native-community" +
       "|react-native-error-boundary" +
       ")/)",


### PR DESCRIPTION
This change includes a change to make the default network testnet in dev builds.  This is to avoid the bug that @samerbuna mentioned where the app fails to load in dev mode if you don't have the backend running.  It also removes the `react-native-exception-handler` library from some files as it is referencing a library which is no longer installed.