### PR TITLE
fix: broken transaction details on transactions screen

### DIFF
--- a/app/graphql/query.ts
+++ b/app/graphql/query.ts
@@ -111,6 +111,7 @@ export const TRANSACTIONS_LIST = gql`
         id
         wallets {
           id
+          walletCurrency
           transactions(first: $first, after: $after) {
             ...TransactionList
           }

--- a/app/screens/transaction-screen/transaction-screen.tsx
+++ b/app/screens/transaction-screen/transaction-screen.tsx
@@ -92,7 +92,12 @@ export const TransactionHistoryScreenDataInjected: ScreenType = ({
     return null
   }
 
-  const { edges, pageInfo } = data.me.defaultAccount.wallets[0].transactions
+  const walletCurrency = data.me.defaultAccount.wallets[0].walletCurrency
+  const { edges: edgesRaw, pageInfo } = data.me.defaultAccount.wallets[0].transactions
+  const edges = edgesRaw.map((edge) => ({
+    ...edge,
+    node: { ...edge.node, walletType: walletCurrency },
+  }))
   const lastDataCursor = edges.length > 0 ? edges[edges.length - 1].cursor : null
   let lastSeenCursor =
     transactionsRef.current.length > 0


### PR DESCRIPTION
## Description

I was taking a look at the code and came across this missing property on the transactions screen. Not sure if this was the right place for this fix, but thought I'd push it anyway in case it helps.

### Backend question

I also noticed that USD transactions aren't being added to the transactions screen as yet and I remember David bringing up an issue with being able to paginate across different wallets while maintaining the timestamp ordering.

Should we look into whether it's feasible to add something like  `transactionsByAccount` or `transactionsByWallets(WalletId[])` mutations to help get around this from the backend?