### PR TITLE
perf: increase debounce time

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -209,7 +209,7 @@ export const SendBitcoinScreen: ScreenType = ({
     () =>
       debounce(async () => {
         userDefaultWalletIdQuery({ variables: { username: destination } })
-      }, 1000),
+      }, 1500),
     [destination, userDefaultWalletIdQuery],
   )
 


### PR DESCRIPTION
After doing some research on the topic, the consensus seems to be that you should tweak the debounce time until you get the right balance of app feedback to the user in a timely manner and reducing server load. I went with 500ms for now. 
I tried to simulate entering a username from a list of examples that required me to stop briefly to look as I typed and 1500ms triggered the function call the fewest times while not taking an unreasonable time to provide validation feedback.

resolve: #364 