### PR TITLE
refactor: Refactored transactions screen

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ android
 ignite/ignite.json
 package.json
 __generated__
+app/components/price-graph/data-tst.ts

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -1,7 +1,17 @@
-import { InMemoryCache } from "@apollo/client"
+import { InMemoryCache, PossibleTypesMap } from "@apollo/client"
 import "moment/locale/es"
+import possibleTypes from "@generated/possibleTypes.json"
+import { relayStylePagination } from "@apollo/client/utilities"
+import * as tslib from "tslib"
+
+const notExtras = ["edges", "pageInfo"]
+const getExtras = function (obj) {
+  return tslib.__rest(obj, notExtras)
+}
 
 export const cache = new InMemoryCache({
+  // This is ugly but necessary unfortunately https://github.com/Microsoft/TypeScript/issues/28067
+  possibleTypes: possibleTypes as unknown as PossibleTypesMap,
   typePolicies: {
     Contact: {
       fields: {
@@ -16,6 +26,41 @@ export const cache = new InMemoryCache({
       fields: {
         completed: {
           read: (value) => value ?? false,
+        },
+      },
+    },
+    BTCWallet: {
+      fields: {
+        // transactions: relayStylePagination(),
+        transactions: {
+          ...relayStylePagination(),
+          read: (existing, _a) => {
+            const canRead = _a.canRead,
+              readField = _a.readField
+            if (!existing) return existing
+            const edges = []
+            let firstEdgeCursor = ""
+            let lastEdgeCursor = ""
+            existing.edges.forEach(function (edge) {
+              if (canRead(readField("node", edge))) {
+                edges.push(edge)
+                if (edge.cursor) {
+                  firstEdgeCursor = firstEdgeCursor || edge.cursor || ""
+                  lastEdgeCursor = edge.cursor || lastEdgeCursor
+                }
+              }
+            })
+            const _b = existing.pageInfo || {},
+              startCursor = _b.startCursor,
+              endCursor = _b.endCursor
+            return tslib.__assign(tslib.__assign({}, getExtras(existing)), {
+              edges: edges,
+              pageInfo: tslib.__assign(tslib.__assign({}, existing.pageInfo), {
+                startCursor: startCursor || firstEdgeCursor,
+                endCursor: endCursor || lastEdgeCursor,
+              }),
+            })
+          },
         },
       },
     },

--- a/app/graphql/graphql.types.d.ts
+++ b/app/graphql/graphql.types.d.ts
@@ -37,6 +37,7 @@ type WalletTransaction = {
   readonly direction: "SEND" | "RECEIVE"
   readonly memo: string | null
   readonly createdAt: number
+  readonly cursor: string
 
   readonly settlementVia:
     | SettlementViaIntraLedger

--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -88,9 +88,6 @@ export const MAIN_QUERY = gql`
           id
           balance
           walletCurrency
-          transactions(first: 3) {
-            ...TransactionList
-          }
         }
       }
     }
@@ -100,7 +97,6 @@ export const MAIN_QUERY = gql`
       minSupported
     }
   }
-  ${TRANSACTION_LIST_FRAGMENT}
 `
 
 export const TRANSACTIONS_LIST = gql`

--- a/app/hooks/hooks.types.d.ts
+++ b/app/hooks/hooks.types.d.ts
@@ -12,7 +12,6 @@ type useMainQueryOutput = {
   userPreferredLanguage: string
   btcWalletBalance: number
   btcWalletId: string
-  transactionsEdges: object[]
   csvEncoded: any
   me: any
   myPubKey: string

--- a/app/hooks/use-main-query.ts
+++ b/app/hooks/use-main-query.ts
@@ -64,7 +64,6 @@ const useMainQuery = (): useMainQueryOutput => {
     userPreferredLanguage,
     btcWalletBalance,
     btcWalletId,
-    transactionsEdges,
     csvEncoded,
     me,
     myPubKey,

--- a/app/hooks/use-transactions.ts
+++ b/app/hooks/use-transactions.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@apollo/client"
+import { TRANSACTIONS_LIST } from "@app/graphql/query"
+
+export const useTransactions = () => {
+  const { error, data, refetch, loading, fetchMore } = useQuery(TRANSACTIONS_LIST, {
+    variables: { first: 20, after: null },
+    fetchPolicy: "cache-and-network",
+    notifyOnNetworkStatusChange: true,
+  })
+
+  const transactions = data?.me?.defaultAccount?.wallets[0]?.transactions?.edges.map(
+    (edge) => ({ ...edge.node, cursor: edge.cursor }),
+  )
+  const pageInfo = data?.me?.defaultAccount?.wallets[0]?.transactions?.pageInfo
+  console.log(pageInfo)
+  console.log(transactions)
+  return {
+    error,
+    transactions,
+    pageInfo,
+    refetch,
+    loading,
+    fetchMore,
+  }
+}

--- a/app/hooks/use-wallet-balance.ts
+++ b/app/hooks/use-wallet-balance.ts
@@ -1,6 +1,7 @@
 import useToken from "../utils/use-token"
 import { useMySubscription } from "./user-hooks"
 import useMainQuery from "./use-main-query"
+import { useTransactions } from "./use-transactions"
 
 export const useWalletBalance = (): {
   walletId?: string
@@ -10,7 +11,8 @@ export const useWalletBalance = (): {
 } => {
   const { convertCurrencyAmount, currentBalance, mySubscriptionLoading } =
     useMySubscription()
-  const { btcWalletBalance, btcWalletId, refetch: refetchMainQuery } = useMainQuery()
+  const { btcWalletBalance, btcWalletId } = useMainQuery()
+  const { refetch: refetchTransactions } = useTransactions()
 
   const { hasToken } = useToken()
 
@@ -23,7 +25,10 @@ export const useWalletBalance = (): {
   }
 
   if (currentBalance && currentBalance !== btcWalletBalance) {
-    refetchMainQuery()
+    // balance has updated so new transactions have been made
+    refetchTransactions({
+      first: 10,
+    })
   }
 
   return {

--- a/babel.config.js
+++ b/babel.config.js
@@ -7,6 +7,7 @@ module.exports = {
         root: ["./app"],
         alias: {
           "^@app/(.+)": "./app/\\1",
+          "^@generated/(.+)": "./__generated__/\\1",
         },
       },
     ],

--- a/ios/GaloyApp.xcodeproj/project.pbxproj
+++ b/ios/GaloyApp.xcodeproj/project.pbxproj
@@ -579,7 +579,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -641,7 +641,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "arm64 ";
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -464,35 +464,6 @@ PODS:
     - React-Core
   - RNReactNativeHapticFeedback (1.13.0):
     - React-Core
-  - RNReanimated (2.2.4):
-    - DoubleConversion
-    - FBLazyVector
-    - FBReactNativeSpec
-    - glog
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-callinvoker
-    - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
-    - React-RCTVibration
-    - ReactCommon/turbomodule/core
-    - Yoga
   - RNScreens (3.9.0):
     - React-Core
     - React-RCTImage
@@ -574,7 +545,6 @@ DEPENDENCIES:
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - RNLocalize (from `../node_modules/react-native-localize`)
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
-  - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSecureKeyStore (from `../node_modules/react-native-secure-key-store/ios`)
   - RNShare (from `../node_modules/react-native-share`)
@@ -726,8 +696,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-localize"
   RNReactNativeHapticFeedback:
     :path: "../node_modules/react-native-haptic-feedback"
-  RNReanimated:
-    :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNSecureKeyStore:
@@ -819,7 +787,6 @@ SPEC CHECKSUMS:
   RNKeychain: 4f63aada75ebafd26f4bc2c670199461eab85d94
   RNLocalize: 74b82db20cc3895ccc25af992c644879bcec2815
   RNReactNativeHapticFeedback: b83bfb4b537bdd78eb4f6ffe63c6884f7b049ead
-  RNReanimated: 65583befd5706cc9c86ae9a081786181ced37b93
   RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
   RNSecureKeyStore: f1ad870e53806453039f650720d2845c678d89c8
   RNShare: 3013bd25beed9c5ea93961c0783a44c30ac72e9b

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ module.exports = {
   moduleNameMapper: {
     "^@app/(.*)$": ["<rootDir>app/$1"],
     "^@mocks/(.*)$": ["<rootDir>__mocks__/$1"],
+    "^@generated/(.*)$": ["<rootDir>__generated__/$1"],
   },
   transformIgnorePatterns: [
     "node_modules/(?!(react-native" +
@@ -32,7 +33,6 @@ module.exports = {
       "|react-native-screens" +
       "|react-native-size-matters" +
       "|react-native-ratings" +
-      "|react-native-reanimated" +
       "|react-native-root-siblings" +
       "|react-native-root-toast" +
       "|react-native-vector-icons" +

--- a/metro.config.js
+++ b/metro.config.js
@@ -26,7 +26,7 @@ module.exports = (async () => {
     projectRoot: path.resolve(__dirname),
     resolver: {
       assetExts: assetExts.filter((ext) => ext !== "svg"),
-      sourceExts: [...sourceExts, "svg"],
+      sourceExts: [...sourceExts, "svg", "cjs"],
       extraNodeModules: {
         stream: path.resolve(__dirname, "node_modules/readable-stream"),
         zlib: path.resolve(__dirname, "node_modules/browserify-zlib"),

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
     "patch": "patch-package",
     "postinstall": "jetify && if which pod >/dev/null; then (cd ios; pod install); fi",
     "hack:types-react-native": "rimraf node_modules/@types/react-native/node_modules/@types",
-    "prepare": "npm-run-all patch hack:*"
+    "prepare": "npm-run-all patch hack:*",
+    "generate-possible-types": "node utils/generate-possible-types.js"
   },
   "dependencies": {
-    "@apollo/client": "^3.4.16",
+    "@apollo/client": "^3.5.6",
     "@galoymoney/react-native-geetest-module": "^0.1.3",
     "@react-native-async-storage/async-storage": "^1.15.9",
     "@react-native-community/clipboard": "^1.2.3",
@@ -91,7 +92,6 @@
     "react-native-phone-number-input": "^2.1.0",
     "react-native-push-notification": "^8.1.1",
     "react-native-qrcode-svg": "^6.0.6",
-    "react-native-reanimated": "^2.2.3",
     "react-native-restart": "daviroo/react-native-restart.git#master",
     "react-native-root-siblings": "^4.1.1",
     "react-native-root-toast": "^3.3.0",
@@ -108,6 +108,7 @@
     "react-native-walkthrough-tooltip": "^1.2.0",
     "react-native-youtube": "^2.0.0",
     "subscriptions-transport-ws": "^0.11.0",
+    "tslib": "^2.3.1",
     "url": "^0.11.0",
     "victory-native": "^36.2.0"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
     "resolveJsonModule": true,
     "baseUrl": "./",
     "paths": {
-      "@app/*": ["app/*"]
+      "@app/*": ["app/*"],
+      "@generated/*": ["__generated__/*"]
     }
   },
   "exclude": ["node_modules"],

--- a/utils/generate-possible-types.js
+++ b/utils/generate-possible-types.js
@@ -1,0 +1,49 @@
+// eslint-disable @typescript-eslint/no-var-requires
+const fetch = require("cross-fetch")
+const fs = require("fs")
+
+fetch(`http://localhost:4002/graphql`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({
+    variables: {},
+    query: `
+      {
+        __schema {
+          types {
+            kind
+            name
+            possibleTypes {
+              name
+            }
+          }
+        }
+      }
+    `,
+  }),
+})
+  .then((result) => result.json())
+  .then((result) => {
+    const possibleTypes = {}
+    console.log(result)
+
+    result.data.__schema.types.forEach((supertype) => {
+      if (supertype.possibleTypes) {
+        possibleTypes[supertype.name] = supertype.possibleTypes.map(
+          (subtype) => subtype.name,
+        )
+      }
+    })
+
+    fs.writeFile(
+      __dirname + "/../__generated__/possibleTypes.json",
+      JSON.stringify(possibleTypes),
+      (err) => {
+        if (err) {
+          console.error("Error writing possibleTypes.json", err)
+        } else {
+          console.log("Fragment types successfully extracted!")
+        }
+      },
+    )
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.4.16":
-  version "3.4.17"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.17.tgz#4972e19a49809e16d17c5adc67f45623a6dac135"
-  integrity sha512-MDt2rwMX1GqodiVEKJqmDmAz8xr0qJmq5PdWeIt0yDaT4GOkKYWZiWkyfhfv3raTk8PyJvbsNG9q2CqmUrlGfg==
+"@apollo/client@^3.5.6":
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.5.6.tgz#911929df073280689efd98e5603047b79e0c39a2"
+  integrity sha512-XHoouuEJ4L37mtfftcHHO1caCRrKKAofAwqRoq28UQIPMJk+e7n3X9OtRRNXKk/9tmhNkwelSary+EilfPwI7A==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"
@@ -16,9 +16,9 @@
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.9.0"
+    ts-invariant "^0.9.4"
     tslib "^2.3.0"
-    zen-observable-ts "~1.1.0"
+    zen-observable-ts "^1.2.0"
 
 "@babel/code-frame@7.5.5":
   version "7.5.5"
@@ -1069,13 +1069,6 @@
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.14.5.tgz"
   integrity sha512-lvhjk4UN9xJJYB1mI5KC0/o1D5EcJXdbhVe+4fSk08D6ZN+iuAIs7LJC+71h8av9Ew4+uRq9452v9R93SFmQlQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-
-"@babel/plugin-transform-object-assign@^7.10.4":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.16.0.tgz#750c726397f1f6402fb1ceffe9d8ff3595c8a0df"
-  integrity sha512-TftKY6Hxo5Uf/EIoC3BKQyLvlH46tbtK4xub90vzi9+yS8z1+O/52YHyywCZvYeLPOvv//1j3BPokLuHTWPcbg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
@@ -3563,11 +3556,6 @@
   integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
-
-"@types/zen-observable@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.3.tgz#781d360c282436494b32fe7d9f7f8e64b3118aa3"
-  integrity sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==
 
 "@typescript-eslint/eslint-plugin@^5.4.0":
   version "5.4.0"
@@ -11694,11 +11682,6 @@ mock-apollo-client@^1.2.0:
   resolved "https://registry.yarnpkg.com/mock-apollo-client/-/mock-apollo-client-1.2.0.tgz#72543df0d74577d29be1b34cecba8898c7e71451"
   integrity sha512-zCVHv3p7zvUmen9zce9l965ZrI6rMbrm2/oqGaTerVYOaYskl/cVgTG/L7iIToTIpI7onk/f6tu8hxPXZdyy/g==
 
-mockdate@^3.0.2:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
-  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
-
 modal-react-native-web@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/modal-react-native-web/-/modal-react-native-web-0.2.0.tgz#5daaa76213218fd25df739a267b11aed37e8c0c2"
@@ -13771,16 +13754,6 @@ react-native-ratings@8.0.4:
   dependencies:
     lodash "^4.17.15"
 
-react-native-reanimated@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.2.4.tgz#36c5d15028b0bd7d479fba5199117ac870c7a532"
-  integrity sha512-Nn648MfEEnTCEiWsl1YmfkojiLyV0NMY0EiRdDRbZNfJVfxBuyqhCxI/4Jd7aBi162qpgf8XK2mByYgvF4zLrQ==
-  dependencies:
-    "@babel/plugin-transform-object-assign" "^7.10.4"
-    fbjs "^3.0.0"
-    mockdate "^3.0.2"
-    string-hash-64 "^1.0.3"
-
 react-native-restart@daviroo/react-native-restart.git#master:
   version "0.0.22"
   resolved "https://codeload.github.com/daviroo/react-native-restart/tar.gz/842e2f61f20d78233c60e9d503ba5411f34b5982"
@@ -15247,11 +15220,6 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
-string-hash-64@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
-  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz"
@@ -15877,10 +15845,10 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-invariant@^0.9.0:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.3.tgz#4b41e0a80c2530a56ce4b8fd4e14183aaac0efa8"
-  integrity sha512-HinBlTbFslQI0OHP07JLsSXPibSegec6r9ai5xxq/qHYCsIQbzpymLpDhAUsnXcSrDEcd0L62L8vsOEdzM0qlA==
+ts-invariant@^0.9.4:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.9.4.tgz#42ac6c791aade267dd9dc65276549df5c5d71cac"
+  integrity sha512-63jtX/ZSwnUNi/WhXjnK8kz4cHHpYS60AnmA6ixz17l7E12a5puCWFlNpkne5Rl0J8TBPVHpGjsj4fxs8ObVLQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -15928,7 +15896,7 @@ tslib@^2.0.1:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
+tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -17277,12 +17245,11 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zen-observable-ts@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz#2d1aa9d79b87058e9b75698b92791c1838551f83"
-  integrity sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==
+zen-observable-ts@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
+  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
   dependencies:
-    "@types/zen-observable" "0.8.3"
     zen-observable "0.8.15"
 
 zen-observable@0.8.15:


### PR DESCRIPTION
I'm refactoring the transaction screen.  I think I found out why we saw really strange cache behaviour, especially in our paginated endpoints.  Apollo caching takes into account the variables passed to graphql functions when creating cache keys.  This makes sense if, for example, you are querying for a user using a user ID - you would want the cache to store different users under different locations in the cache.  But this totally breaks when it comes to paginated endpoints as it stores the query results for different pages in different cache keys.  In the apollo docs it includes a section on [how to use the relay style of pagination](https://www.apollographql.com/docs/react/pagination/cursor-based/#relay-style-cursor-pagination) (which we use) in the cache.  I think this is a pattern we should bring across to the web wallet @samerbuna.  It's not working fully yet, the `fetchMore()` function runs but then the original query for the first 20 runs again and causes a refresh loop.