### PR TITLE
fix: send bitcoin flow

### DIFF
--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -57,7 +57,8 @@ export type RootStackParamList = {
     destination: string
     recipientWalletId?: string
     payerWalletDescriptor: WalletDescriptor<WalletCurrency>
-    paymentAmount?: PaymentAmount<WalletCurrency>
+    paymentAmountInBtc?: PaymentAmount<WalletCurrency.BTC>
+    paymentAmountInUsd?: PaymentAmount<WalletCurrency.USD>
     note?: string
     paymentType: PaymentType
     sameNode: boolean

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -389,14 +389,10 @@ const SendBitcoinDetailsScreen = ({
   const showWalletPicker = !usdDisabled && wallets.length > 1
 
   const goToNextScreen = async () => {
-    let invoice: string | undefined,
-      paymentAmount: PaymentAmount<WalletCurrency> | undefined
+    let invoice: string | undefined
 
-    if (isFixedAmountInvoice) {
-      paymentAmount = fixedAmount
-    } else {
-      paymentAmount = amountCurrency === WalletCurrency.BTC ? satAmount : centAmount
-    }
+    const paymentAmountInBtc = satAmount
+    const paymentAmountInUsd = centAmount
 
     if (paymentType === "lnurl") {
       try {
@@ -412,18 +408,20 @@ const SendBitcoinDetailsScreen = ({
       }
     }
 
+    const payerWalletDescriptor = {
+      id: fromWallet.id,
+      currency:
+        fromWallet.__typename === "BTCWallet" ? WalletCurrency.BTC : WalletCurrency.USD,
+    }
     navigation.navigate("sendBitcoinConfirmation", {
       lnurlInvoice: invoice,
       fixedAmount,
-      paymentAmount,
+      paymentAmountInBtc,
+      paymentAmountInUsd,
       recipientWalletId,
       paymentType,
       destination,
-      payerWalletDescriptor: {
-        id: fromWallet.id,
-        currency:
-          fromWallet.__typename === "BTCWallet" ? WalletCurrency.BTC : WalletCurrency.USD,
-      },
+      payerWalletDescriptor,
       note,
       sameNode,
     })


### PR DESCRIPTION
- ensure destination is properly passed across screens
- ensure usd + btc amounts are present for calculating fees. Currently it is trying to calculate the fee using a paymentAmount that hasn't been converted yet to the proper currency and is resulting in NaN. This is fixed by passing in both usd and btc values into the "send-bitcoin-confirmation" screen