### PR TITLE
fix: Fix crashlytics error reporting

### DIFF
--- a/app/hooks/use-main-query.ts
+++ b/app/hooks/use-main-query.ts
@@ -23,7 +23,7 @@ const useMainQuery = (): useMainQueryOutput => {
         crashlytics().recordError(e)
         console.log(e)
       })
-      throw translate("errors.fatalError")
+      throw new Error(translate("errors.fatalError"))
     }
     if (error.networkError && previousData) {
       // Call to mainquery has failed but we have data in the cache
@@ -39,7 +39,7 @@ const useMainQuery = (): useMainQueryOutput => {
     if (error.networkError && !previousData) {
       // This is the first execution of mainquery and it has failed
       crashlytics().recordError(error.networkError)
-      throw translate("errors.fatalError")
+      throw new Error(translate("errors.fatalError"))
     }
   }
   const userPreferredLanguage = data?.me?.language
@@ -48,7 +48,7 @@ const useMainQuery = (): useMainQueryOutput => {
   )
   if (hasToken && !btcWallet && !loading) {
     // User is logged in but no wallet was returned.  We need a BTC wallet for the app to function.
-    throw translate("errors.fatalError")
+    throw new Error(translate("errors.fatalError"))
   }
   const btcWalletBalance = btcWallet?.balance
   const btcWalletId = btcWallet?.id

--- a/app/screens/error-screen/error-screen.tsx
+++ b/app/screens/error-screen/error-screen.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-native/no-color-literals */
 /* eslint-disable react-native/no-unused-styles */
-import React from "react"
+import React, { useEffect } from "react"
 import { WHATSAPP_CONTACT_NUMBER } from "@app/constants/support"
 import { color, palette } from "@app/theme"
 import { openWhatsApp } from "@app/utils/external"
@@ -59,7 +59,7 @@ const styles = EStyleSheet.create({
   },
 })
 export const ErrorScreen = ({ error, resetError }) => {
-  crashlytics().recordError(error)
+  useEffect(() => crashlytics().recordError(error), [error])
   return (
     <KeyboardAvoidingView
       style={[presets.fixed.outer, { backgroundColor: palette.lightBlue }]}
@@ -74,7 +74,7 @@ export const ErrorScreen = ({ error, resetError }) => {
           <Text style={styles.text}>{translate("errors.fatalError")}</Text>
           <Button
             title={translate("errors.showError")}
-            onPress={() => Alert.alert(translate("common.error"), error)}
+            onPress={() => Alert.alert(translate("common.error"), String(error))}
             containerStyle={styles.buttonContainer}
             buttonStyle={styles.buttonStyle}
             titleStyle={styles.buttonTitle}


### PR DESCRIPTION
After a lot of debugging I found out that we have a few issues with crashlytics.

1. Crashlytics batches up errors on android and only reports the batch when the app restarts.
2. For the errors in the `useMainQuery` hook we are throwing strings instead of javascript errors.  Crashlytics has some validation on objects passed to the `recordError` method to make sure it's a proper javascript error.

This PR fixes point 2.