### PR TITLE
fix: update delta calc in price graph

### DIFF
--- a/app/components/price-graph/price-graph.tsx
+++ b/app/components/price-graph/price-graph.tsx
@@ -127,11 +127,7 @@ export const PriceGraph: ComponentType = ({
     price =
       (currentPriceData.base / 10 ** currentPriceData.offset) *
       multiple(currentPriceData.currencyUnit)
-    delta =
-      (price -
-        (startPriceData.base / 10 ** startPriceData.offset) *
-          multiple(startPriceData.currencyUnit)) /
-      price
+    delta = currentPriceData.base / startPriceData.base - 1
     color = delta > 0 ? { color: palette.green } : { color: palette.red }
   } catch (err) {
     // FIXME proper Loader


### PR DESCRIPTION
Update delta calculation in price graph. Please notice that we dont need to convert prices to do the calculation 