### PR TITLE
Fix final 'keep digging' button on android

### DIFF
--- a/app/screens/earns-screen/section-completed.tsx
+++ b/app/screens/earns-screen/section-completed.tsx
@@ -23,7 +23,7 @@ const styles = EStyleSheet.create({
     backgroundColor: palette.white,
     borderRadius: 32,
     marginTop: "24rem",
-    width: "100%",
+    width: "75%",
   },
 
   container: {
@@ -51,6 +51,8 @@ const styles = EStyleSheet.create({
     color: palette.lightBlue,
     fontSize: "18rem",
     fontWeight: "bold",
+    flex: 1,
+    justifyContent: "center",
   },
 })
 


### PR DESCRIPTION
Mentioned in issue #71 the 'Keep digging!' button on the final quiz screen for Android was not centered. I have updated this so it is now centered:

![image](https://user-images.githubusercontent.com/85003930/156505315-9c9c3521-439e-47d5-a952-a28dcdb85e4b.png)
