### PR TITLE
fix: Make contact header smaller so fits better on smaller screens

### DIFF
--- a/app/screens/contacts-screen/contacts-detail.tsx
+++ b/app/screens/contacts-screen/contacts-detail.tsx
@@ -22,7 +22,7 @@ const styles = EStyleSheet.create({
 
   amount: {
     color: palette.white,
-    fontSize: "40rem",
+    fontSize: "36rem",
   },
 
   amountSecondary: {
@@ -111,7 +111,7 @@ export const ContactsDetailScreenJSX: ScreenType = ({
       <View style={[styles.amountView, { backgroundColor: palette.green }]}>
         <Icon
           name="ios-person-outline"
-          size={94}
+          size={86}
           color={palette.white}
           style={styles.icon}
         />

--- a/app/screens/contacts-screen/contacts-detail.tsx
+++ b/app/screens/contacts-screen/contacts-detail.tsx
@@ -32,8 +32,7 @@ const styles = EStyleSheet.create({
 
   amountView: {
     alignItems: "center",
-    paddingBottom: "24rem",
-    paddingTop: "48rem",
+    paddingBottom: "6rem",
   },
 
   icon: { margin: 0 },


### PR DESCRIPTION
As reported in issue #355 the contact screen was not displaying properly on smaller devices. I have reduced the padding in the header and the user icon / contact text size so that it gives more room for the bottom transaction section on smaller devices.

![image](https://user-images.githubusercontent.com/85003930/156498564-bd1a8ba5-5d51-47d6-aa91-a1c0273915f4.png)

