### PR TITLE
Resolve USD to BTC issue with lnurl-pay

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -317,7 +317,15 @@ export const SendBitcoinScreen: ScreenType = ({
       toastShow(translate("SendBitcoinScreen.usernameNotFound"))
       return
     } else if (paymentType == "lnurl") {
-      const satAmount = primaryAmount.value * 1000
+
+      let satAmount = 0
+
+      if(primaryCurrency === "BTC") {
+        satAmount = primaryAmount.value * 1000
+      } else {
+        satAmount = Math.round(secondaryAmount.value) * 1000
+      }
+      
       const lnurlInvoice = await fetchInvoice(
         `${lnurlPay.callback}?amount=${satAmount}&comment=${encodeURIComponent(memo)}`,
       )
@@ -363,6 +371,7 @@ export const SendBitcoinScreen: ScreenType = ({
     invoice,
     lnurlPay,
     primaryAmount,
+    secondaryAmount,
     memo,
     primaryCurrency,
     referenceAmount,
@@ -482,6 +491,18 @@ export const SendBitcoinScreenJSX: ScreenType = ({
         primaryAmount &&
         primaryAmount.currency === "BTC" &&
         primaryAmount.value < lnurlPay.minSendable
+      ) {
+        lnurlErrorStr = translate("lnurl.underLimit")
+      } else if (
+        secondaryAmount &&
+        secondaryAmount.currency === "BTC" &&
+        secondaryAmount.value > lnurlPay.maxSendable
+      ) {
+        lnurlErrorStr = translate("lnurl.overLimit")
+      } else if (
+        secondaryAmount &&
+        secondaryAmount.currency === "BTC" &&
+        secondaryAmount.value < lnurlPay.minSendable
       ) {
         lnurlErrorStr = translate("lnurl.underLimit")
       } else if (lnurlPay.commentAllowed && memo === "") {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -317,15 +317,14 @@ export const SendBitcoinScreen: ScreenType = ({
       toastShow(translate("SendBitcoinScreen.usernameNotFound"))
       return
     } else if (paymentType == "lnurl") {
-
       let satAmount = 0
 
-      if(primaryCurrency === "BTC") {
+      if (primaryCurrency === "BTC") {
         satAmount = primaryAmount.value * 1000
       } else {
         satAmount = Math.round(secondaryAmount.value) * 1000
       }
-      
+
       const lnurlInvoice = await fetchInvoice(
         `${lnurlPay.callback}?amount=${satAmount}&comment=${encodeURIComponent(memo)}`,
       )


### PR DESCRIPTION
Our beta testers identified an issue with the lnurl-pay implementation. The app was not converting the USD amount to BTC properly when hitting the lnurl-pay callback URL. This resulted in an invoice of the incorrect amount being created on the back-end.