### PR TITLE
feat: Add continue button to phone auth screen

### DIFF
--- a/__tests__/screens/__snapshots__/phone-auth.spec.tsx.snap
+++ b/__tests__/screens/__snapshots__/phone-auth.spec.tsx.snap
@@ -710,6 +710,75 @@ exports[`WelcomePhoneInputScreen render matches snapshot 1`] = `
               }
             />
           </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "borderRadius": 3,
+                  "overflow": "hidden",
+                },
+                Object {
+                  "borderRadius": 3,
+                },
+                undefined,
+                false,
+              ]
+            }
+          >
+            <View
+              accessibilityRole="button"
+              accessibilityState={
+                Object {
+                  "busy": false,
+                  "disabled": false,
+                }
+              }
+              accessible={true}
+              collapsable={false}
+              focusable={true}
+              nativeID="animatedComponent"
+              onClick={[Function]}
+              onResponderGrant={[Function]}
+              onResponderMove={[Function]}
+              onResponderRelease={[Function]}
+              onResponderTerminate={[Function]}
+              onResponderTerminationRequest={[Function]}
+              onStartShouldSetResponder={[Function]}
+              style={
+                Object {
+                  "opacity": 1,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "backgroundColor": "#2089dc",
+                    "borderColor": "#2089dc",
+                    "borderRadius": 3,
+                    "borderWidth": 0,
+                    "flexDirection": "row",
+                    "justifyContent": "center",
+                    "padding": 8,
+                  }
+                }
+              >
+                <Text
+                  style={
+                    Object {
+                      "color": "white",
+                      "fontSize": 18,
+                      "paddingVertical": 1,
+                      "textAlign": "center",
+                    }
+                  }
+                >
+                  Continue
+                </Text>
+              </View>
+            </View>
+          </View>
         </View>
         <View>
           <Text

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -621,7 +621,8 @@
     "header": "Enter your phone number, and we'll text you an access code.",
     "headerVerify": "Verify you are human",
     "placeholder": "Phone Number",
-    "verify": "Click to Verify"
+    "verify": "Click to Verify",
+    "continue": "Continue"
   },
   "WelcomePhoneValidationScreen": {
     "errorLoggingIn": "Error logging in. Did you use the right code?",

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -658,7 +658,8 @@
     "header": "Ingrese su número de teléfono, y le enviaremos un mensaje de texto con un código de acceso.",
     "headerVerify": "¿Eres un robot?",
     "placeholder": "Número de teléfono",
-    "verify": "No soy un robot"
+    "verify": "No soy un robot",
+    "continue": "Continuar"
   },
   "WelcomePhoneValidationScreen": {
     "errorLoggingIn": "Error al iniciar sesión. ¿Usó el código correcto?",

--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -91,7 +91,7 @@ const styles = EStyleSheet.create({
     alignSelf: "center",
     backgroundColor: color.palette.blue,
     width: "200rem",
-    marginVertical: "10rem",
+    marginVertical: "15rem",
     padding: "15rem",
   },
 
@@ -332,7 +332,7 @@ export const WelcomePhoneInputScreen: ScreenType = ({
         <Button
           buttonStyle={styles.buttonContinue}
           title={translate("WelcomePhoneInputScreen.continue")}
-          disabled={phoneNumber}
+          disabled={phoneNumber ? true : false}
           onPress={() => {
             submitPhoneNumber()
           }}

--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -87,6 +87,12 @@ const styles = EStyleSheet.create({
     width: "200rem",
   },
 
+  buttonContinue: {
+    alignSelf: "center",
+    backgroundColor: color.palette.blue,
+    width: "200rem",
+  },
+
   codeContainer: {
     alignSelf: "center",
     width: "70%",
@@ -321,6 +327,13 @@ export const WelcomePhoneInputScreen: ScreenType = ({
             />
           </KeyboardAvoidingView>
         )}
+        <Button
+          buttonStyle={styles.buttonContinue}
+          title={translate("WelcomePhoneInputScreen.continue")}
+          onPress={() => {
+            submitPhoneNumber()
+          }}
+        />
       </View>
       <CloseCross color={palette.darkGrey} onPress={() => navigation.goBack()} />
     </Screen>

--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -91,6 +91,8 @@ const styles = EStyleSheet.create({
     alignSelf: "center",
     backgroundColor: color.palette.blue,
     width: "200rem",
+    marginVertical: "10rem",
+    padding: "15rem",
   },
 
   codeContainer: {
@@ -330,6 +332,7 @@ export const WelcomePhoneInputScreen: ScreenType = ({
         <Button
           buttonStyle={styles.buttonContinue}
           title={translate("WelcomePhoneInputScreen.continue")}
+          disabled={phoneNumber}
           onPress={() => {
             submitPhoneNumber()
           }}


### PR DESCRIPTION
As requested in issue #390 I have added a Continue button to the phone auth screen. Now users can either use the submit button on the keyboard or they can dismiss the keyboard and hit the Continue button when they are ready. I can adjust the styling if you had something different in mind for the design.

Cheers!

Screenshot:
![image](https://user-images.githubusercontent.com/85003930/155653441-71ad0fb7-ddfc-420d-86ba-159b7c67df20.png)

