### PR TITLE
fix: Fix username input

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-screen.tsx
@@ -299,7 +299,8 @@ export const SendBitcoinScreen: ScreenType = ({
         userDefaultWalletIdQueryDebounced()
       }
     }
-    return () => userDefaultWalletIdQueryDebounced.cancel()
+    return () => userDefaultWalletIdQueryDebounced.flush()
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [destination])
 
@@ -651,7 +652,13 @@ export const SendBitcoinScreenJSX: ScreenType = ({
           }
           onPress={pay}
           disabled={
-            !primaryAmount.value || !!errorMessage || !destination || !!lnurlError
+            !primaryAmount.value ||
+            !!errorMessage ||
+            !destination ||
+            !!lnurlError ||
+            loadingUserNameExist ||
+            (UsernameValidation.isValid(destination) &&
+              destinationStatus === "NOT_CHECKED")
           }
         />
       </ScrollView>


### PR DESCRIPTION
We had an issue where a user paid to the wrong username because the `defaultWalletId` forwarded to the `SendBitcoinConfirmation` screen was incorrect.  This was because the debounced function which fetches the `defaultWalletId` had returned for a previous valid username and the user was then able to navigate to the next page which cancelled the most recent invocation of the debounced function.  I've added logic to block the user from continuing to the next page while we are executing checks for the current username value.  