### PR TITLE
Feature: Add NFC scanning/programming functionality

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"  />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <!-- why only for debug? -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,6 +43,13 @@
 
             <!-- note that the leading "/" is required for pathPrefix-->
         </intent-filter>
+        <intent-filter>
+          <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <data android:scheme="https"
+            android:host="ln.bitcoinbeach.com"
+            />
+        </intent-filter>
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
 

--- a/app/components/modal-nfc/index.ts
+++ b/app/components/modal-nfc/index.ts
@@ -1,0 +1,1 @@
+export * from "./modal-nfc"

--- a/app/components/modal-nfc/modal-nfc.tsx
+++ b/app/components/modal-nfc/modal-nfc.tsx
@@ -1,0 +1,133 @@
+import { useReactiveVar } from "@apollo/client"
+import * as React from "react"
+import { StyleSheet, Text, TouchableWithoutFeedback, View } from "react-native"
+import { Button } from "react-native-elements"
+import Modal from "react-native-modal"
+import { SafeAreaView } from "react-native-safe-area-context"
+import Icon from "react-native-vector-icons/Ionicons"
+import { modalNfcVisibleVar } from "../../graphql/client-only-query"
+import NfcManager from "react-native-nfc-manager"
+import { translate } from "../../i18n"
+import { color } from "../../theme"
+import { palette } from "../../theme/palette"
+import type { ComponentType } from "../../types/jsx"
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignContent: "stretch",
+  },
+
+  buttonStyle: {
+    backgroundColor: color.primary,
+    marginHorizontal: 20,
+    marginVertical: 10,
+    width: 145,
+  },
+
+  icon: {
+    height: 40,
+    top: -40,
+  },
+
+  iconContainer: {
+    height: 14,
+  },
+
+  scanIcon: {
+    height: 40,
+  },
+
+  scanIconContainer: {
+    height: 40,
+  },
+
+  message: {
+    fontSize: 18,
+    marginVertical: 8,
+    color: palette.darkGrey,
+  },
+
+  modal: {
+    flexGrow: 1,
+    marginBottom: 0,
+    marginHorizontal: 0,
+  },
+
+  modalBackground: {
+    alignItems: "center",
+    flex: 1,
+    justifyContent: "space-around",
+  },
+
+  modalForeground: {
+    alignItems: "center",
+    backgroundColor: palette.white,
+    paddingHorizontal: 20,
+    paddingTop: 10,
+  },
+
+  touchable: {
+    height: "100%",
+    width: "100%",
+  },
+})
+
+export const ModalNfc: ComponentType = () => {
+  const isVisible = useReactiveVar(modalNfcVisibleVar)
+
+  const dismiss = async () => {
+    modalNfcVisibleVar(false)
+    NfcManager.cancelTechnologyRequest()
+  }
+
+  React.useEffect(() => {
+    if (!isVisible) {
+      return
+    }
+  }, [isVisible])
+
+  return (
+    <Modal
+      swipeDirection={["down"]}
+      isVisible={isVisible}
+      onSwipeComplete={dismiss}
+      swipeThreshold={50}
+      propagateSwipe
+      style={styles.modal}
+    >
+      <View style={styles.modalBackground}>
+        <TouchableWithoutFeedback onPress={dismiss}>
+          <View style={styles.touchable} />
+        </TouchableWithoutFeedback>
+      </View>
+      <SafeAreaView style={styles.modalForeground}>
+        <View style={styles.iconContainer}>
+          <Icon
+            name="ios-remove"
+            size={72}
+            color={palette.lightGrey}
+            style={styles.icon}
+          />
+        </View>
+        <Text style={styles.message}>Scan NFC Now</Text>
+        <View style={styles.scanIconContainer}>
+          <Icon
+            name="ios-scan"
+            size={40}
+            color={palette.lightGrey}
+            style={styles.scanIcon}
+          />
+        </View>
+        <View style={styles.buttonContainer}>
+          <Button
+            title={translate("common.cancel")}
+            onPress={dismiss}
+            buttonStyle={styles.buttonStyle}
+          />
+        </View>
+      </SafeAreaView>
+    </Modal>
+  )
+}

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -10,6 +10,7 @@ import {
 import { ScreenProps } from "./screen.props"
 import { isNonScrolling, offsets, presets } from "./screen.presets"
 import { ModalClipboard } from "../modal-clipboard"
+import { ModalNfc } from "../modal-nfc"
 import { isIos } from "../../utils/helper"
 
 function ScreenWithoutScrolling(props: ScreenProps) {
@@ -32,6 +33,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
       />
       {/* modalClipboard requires StoreContext which requiere being inside a navigator */}
       <ModalClipboard />
+      <ModalNfc />
       <Wrapper style={[preset.inner, style]}>{props.children}</Wrapper>
     </KeyboardAvoidingView>
   )
@@ -56,6 +58,7 @@ function ScreenWithScrolling(props: ScreenProps) {
         backgroundColor={props.backgroundColor}
       />
       <ModalClipboard />
+      <ModalNfc />
       <Wrapper style={[preset.outer, backgroundStyle]}>
         <ScrollView
           style={[preset.outer, backgroundStyle]}

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -24,6 +24,7 @@ export const networkVar = makeVar<INetwork | null>(null)
 
 export const prefCurrencyVar = makeVar<CurrencyType>("USD")
 export const modalClipboardVisibleVar = makeVar(false)
+export const modalNfcVisibleVar = makeVar(false)
 
 export const nextPrefCurrency = (): void => {
   const units: CurrencyType[] = ["BTC", "USD"]

--- a/app/i18n/en.json
+++ b/app/i18n/en.json
@@ -471,6 +471,7 @@
   },
   "MoveMoneyScreen": {
     "receive": "Receive",
+    "scanNFCTag": "Scan NFC Tag",
     "send": "Send",
     "title": "Home",
     "updateAvailable": "An update is available.\nTab to update now",
@@ -576,7 +577,8 @@
     "title": "Settings",
     "csvTransactionsError": "Unable to export transactions to csv. Something went wrong. If issue persists please contact support.",
     "lnurlNoUsername": "To generate an lnurl address you must first set a username.  Do you want to set a username now?",
-    "copyClipboardLnurl": "Lnurl address has been copied in the clipboard"
+    "copyClipboardLnurl": "Lnurl address has been copied in the clipboard",
+    "programNfcTag": "Program New NFC Tag"
   },
   "Languages": {
     "DEFAULT": "Default (OS)",
@@ -737,5 +739,17 @@
     "underLimit": "You can't send less than min amount",
     "commentRequired": "Comment required",
     "viewPrintable": "View Printable Version"
+  },
+  "nfc": {
+    "writeSuccess": "Your NFC Tag has been written successfully and can now be used.",
+    "TagNotWritable": "This tag has already been programmed once and cannot be re-programmed.",
+    "TagConnectionLost": "The connection to the NFC tag has been lost. Please keep the phone close to the tag a little longer when trying again.",
+    "TagUpdateFailure": "Writing to this tag failed. If this issue persists, it may be a faulty tag.",
+    "Timeout": "Reading this tag has timed out. Please try again.",
+    "Unexpected": "An unexpected error has occurred. Please try again.",
+    "SystemBusy": "The device is currently busy and unable to read the NFC tag. Please try again later.",
+    "FirstNdefInvalid": "This tag is unreadable.",
+    "RadioDisabled": "The NFC reader on this device is currently disabled. Please check your device settings.",
+    "UnsupportedFeature": "NFC is not currently supported on this type of device."
   }
 }

--- a/app/i18n/es.json
+++ b/app/i18n/es.json
@@ -502,6 +502,7 @@
     "needBankAccount": "Abra una cuenta de efectivo para activar",
     "openAccount": "Abre una cuenta",
     "receive": "Recibir",
+    "scanNFCTag": "Escanear NFC",
     "seeTransaction": "Supervisar la transacción de apertura",
     "send": "Enviar",
     "title": "Mover dinero",
@@ -613,7 +614,8 @@
     "title": "Configuración",
     "csvTransactionsError": "No se pueden exportar transacciones a csv. Algo salió mal. Si el problema persiste, póngase en contacto con el soporte.",
     "lnurlNoUsername": "Para generar una dirección lnurl primero debe establecer un nombre de usuario. ¿Desea establecer un nombre de usuario ahora?",
-    "copyClipboardLnurl": "La dirección de Lnurl se ha copiado en el portapapeles"
+    "copyClipboardLnurl": "La dirección de Lnurl se ha copiado en el portapapeles",
+    "programNfcTag": "Programar nueva tag NFC"
   },
   "Languages": {
     "DEFAULT": "Predeterminado (OS)",
@@ -769,5 +771,17 @@
     "underLimit": "No se puede enviar una cantidad inferior a la mínima",
     "commentRequired": "Se requiere una nota",
     "viewPrintable": "Ver Versión Imprimible"
+  },
+  "nfc": {
+    "writeSuccess": "Su tag NFC se ha escrito con éxito y ahora se puede utilizar.",
+    "TagNotWritable": "Esta tag ya se programó una vez y no se puede volver a programar.",
+    "TagConnectionLost": "Se ha perdido la conexión con la tag NFC. Mantenga el teléfono cerca de la tag un poco más cuando vuelva a intentarlo.",
+    "TagUpdateFailure": "Error al escribir en esta tag. Si este problema persiste, puede ser una tag defectuosa.",
+    "Timeout": "Se agotó el tiempo de lectura de esta etiqueta. Inténtalo de nuevo.",
+    "Unexpected": "Ocurrió un error inesperado. Inténtalo de nuevo.",
+    "SystemBusy": "El dispositivo está actualmente ocupado y no puede leer la tag NFC. Por favor, inténtelo de nuevo más tarde.",
+    "FirstNdefInvalid": "Esta tag es ilegible.",
+    "RadioDisabled": "El lector de NFC en este dispositivo está deshabilitado actualmente. Verifique la configuración de su dispositivo.",
+    "UnsupportedFeature": "NFC no es compatible con este tipo de dispositivo."
   }
 }

--- a/app/screens/move-money-screen/move-money-screen.tsx
+++ b/app/screens/move-money-screen/move-money-screen.tsx
@@ -262,8 +262,8 @@ export const MoveMoneyScreen: ScreenType = ({
                 },
               ],
             )
-            break  
-        }      
+            break
+        }
       } else {
         Alert.alert(
           translate("ScanningQRCodeScreen.invalidTitle"),
@@ -282,7 +282,7 @@ export const MoveMoneyScreen: ScreenType = ({
 
   const scanNfcTag = async () => {
     const nfcTagReadResult = await readNfcTag()
-        
+
     if (nfcTagReadResult.success) {
       await decodeInvoice(nfcTagReadResult.data)
     } else if (nfcTagReadResult.errorMessage != "UserCancel") {
@@ -301,7 +301,7 @@ export const MoveMoneyScreen: ScreenType = ({
   const onMenuClick = async (target) => {
     if (!hasToken) {
       setModalVisible(true)
-    } else if (target == 'scanningNFCTag') {
+    } else if (target == "scanningNFCTag") {
       await scanNfcTag()
     } else {
       navigation.navigate(target)

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -215,7 +215,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     const lnurlEncodedString = getLnurlPayEncodedString(username)
     const nfcTagWriteResult = await writeNfcTag(
       lnurlEncodedString,
-      LN_PAGE_DOMAIN + username,
+      GALOY_PAY_DOMAIN + username,
     )
 
     if (nfcTagWriteResult.success) {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -213,7 +213,10 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
 
   const writeNfcTagAction = async (username) => {
     const lnurlEncodedString = getLnurlPayEncodedString(username)
-    const nfcTagWriteResult = await writeNfcTag(lnurlEncodedString, LN_PAGE_DOMAIN + username)
+    const nfcTagWriteResult = await writeNfcTag(
+      lnurlEncodedString,
+      LN_PAGE_DOMAIN + username,
+    )
 
     if (nfcTagWriteResult.success) {
       Alert.alert(translate("common.success"), translate("nfc.writeSuccess"), [

--- a/app/utils/bech32.ts
+++ b/app/utils/bech32.ts
@@ -1,11 +1,11 @@
 import { bech32 } from "bech32"
-import { LN_PAGE_DOMAIN } from "../constants/support"
+import { GALOY_PAY_DOMAIN } from "../constants/support"
 
 export const getLnurlPayEncodedString = (username: string): string => {
   return bech32.encode(
     "lnurl",
     bech32.toWords(
-      Buffer.from(`${LN_PAGE_DOMAIN}/.well-known/lnurlp/${username}`, "utf8"),
+      Buffer.from(`${GALOY_PAY_DOMAIN}.well-known/lnurlp/${username}`, "utf8"),
     ),
     1500,
   )

--- a/app/utils/bech32.ts
+++ b/app/utils/bech32.ts
@@ -1,0 +1,12 @@
+import { bech32 } from "bech32"
+import { LN_PAGE_DOMAIN } from "../constants/support"
+
+export const getLnurlPayEncodedString = (username: string): string => {
+  return bech32.encode(
+    "lnurl",
+    bech32.toWords(
+      Buffer.from(`${LN_PAGE_DOMAIN}/.well-known/lnurlp/${username}`, "utf8"),
+    ),
+    1500,
+  )
+}

--- a/app/utils/nfc.ts
+++ b/app/utils/nfc.ts
@@ -1,0 +1,112 @@
+import NfcManager, { NfcTech, Ndef } from "react-native-nfc-manager"
+import { Platform } from "react-native"
+import { modalNfcVisibleVar } from "../graphql/client-only-query"
+
+type WriteNfcReturn = {
+  success: boolean
+  errorMessage: string
+}
+
+type ReadNfcReturn = {
+  success: boolean
+  data: string
+  errorMessage: string
+}
+
+export const writeNfcTag = async (
+  lnurlEncodedString: string,
+  payUrlString: string
+): Promise<WriteNfcReturn> => {
+  const result = {
+    success: false,
+    errorMessage: "",
+  }
+
+  try {
+    if (!NfcManager.isSupported()) {
+      result.errorMessage = "UnsupportedFeature"
+      return result
+    }
+
+    if (Platform.OS == "android") {
+      modalNfcVisibleVar(true)
+    }
+
+    await NfcManager.requestTechnology(NfcTech.Ndef)
+
+    const bytes = Ndef.encodeMessage([
+      Ndef.uriRecord(payUrlString),
+      Ndef.textRecord(lnurlEncodedString), 
+    ])
+
+    await NfcManager.ndefHandler.writeNdefMessage(bytes)
+
+    if (!__DEV__) {
+      await NfcManager.ndefHandler.makeReadOnly()
+    }
+
+    result.success = true
+  } catch (ex) {
+    result.errorMessage = ex.constructor.name
+  } finally {
+    NfcManager.cancelTechnologyRequest()
+  }
+
+  if (Platform.OS == "android") {
+    modalNfcVisibleVar(false)
+  }
+
+  if (!result.success) {
+    result.errorMessage = "Unexpected"
+  }
+
+  return result
+}
+
+export const readNfcTag = async (): Promise<ReadNfcReturn> => {
+  const result = {
+    success: false,
+    data: "",
+    errorMessage: "",
+  }
+
+  NfcManager.start()
+
+  try {
+    if (!NfcManager.isSupported()) {
+      result.errorMessage = "UnsupportedFeature"
+      return result
+    }
+
+    if (Platform.OS == "android") {
+      modalNfcVisibleVar(true)
+    }
+
+    await NfcManager.requestTechnology(NfcTech.Ndef)
+
+    const tag = await NfcManager.getTag()
+    const message = tag?.ndefMessage?.find(el => 
+      Ndef.text.decodePayload(new Uint8Array(el.payload))
+      .indexOf('lnurl') !== -1
+    )
+
+    if (message && message?.payload) {
+      result.data = Ndef.text.decodePayload(new Uint8Array(message.payload))
+      result.success = true
+    }
+  } catch (ex) {
+    result.errorMessage = ex.constructor.name
+  } finally {
+    NfcManager.cancelTechnologyRequest()
+  }
+
+  if (Platform.OS == "android") {
+    modalNfcVisibleVar(false)
+  }
+
+  if (!result.success) {
+    result.errorMessage = "Unexpected"
+  }
+
+  return result
+}

--- a/app/utils/nfc.ts
+++ b/app/utils/nfc.ts
@@ -15,7 +15,7 @@ type ReadNfcReturn = {
 
 export const writeNfcTag = async (
   lnurlEncodedString: string,
-  payUrlString: string
+  payUrlString: string,
 ): Promise<WriteNfcReturn> => {
   const result = {
     success: false,
@@ -36,7 +36,7 @@ export const writeNfcTag = async (
 
     const bytes = Ndef.encodeMessage([
       Ndef.uriRecord(payUrlString),
-      Ndef.textRecord(lnurlEncodedString), 
+      Ndef.textRecord(lnurlEncodedString),
     ])
 
     await NfcManager.ndefHandler.writeNdefMessage(bytes)
@@ -85,9 +85,8 @@ export const readNfcTag = async (): Promise<ReadNfcReturn> => {
     await NfcManager.requestTechnology(NfcTech.Ndef)
 
     const tag = await NfcManager.getTag()
-    const message = tag?.ndefMessage?.find(el => 
-      Ndef.text.decodePayload(new Uint8Array(el.payload))
-      .indexOf('lnurl') !== -1
+    const message = tag?.ndefMessage?.find(
+      (el) => Ndef.text.decodePayload(new Uint8Array(el.payload)).indexOf("lnurl") !== -1,
     )
 
     if (message && message?.payload) {

--- a/ios/GaloyApp/GaloyApp.entitlements
+++ b/ios/GaloyApp/GaloyApp.entitlements
@@ -10,6 +10,11 @@
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>NDEF</string>
+		<string>TAG</string>
+	</array>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
 </dict>

--- a/ios/GaloyApp/Info.plist
+++ b/ios/GaloyApp/Info.plist
@@ -143,5 +143,7 @@
 	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NFCReaderUsageDescription</key>
+	<string>We need to use NFC</string>
 </dict>
 </plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -348,6 +348,8 @@ PODS:
     - React-Core
   - react-native-netinfo (7.1.7):
     - React-Core
+  - react-native-nfc-manager (3.13.0):
+    - React
   - react-native-qrcode-local-image (1.0.4):
     - React
   - react-native-restart (0.0.22):
@@ -540,6 +542,7 @@ DEPENDENCIES:
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - react-native-maps (from `../node_modules/react-native-maps`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
+  - react-native-nfc-manager (from `../node_modules/react-native-nfc-manager`)
   - "react-native-qrcode-local-image (from `../node_modules/@remobile/react-native-qrcode-local-image`)"
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -658,6 +661,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-maps"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
+  react-native-nfc-manager:
+    :path: "../node_modules/react-native-nfc-manager"
   react-native-qrcode-local-image:
     :path: "../node_modules/@remobile/react-native-qrcode-local-image"
   react-native-restart:
@@ -785,6 +790,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 869530859570f2af86ae57bc48886a5e2367a825
   react-native-maps: a421fe6aeb74279597c4ea9598f25796108e2d89
   react-native-netinfo: 27f287f2d191693f3b9d01a4273137fcf91c3b5d
+  react-native-nfc-manager: 001c3a98e68efd57b7fb04b1837ab06ca7243238
   react-native-qrcode-local-image: a16d554baf5cf5c04da86b464d99cf658e215c52
   react-native-restart: 733a51ad137f15b0f8dc34c4082e55af7da00979
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-native-localize": "^2.1.5",
     "react-native-maps": "0.29.4",
     "react-native-modal": "^13.0.0",
+    "react-native-nfc-manager": "^3.13.0",
     "react-native-phone-number-input": "^2.1.0",
     "react-native-push-notification": "^8.1.1",
     "react-native-qrcode-svg": "^6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,6 +1685,28 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@expo/config-plugins@^4.0.16":
+  version "4.0.16"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.16.tgz#832fb533245180c6dfd82fd359474f68a8e857b2"
+  integrity sha512-UTyE5JTBatMSwoOZCtX0u2H3zkp/ybMftc1228ARMop35Dbq+sYO11Ym3MrY5RPh8PYPofokDSOvoUq1jjORXw==
+  dependencies:
+    "@expo/config-types" "^43.0.1"
+    "@expo/json-file" "8.2.34"
+    "@expo/plist" "0.0.17"
+    "@expo/sdk-runtime-versions" "^1.0.0"
+    "@react-native/normalize-color" "^2.0.0"
+    chalk "^4.1.2"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    semver "^7.3.5"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "0.4.23"
+
 "@expo/config-plugins@^4.0.3":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.4.tgz#2c8b06e92507ccea4be24b0347a0aa013747eb58"
@@ -1711,10 +1733,24 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-43.0.0.tgz#e283a4a1b72a655a6a2a745bd277caef58c8edb0"
   integrity sha512-GBbEtLdGX40DJ1wTixWtOHseupA5xWclV57KNZ58ebauWAOyK3Fyni7GD2OCOzxTIFi1nSjqgO9JlMp3ayP4Tw==
 
+"@expo/config-types@^43.0.1":
+  version "43.0.1"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-43.0.1.tgz#3e047dccb371741a540980eaff26fb0c95039c30"
+  integrity sha512-EtllpCGDdB/UdwAIs5YXJwBLpbFQNdlLLrxIvoILA9cXrpQMWkeDCT9lQPJzFRMFcLUaMuGvkzX2tR4tx5EQFQ==
+
 "@expo/json-file@8.2.33":
   version "8.2.33"
   resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.33.tgz#78f56f33a2cfb807b23c81e00237a33159aa1f32"
   integrity sha512-CDnhjdirUs6OdN5hOSTJ2y3i9EiJMk7Z5iDljC5xyCHCrUex7oyI8vbRsZEojAahxZccgL/PrO+CjakiFFWurg==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    json5 "^1.0.1"
+    write-file-atomic "^2.3.0"
+
+"@expo/json-file@8.2.34":
+  version "8.2.34"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.34.tgz#2f24e90a677195f7a81e167115460eb2902c3130"
+  integrity sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==
   dependencies:
     "@babel/code-frame" "~7.10.4"
     json5 "^1.0.1"
@@ -1728,6 +1764,20 @@
     "@xmldom/xmldom" "~0.7.0"
     base64-js "^1.2.3"
     xmlbuilder "^14.0.0"
+
+"@expo/plist@0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.17.tgz#0f6c594e116f45a28f5ed20998dadb5f3429f88b"
+  integrity sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==
+  dependencies:
+    "@xmldom/xmldom" "~0.7.0"
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+
+"@expo/sdk-runtime-versions@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
+  integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
 
 "@galoymoney/react-native-geetest-module@^0.1.3":
   version "0.1.3"
@@ -13759,6 +13809,13 @@ react-native-modal@^13.0.0:
   dependencies:
     prop-types "^15.6.2"
     react-native-animatable "1.3.3"
+
+react-native-nfc-manager@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-nfc-manager/-/react-native-nfc-manager-3.13.0.tgz#e4c85f9b9777bf8197669c71d746a0eca2ada631"
+  integrity sha512-5oAfvt0xfmALzWFT+sbWU/GmG8kjW9ZFPh0LQl57ogXbWIiWfVdjJYMIuAL/LfubB2CxwsdlFC49dXI2bPiNEw==
+  dependencies:
+    "@expo/config-plugins" "^4.0.16"
 
 react-native-phone-number-input@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This feature adds the ability to program & scan NFC tags that users can use to pay instead of QR codes.

From the Settings Screen, users can now program a NFC Tag that will encode 2 things to the tag: a bech32 encoded LNURL-pay address and a Galoy Wallet username (as a URL i.e. https://ln.bitcoinbeach.com/${user}).

From the Move Money Screen, users can now click "Scan NFC Tag". Once clicked, they tap their phone to a programmed NFC Tag, which will then populate the Send Money screen appropriately with the LNURL-pay address.

From the device's Home Screen, users can tap their phone to a programmed NFC Tag, which will prompt the user to open the Galoy instance app. Once opened, the app will navigate to the Send Money screen and populate appropriately with the username. 