### PR TITLE
fix: Handle 401 Unauthorized Responses from GraphQL

### DIFF
--- a/__tests__/screens/global-error.spec.tsx
+++ b/__tests__/screens/global-error.spec.tsx
@@ -75,7 +75,7 @@ describe("GlobalError tests", () => {
     expect(toastSpy).toHaveBeenCalledWith("Server Error. Please try again later")
   })
 
-  it(`should show a toast with "You have been logged out." 
+  it(`should show a toast with "Your session has expired. Please log in again." 
       when statusCode >= 400 and < 500; and errorCode is "INVALID_AUTHENTICATION"`, () => {
     renderGlobalErrorToast({
       queryError: {
@@ -87,10 +87,13 @@ describe("GlobalError tests", () => {
     })
 
     expect(toastSpy).toHaveBeenCalledTimes(1)
-    expect(toastSpy).toHaveBeenCalledWith("You have been logged out.", {
-      duration: Toast.durations.SHORT,
-      onHidden: expect.any(Function),
-    })
+    expect(toastSpy).toHaveBeenCalledWith(
+      "Your session has expired. Please log in again.",
+      {
+        duration: Toast.durations.SHORT,
+        onHidden: expect.any(Function),
+      },
+    )
   })
 
   it(`should show a toast with "Request issue.\nContact support if the problem persists" 

--- a/app/components/global-error/global-error.tsx
+++ b/app/components/global-error/global-error.tsx
@@ -32,10 +32,19 @@ export const GlobalErrorToast: ComponentType = () => {
   }
 
   if (networkError.statusCode >= 400 && networkError.statusCode < 500) {
-    const errorCode = (networkError as ServerError).result?.errors?.[0]?.code
+    let errorCode = (networkError as ServerError).result?.errors?.[0]?.code
+
+    if(!errorCode) {
+      switch(networkError.statusCode) {
+        case 401:
+          errorCode = "INVALID_AUTHENTICATION"
+          break;
+      }
+    }
+
     switch (errorCode) {
       case NetworkErrorCode.InvalidAuthentication:
-        toastShow(translate("common.loggedOut"), {
+        toastShow(translate("common.reauth"), {
           duration: Toast.durations.SHORT,
           onHidden: () => logout(),
         })

--- a/app/components/global-error/global-error.tsx
+++ b/app/components/global-error/global-error.tsx
@@ -34,11 +34,11 @@ export const GlobalErrorToast: ComponentType = () => {
   if (networkError.statusCode >= 400 && networkError.statusCode < 500) {
     let errorCode = (networkError as ServerError).result?.errors?.[0]?.code
 
-    if(!errorCode) {
-      switch(networkError.statusCode) {
+    if (!errorCode) {
+      switch (networkError.statusCode) {
         case 401:
           errorCode = "INVALID_AUTHENTICATION"
-          break;
+          break
       }
     }
 

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -668,6 +668,7 @@
     "ok": "OK",
     "openWallet": "Open Wallet",
     "phoneNumber": "Phone Number",
+    "reauth": "Your session has expired. Please log in again.",
     "restart": "Restart",
     "sats": "sats",
     "search": "Search",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -704,6 +704,7 @@
     "ok": "OK",
     "openWallet": "Abrir billetera",
     "phoneNumber": "Número de teléfono",
+    "reauth": "Su sesión ha expirado. Inicie sesión de nuevo.",
     "restart": "Reiniciar",
     "sats": "Satoshis",
     "security": "Seguridad",


### PR DESCRIPTION
This PR has the mobile app respond to 401 Unauthorized responses from the GraphQL API by notifying the user and  This is a small change that fixes existing code that wasn't being triggered as expected. 