### PR TITLE
Add better error handling for 401 status codes

### DIFF
--- a/app/hooks/use-main-query.ts
+++ b/app/hooks/use-main-query.ts
@@ -13,7 +13,11 @@ const useMainQuery = (): useMainQueryOutput => {
   })
   let errors = []
   if (error) {
-    if (hasToken && error.networkError && (error.networkError as ServerError).statusCode === 401) {
+    if (
+      hasToken &&
+      error.networkError &&
+      (error.networkError as ServerError).statusCode === 401
+    ) {
       throw new Error("401")
     }
     if (error.graphQLErrors && previousData) {

--- a/app/hooks/use-main-query.ts
+++ b/app/hooks/use-main-query.ts
@@ -13,6 +13,9 @@ const useMainQuery = (): useMainQueryOutput => {
   })
   let errors = []
   if (error) {
+    if (hasToken && error.networkError && error.networkError.statusCode === 401) {
+      throw new Error(401)
+    }
     if (error.graphQLErrors && previousData) {
       // We got an error back from the server but we have data in the cache
       errors = [...error.graphQLErrors]

--- a/app/hooks/use-main-query.ts
+++ b/app/hooks/use-main-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client"
+import { useQuery, ServerError } from "@apollo/client"
 import { MAIN_QUERY } from "@app/graphql/query"
 import useToken from "@app/utils/use-token"
 import NetInfo from "@react-native-community/netinfo"
@@ -13,8 +13,8 @@ const useMainQuery = (): useMainQueryOutput => {
   })
   let errors = []
   if (error) {
-    if (hasToken && error.networkError && error.networkError.statusCode === 401) {
-      throw new Error(401)
+    if (hasToken && error.networkError && (error.networkError as ServerError).statusCode === 401) {
+      throw new Error("401")
     }
     if (error.graphQLErrors && previousData) {
       // We got an error back from the server but we have data in the cache

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -668,6 +668,7 @@
     "ok": "OK",
     "openWallet": "Open Wallet",
     "phoneNumber": "Phone Number",
+    "reauth": "Your session has expired. Please log in again.",
     "restart": "Restart",
     "sats": "sats",
     "search": "Search",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -704,6 +704,7 @@
     "ok": "OK",
     "openWallet": "Abrir billetera",
     "phoneNumber": "Número de teléfono",
+    "reauth": "Su sesión ha expirado. Inicie sesión de nuevo.",
     "restart": "Reiniciar",
     "sats": "Satoshis",
     "security": "Seguridad",

--- a/app/screens/error-screen/error-screen.tsx
+++ b/app/screens/error-screen/error-screen.tsx
@@ -66,14 +66,14 @@ export const ErrorScreen = ({ error, resetError }) => {
 
   const logoutAction = async () => {
     try {
-        await logout()
-        resetError()
-        Alert.alert(translate("common.reauth"), "", [
-          {
-            text: translate("common.ok"),
-            onPress: () => console.log("OK pressed"),
-          },
-        ])
+      await logout()
+      resetError()
+      Alert.alert(translate("common.reauth"), "", [
+        {
+          text: translate("common.ok"),
+          onPress: () => console.log("OK pressed"),
+        },
+      ])
     } catch (err) {
       // TODO: figure out why ListItem onPress is swallowing errors
       console.error(err)
@@ -85,7 +85,7 @@ export const ErrorScreen = ({ error, resetError }) => {
       setLogoutShown(true)
       logoutAction()
     }
-    
+
     return null
   }
 

--- a/app/screens/error-screen/error-screen.tsx
+++ b/app/screens/error-screen/error-screen.tsx
@@ -13,6 +13,7 @@ import { SafeAreaView } from "react-native-safe-area-context"
 import { isIos } from "@app/utils/helper"
 import { offsets, presets } from "@app/components/screen/screen.presets"
 import crashlytics from "@react-native-firebase/crashlytics"
+import useLogout from "../../hooks/use-logout"
 
 const styles = EStyleSheet.create({
   $color: palette.white,
@@ -59,7 +60,35 @@ const styles = EStyleSheet.create({
   },
 })
 export const ErrorScreen = ({ error, resetError }) => {
+  const { logout } = useLogout()
+  const [logoutShown, setLogoutShown] = React.useState(false)
   useEffect(() => crashlytics().recordError(error), [error])
+
+  const logoutAction = async () => {
+    try {
+        await logout()
+        resetError()
+        Alert.alert(translate("common.reauth"), "", [
+          {
+            text: translate("common.ok"),
+            onPress: () => console.log("OK pressed"),
+          },
+        ])
+    } catch (err) {
+      // TODO: figure out why ListItem onPress is swallowing errors
+      console.error(err)
+    }
+  }
+
+  if (String(error) === "Error: 401") {
+    if (!logoutShown) {
+      setLogoutShown(true)
+      logoutAction()
+    }
+    
+    return null
+  }
+
   return (
     <KeyboardAvoidingView
       style={[presets.fixed.outer, { backgroundColor: palette.lightBlue }]}


### PR DESCRIPTION
This PR adds better handling for 401 status codes coming from the graphql endpoint. This is helpful for jwt secret rotation. When the mobile app receives a 401 response while logged in, we should log the user out and prompt them to log back in. 