### PR TITLE
Fix: Change `LN_PAGE_DOMAIN` to `GALOY_PAY_DOMAIN`, Use `GALOY_PAY_DOMAIN` constant in LNURL screen.

### DIFF
--- a/app/constants/support.ts
+++ b/app/constants/support.ts
@@ -1,3 +1,3 @@
 export const WHATSAPP_CONTACT_NUMBER = "+50369835117"
-export const LN_PAGE_DOMAIN = "https://ln.bitcoinbeach.com/"
+export const GALOY_PAY_DOMAIN = "https://ln.bitcoinbeach.com/"
 export const BLOCKCHAIN_EXPLORER_URL = "https://mempool.space/tx/"

--- a/app/screens/settings-screen/lnurl-screen.tsx
+++ b/app/screens/settings-screen/lnurl-screen.tsx
@@ -79,7 +79,10 @@ export const LnurlScreen: ScreenType = ({ route }: Props) => {
     ),
     1500,
   )
-  const lnurlAddress = `${username}@${LN_PAGE_DOMAIN.replace('https://', '').replace('/', '')}`
+  const lnurlAddress = `${username}@${LN_PAGE_DOMAIN.replace("https://", "").replace(
+    "/",
+    "",
+  )}`
   const viewPrintableVersion = (): Promise<Linking> =>
     Linking.openURL(`${LN_PAGE_DOMAIN}${username}/print`)
 

--- a/app/screens/settings-screen/lnurl-screen.tsx
+++ b/app/screens/settings-screen/lnurl-screen.tsx
@@ -10,6 +10,7 @@ import { palette } from "../../theme/palette"
 
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
+import { LN_PAGE_DOMAIN } from "../../constants/support"
 
 import { bech32 } from "bech32"
 import QRCode from "react-native-qrcode-svg"
@@ -74,13 +75,13 @@ export const LnurlScreen: ScreenType = ({ route }: Props) => {
   const lnurl = bech32.encode(
     "lnurl",
     bech32.toWords(
-      Buffer.from(`https://ln.bitcoinbeach.com/.well-known/lnurlp/${username}`, "utf8"),
+      Buffer.from(`${LN_PAGE_DOMAIN}.well-known/lnurlp/${username}`, "utf8"),
     ),
     1500,
   )
-  const lnurlAddress = `${username}@ln.bitcoinbeach.com`
+  const lnurlAddress = `${username}@${LN_PAGE_DOMAIN.replace('https://', '').replace('/', '')}`
   const viewPrintableVersion = (): Promise<Linking> =>
-    Linking.openURL(`https://ln.bitcoinbeach.com/${username}/print`)
+    Linking.openURL(`${LN_PAGE_DOMAIN}${username}/print`)
 
   return (
     <Screen style={styles.container} preset="scroll">

--- a/app/screens/settings-screen/lnurl-screen.tsx
+++ b/app/screens/settings-screen/lnurl-screen.tsx
@@ -10,7 +10,7 @@ import { palette } from "../../theme/palette"
 
 import type { ScreenType } from "../../types/jsx"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
-import { LN_PAGE_DOMAIN } from "../../constants/support"
+import { GALOY_PAY_DOMAIN } from "../../constants/support"
 
 import { bech32 } from "bech32"
 import QRCode from "react-native-qrcode-svg"
@@ -75,16 +75,16 @@ export const LnurlScreen: ScreenType = ({ route }: Props) => {
   const lnurl = bech32.encode(
     "lnurl",
     bech32.toWords(
-      Buffer.from(`${LN_PAGE_DOMAIN}.well-known/lnurlp/${username}`, "utf8"),
+      Buffer.from(`${GALOY_PAY_DOMAIN}.well-known/lnurlp/${username}`, "utf8"),
     ),
     1500,
   )
-  const lnurlAddress = `${username}@${LN_PAGE_DOMAIN.replace("https://", "").replace(
+  const lnurlAddress = `${username}@${GALOY_PAY_DOMAIN.replace("https://", "").replace(
     "/",
     "",
   )}`
   const viewPrintableVersion = (): Promise<Linking> =>
-    Linking.openURL(`${LN_PAGE_DOMAIN}${username}/print`)
+    Linking.openURL(`${GALOY_PAY_DOMAIN}${username}/print`)
 
   return (
     <Screen style={styles.container} preset="scroll">

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -9,7 +9,7 @@ import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet
 import { Screen } from "../../components/screen"
 import { VersionComponent } from "../../components/version"
 import { palette } from "../../theme/palette"
-import { LN_PAGE_DOMAIN, WHATSAPP_CONTACT_NUMBER } from "../../constants/support"
+import { GALOY_PAY_DOMAIN, WHATSAPP_CONTACT_NUMBER } from "../../constants/support"
 import { translate } from "../../i18n"
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import type { ScreenType } from "../../types/jsx"
@@ -200,7 +200,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     loadingCsvTransactions,
   } = params
   const copyToClipBoard = (username) => {
-    Clipboard.setString(LN_PAGE_DOMAIN + username)
+    Clipboard.setString(GALOY_PAY_DOMAIN + username)
     Clipboard.getString().then((data) =>
       toastShow(translate("tippingLink.copied", { data }), {
         backgroundColor: palette.lightBlue,


### PR DESCRIPTION
This PR changes the new LNURL screen to use the `LN_PAGE_DOMAIN` constant instead of the hardcoded string of `ln.bitcoinbeach.com`. This makes it easier for other instances of Galoy to incorporate this change into their repo.