### PR TITLE
fix: fix userLogin action while loading

### DIFF
--- a/app/screens/phone-auth-screen/phone-auth.tsx
+++ b/app/screens/phone-auth-screen/phone-auth.tsx
@@ -412,6 +412,9 @@ export const WelcomePhoneValidationScreen: ScreenType = ({
   }, [])
 
   const send = async () => {
+    if (loading) {
+      return
+    }
     if (code.length !== 6) {
       toastShow(translate("WelcomePhoneValidationScreen.need6Digits"))
       return


### PR DESCRIPTION
We had some alerts recently due to duplicate key errors in mongodb.  We traced it back to duplicate login calls from the mobile app.  We didn't have protection preventing the user from using the enter key to submit the form while the form was loading.