### PR TITLE
perf: Improve validation for usernameAvailable

### DIFF
--- a/__tests__/username-validation.spec.ts
+++ b/__tests__/username-validation.spec.ts
@@ -117,4 +117,19 @@ describe("Username validation", () => {
     expect(hasNoRestictedStartCharacters).toBeFalsy()
     expect(isValid).toBeFalsy()
   })
+
+  it("is invalid for a username beginning with lnbc1", () => {
+    const username = "lnbc1ps7fqhwpp5"
+
+    const hasValidLength = UsernameValidation.hasValidLength(username)
+    const hasValidCharacters = UsernameValidation.hasValidCharacters(username)
+    const hasNoRestictedStartCharacters =
+      UsernameValidation.hasNoRestictedStartCharacters(username)
+    const isValid = UsernameValidation.isValid(username)
+
+    expect(hasValidLength).toBeTruthy()
+    expect(hasValidCharacters).toBeTruthy()
+    expect(hasNoRestictedStartCharacters).toBeFalsy()
+    expect(isValid).toBeFalsy()
+  })
 })

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -595,11 +595,13 @@
   },
   "UsernameScreen": {
     "3CharactersMinimum": "at least 3 characters are necessary",
+    "50CharactersMaximum": "Username cannot be longer than 50 characters",
     "available": "✅  %{input} is available",
     "confirmSubtext": "The username is permanent and can not be changed later",
     "confirmTitle": "Set %{input} as your username?",
     "forbiddenStart": "Cannot start with lnbc1, bc1, 1, or 3 and cannot be a Bitcoin address or Lightning invoice",
     "letterAndNumber": "Only lowercase letter, number and underscore (_) are accepted",
+    "emailAddress": "Username must not be email address",
     "notAvailable": "❌  %{input} is not available",
     "success": "%{input} is now your username!",
     "usernameToUse": "What username do you want to use?"

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -598,7 +598,7 @@
     "available": "✅  %{input} is available",
     "confirmSubtext": "The username is permanent and can not be changed later",
     "confirmTitle": "Set %{input} as your username?",
-    "forbiddenStart": "Cannot start with bc1, 1, or 3",
+    "forbiddenStart": "Cannot start with lnbc1, bc1, 1, or 3 and cannot be a Bitcoin address or Lightning invoice",
     "letterAndNumber": "Only lowercase letter, number and underscore (_) are accepted",
     "notAvailable": "❌  %{input} is not available",
     "success": "%{input} is now your username!",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -635,7 +635,7 @@
     "available": "✅  %{input} está disponible",
     "confirmSubtext": "Este nombre de usuario es permanente y no se podrá cambiar más adelante.",
     "confirmTitle": "¿Desea establecer %{input} como su nombre de usuario?",
-    "forbiddenStart": "No debe empezar con bc1, 1 o 3",
+    "forbiddenStart": "No debe empezar con lnbc1, bc1, 1 o 3 y no debe ser Bitcoin o factura Lightning",
     "letterAndNumber": "Solo se aceptan letras en minúscula, números y guiones bajos (_)",
     "notAvailable": "❌  %{input} no está disponible",
     "success": "¡%{input} es ahora su nombre de usuario!",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -632,11 +632,13 @@
   },
   "UsernameScreen": {
     "3CharactersMinimum": "al menos de 3 letras son necesarias",
+    "50CharactersMaximum": "Este nombre de usuario no puede tener más de 50 letras",
     "available": "✅  %{input} está disponible",
     "confirmSubtext": "Este nombre de usuario es permanente y no se podrá cambiar más adelante.",
     "confirmTitle": "¿Desea establecer %{input} como su nombre de usuario?",
     "forbiddenStart": "No debe empezar con lnbc1, bc1, 1 o 3 y no debe ser Bitcoin o factura Lightning",
     "letterAndNumber": "Solo se aceptan letras en minúscula, números y guiones bajos (_)",
+    "emailAddress": "el nombre de usuario no debe ser correo electrónico",
     "notAvailable": "❌  %{input} no está disponible",
     "success": "¡%{input} es ahora su nombre de usuario!",
     "usernameToUse": "¿Qué nombre de usuario desea usar?"

--- a/app/screens/settings-screen/username-screen.tsx
+++ b/app/screens/settings-screen/username-screen.tsx
@@ -9,7 +9,7 @@ import EStyleSheet from "react-native-extended-stylesheet"
 import { Screen } from "../../components/screen"
 import { translate } from "../../i18n"
 import { color, palette } from "../../theme"
-import { UsernameValidation } from "../../utils/validation"
+import { InvalidUsernameError, UsernameValidation } from "../../utils/validation"
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import { USERNAME_AVAILABLE } from "../../graphql/query"
@@ -160,17 +160,10 @@ export const UsernameScreen: ScreenType = ({ navigation }: Props) => {
   const onChangeText = (value) => {
     setInputStatus({ message: "", status: "" })
     setInput(value)
-
     if (value) {
-      let errorMessage: string | null = null
-      if (!UsernameValidation.hasValidCharacters(value)) {
-        errorMessage = translate("UsernameScreen.letterAndNumber")
-      }
-      if (!UsernameValidation.hasNoRestictedStartCharacters(value)) {
-        errorMessage = translate("UsernameScreen.forbiddenStart")
-      }
-      if (errorMessage) {
-        setInputStatus({ message: errorMessage, status: "error" })
+      const checkedUsername = UsernameValidation.checkedToUsername(value)
+      if (checkedUsername instanceof InvalidUsernameError) {
+        setInputStatus({ message: String(checkedUsername), status: "error" })
       }
     }
   }

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -56,7 +56,7 @@ export class UsernameValidation {
   }
 
   public static hasNoRestictedStartCharacters = (username: string): boolean => {
-    return new RegExp(/(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i).test(username)
+    return new RegExp(/^(?!bc1|1|3).+$/i).test(username)
   }
 
   public static isValid = (username: string): boolean => {

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -8,7 +8,7 @@ export class UsernameValidation {
   }
 
   public static hasNoRestictedStartCharacters = (username: string): boolean => {
-    return new RegExp(/^(?!bc1|1|3).+$/i).test(username)
+    return new RegExp(/^(?!bc1|1|3|lnbc1).+$/i).test(username)
   }
 
   public static isValid = (username: string): boolean => {

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -47,6 +47,7 @@ export class UsernameValidation {
 
   public static isEmailAddress = (username: string): boolean => {
     return new RegExp(
+        /* eslint-disable no-useless-escape */
       /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
     ).test(username)
   }

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -47,7 +47,7 @@ export class UsernameValidation {
 
   public static isEmailAddress = (username: string): boolean => {
     return new RegExp(
-        /* eslint-disable no-useless-escape */
+      /* eslint-disable no-useless-escape */
       /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
     ).test(username)
   }

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -56,7 +56,7 @@ export class UsernameValidation {
   }
 
   public static hasNoRestictedStartCharacters = (username: string): boolean => {
-    return new RegExp(/^(?!bc1|1|3).+$/i).test(username)
+    return new RegExp(/^(?!bc1|1|3|lnbc1).+$/i).test(username)
   }
 
   public static isValid = (username: string): boolean => {

--- a/app/utils/validation.ts
+++ b/app/utils/validation.ts
@@ -1,6 +1,54 @@
+import { translate } from "@app/i18n"
+
+export class InvalidUsernameError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
 export class UsernameValidation {
+  static usernameRegex = /(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i
+
+  public static Invalid3CharactersMin = translate("UsernameScreen.3CharactersMinimum")
+  public static Invalid50CharactersMax = translate("UsernameScreen.50CharactersMaximum")
+  public static InvalidLettersAndNumbers = translate("UsernameScreen.letterAndNumber")
+  public static InvalidEmailAddress =
+    translate("UsernameScreen.emailAddress") +
+    ". " +
+    translate("UsernameScreen.letterAndNumber")
+  public static InvalidStartCharacters = translate("UsernameScreen.forbiddenStart")
+  public static InvalidUnexpected = translate("errors.unexpectedError")
+
+  public static checkedToUsername = (username: string): string | InvalidUsernameError => {
+    if (!username.match(this.usernameRegex)) {
+      switch (false) {
+        case this.hasValidLength(username):
+          return username.length > 3
+            ? new InvalidUsernameError(this.Invalid50CharactersMax)
+            : new InvalidUsernameError(this.Invalid3CharactersMin)
+        case this.hasValidCharacters(username):
+          if (this.isEmailAddress(username)) {
+            return new InvalidUsernameError(this.InvalidEmailAddress)
+          }
+          return new InvalidUsernameError(this.InvalidLettersAndNumbers)
+        case this.hasNoRestictedStartCharacters(username):
+          return new InvalidUsernameError(this.InvalidStartCharacters)
+        default:
+          return new InvalidUsernameError(this.InvalidUnexpected)
+      }
+    }
+    return username
+  }
+
   public static hasValidLength = (username: string): boolean => {
-    return username.length >= 3
+    return username.length >= 3 && username.length <= 50
+  }
+
+  public static isEmailAddress = (username: string): boolean => {
+    return new RegExp(
+      /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+    ).test(username)
   }
 
   public static hasValidCharacters = (username: string): boolean => {
@@ -8,14 +56,11 @@ export class UsernameValidation {
   }
 
   public static hasNoRestictedStartCharacters = (username: string): boolean => {
-    return new RegExp(/^(?!bc1|1|3|lnbc1).+$/i).test(username)
+    return new RegExp(/(?!^(1|3|bc1|lnbc1))^[0-9a-z_]{3,50}$/i).test(username)
   }
 
   public static isValid = (username: string): boolean => {
-    return (
-      UsernameValidation.hasValidLength(username) &&
-      UsernameValidation.hasValidCharacters(username) &&
-      UsernameValidation.hasNoRestictedStartCharacters(username)
-    )
+    const checkedUsername = this.checkedToUsername(username)
+    return !(checkedUsername instanceof InvalidUsernameError)
   }
 }


### PR DESCRIPTION
Resolves #365 
- Adds "lnbc1" to the `hasNoRestictedStartCharacters` function to reduce calls to the server. 
- Adds some clarity to the forbiddenStart message letting the user know the username cannot be a bitcoin address or lightning invoice
- Adds test for "lnbc1" 

*Note - I did my best to translate the forbidden start error message which may benefit from being proofed by a native Spanish speaker. The added language may not be even be necessary and can be removed also. 