### PR TITLE
refactor: Enable paste lnurl

### DIFF
--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -522,7 +522,8 @@
     "invalidContent": "We found:\n\n{{found}}\n\nThis is not a valid Bitcoin address or Lightning invoice",
     "invalidTitle": "Invalid QR Code",
     "noQrCode": "We could not find a QR code in the image",
-    "title": "Scan QR Code"
+    "title": "Scan QR Code",
+    "invalidContentLnurl": "We found:\n\n{{found}}\n\n is not currently supported"
   },
   "SecurityScreen": {
     "biometricDescription": "Unlock with fingerprint or facial recognition.",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -565,8 +565,7 @@
     "note": "optional note",
     "success": "Payment has been sent successfully",
     "title": "Send Bitcoin",
-    "usernameNotFound": "A user matching the entered username could not be found.",
-    "invalidLnurl": "Invalid lnurl"
+    "usernameNotFound": "A user matching the entered username could not be found."
   },
   "SettingsScreen": {
     "activate": "Tap to activate",

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -564,7 +564,8 @@
     "note": "optional note",
     "success": "Payment has been sent successfully",
     "title": "Send Bitcoin",
-    "usernameNotFound": "A user matching the entered username could not be found."
+    "usernameNotFound": "A user matching the entered username could not be found.",
+    "invalidLnurl": "Invalid lnurl"
   },
   "SettingsScreen": {
     "activate": "Tap to activate",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -562,7 +562,7 @@
     "invalidTitle": "Código QR inválido",
     "noQrCode": "No pudimos encontrar un código QR en la imagen",
     "title": "Escanear QR",
-    "invalidTitleLnurl": "Encontramos lo siguiente:\n\n{{found}}\n\n actualmente no es compatible"
+    "invalidContentLnurl": "Encontramos lo siguiente:\n\n{{found}}\n\n actualmente no es compatible"
   },
   "SecurityScreen": {
     "biometricDescription": "Desbloqueo con huella dactilar o reconocimiento facial.",
@@ -603,9 +603,7 @@
     "note": "Nota ",
     "payFromUSD": "Pago desde $USD",
     "success": "El pago se ha enviado correctamente.",
-    "title": "Enviar Bitcoin",
-    "totalExceed": "total excede su saldo",
-    "invalidLnurl": "lnurl no válido"
+    "title": "Enviar Bitcoin"
   },
   "SettingsScreen": {
     "activated": "Activada",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -561,7 +561,8 @@
     "invalidContent": "Encontramos lo siguiente:\n\n{{found}}\n\nEsto no es una dirección Bitcoin o factura Lightning válida",
     "invalidTitle": "Código QR inválido",
     "noQrCode": "No pudimos encontrar un código QR en la imagen",
-    "title": "Escanear QR"
+    "title": "Escanear QR",
+    "invalidTitleLnurl": "Encontramos lo siguiente:\n\n{{found}}\n\n actualmente no es compatible"
   },
   "SecurityScreen": {
     "biometricDescription": "Desbloqueo con huella dactilar o reconocimiento facial.",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -603,7 +603,8 @@
     "payFromUSD": "Pago desde $USD",
     "success": "El pago se ha enviado correctamente.",
     "title": "Enviar Bitcoin",
-    "totalExceed": "total excede su saldo"
+    "totalExceed": "total excede su saldo",
+    "invalidLnurl": "lnurl no válido"
   },
   "SettingsScreen": {
     "activated": "Activada",

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -110,7 +110,7 @@ export const ScanningQRCodeScreen: ScreenType = ({
             default:
               Alert.alert(
                 translate("ScanningQRCodeScreen.invalidTitle"),
-                translate("ScanningQRCodeScreen.invalidContent", {
+                translate("ScanningQRCodeScreen.invalidContentLnurl", {
                   found: lnurlParams.tag,
                 }),
                 [

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -6,6 +6,7 @@ import EStyleSheet from "react-native-extended-stylesheet"
 import { launchImageLibrary } from "react-native-image-picker"
 import Svg, { Circle } from "react-native-svg"
 import Icon from "react-native-vector-icons/Ionicons"
+import Paste from "react-native-vector-icons/FontAwesome"
 import { Screen } from "../../components/screen"
 import { translate } from "../../i18n"
 import { palette } from "../../theme/palette"
@@ -18,6 +19,7 @@ import { MoveMoneyStackParamList } from "../../navigation/stack-param-lists"
 import { StackNavigationProp } from "@react-navigation/stack"
 import useToken from "../../utils/use-token"
 import useMainQuery from "@app/hooks/use-main-query"
+import Clipboard from "@react-native-community/clipboard"
 
 const CAMERA: ViewStyle = {
   width: "100%",
@@ -80,7 +82,6 @@ export const ScanningQRCodeScreen: ScreenType = ({
     if (pending) {
       return
     }
-
     try {
       const { valid, lnurl } = validPayment(data, tokenNetwork, myPubKey, username)
       if (valid) {
@@ -141,6 +142,15 @@ export const ScanningQRCodeScreen: ScreenType = ({
           ],
         )
       }
+    } catch (err) {
+      Alert.alert(err.toString())
+    }
+  }
+  const handleInvoicePaste = async () => {
+    try {
+      Clipboard.getString().then((data) => {
+        decodeInvoice(data)
+      })
     } catch (err) {
       Alert.alert(err.toString())
     }
@@ -217,6 +227,15 @@ export const ScanningQRCodeScreen: ScreenType = ({
                 color={palette.lightGrey}
                 // eslint-disable-next-line react-native/no-inline-styles
                 style={{ opacity: 0.8 }}
+              />
+            </Pressable>
+            <Pressable onPress={handleInvoicePaste}>
+              <Paste
+                name="paste"
+                size={64}
+                color={palette.lightGrey}
+                // eslint-disable-next-line react-native/no-inline-styles
+                style={{ opacity: 0.8, position: "absolute", bottom: "5%", right: "15%" }}
               />
             </Pressable>
           </View>

--- a/app/utils/parsing.ts
+++ b/app/utils/parsing.ts
@@ -66,8 +66,11 @@ export const validPayment = (
   }
 
   // input might start with 'lightning:', 'bitcoin:'
+  if(input.toLowerCase().startsWith("lightning:lnurl")){
+    input = input.replace("lightning:", "")
+  }
   // eslint-disable-next-line prefer-const
-  let [protocol, data] = input.replace("lightning:", "").split(":")
+  let [protocol, data] = input.split(":")
   let paymentType: IPaymentType
   let lnurl: string
 

--- a/app/utils/parsing.ts
+++ b/app/utils/parsing.ts
@@ -67,7 +67,7 @@ export const validPayment = (
 
   // input might start with 'lightning:', 'bitcoin:'
   if (input.toLowerCase().startsWith("lightning:lnurl")) {
-     /* eslint-disable no-param-reassign */
+    /* eslint-disable no-param-reassign */
     input = input.replace("lightning:", "")
   }
   // eslint-disable-next-line prefer-const

--- a/app/utils/parsing.ts
+++ b/app/utils/parsing.ts
@@ -66,7 +66,8 @@ export const validPayment = (
   }
 
   // input might start with 'lightning:', 'bitcoin:'
-  if(input.toLowerCase().startsWith("lightning:lnurl")){
+  if (input.toLowerCase().startsWith("lightning:lnurl")) {
+     /* eslint-disable no-param-reassign */
     input = input.replace("lightning:", "")
   }
   // eslint-disable-next-line prefer-const

--- a/app/utils/parsing.ts
+++ b/app/utils/parsing.ts
@@ -67,7 +67,7 @@ export const validPayment = (
 
   // input might start with 'lightning:', 'bitcoin:'
   // eslint-disable-next-line prefer-const
-  let [protocol, data] = input.split(":")
+  let [protocol, data] = input.replace("lightning:", "").split(":")
   let paymentType: IPaymentType
   let lnurl: string
 


### PR DESCRIPTION
Addresses issue #316 

Send Bitcoin screen was able to handle lnurl from scanned QR code but was not able to handle user pasting lnurl directly.

- added ability to paste lnurl from send bitcoin screen 
- added clipboard icon to bottom of QR code, if user has copied it to clipboard and taps the clipboard it will paste and transition to send bitcoin screen to confirm, similar to Wallet of Satoshi and Strik

https://user-images.githubusercontent.com/17483038/151304524-8c7487ab-3a25-4be0-8e32-1bac5f83c890.mov

