### PR TITLE
Typo in `updateAvailable` string

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -473,7 +473,7 @@
     "receive": "Receive",
     "send": "Send",
     "title": "Home",
-    "updateAvailable": "An update is available.\nTab to update now",
+    "updateAvailable": "An update is available.\nTap to update now",
     "useLightning": "We use the Lightning Network."
   },
   "Overlay": {

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -505,6 +505,7 @@
     "seeTransaction": "Supervisar la transacción de apertura",
     "send": "Enviar",
     "title": "Mover dinero",
+    "updateAvailable": "Hay disponible una actualización.\nToca para actualizar ahora",
     "useLightning": "Usamos la red de lightning",
     "walletInCreation": "Se está creando tu billetera"
   },


### PR DESCRIPTION
We encountered a typo in the `updateAvailable` string, and the Spanish version was missing entirely. This PR fixes the typo and adds a Spanish translation.