### PR TITLE
fix: Fixed scan pay URL on android

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.6",
-    "@galoymoney/client": "^0.1.33",
+    "@galoymoney/client": "^0.1.39",
     "@galoymoney/react-native-geetest-module": "^0.1.3",
     "@react-native-async-storage/async-storage": "^1.17.6",
     "@react-native-community/clipboard": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,10 +1880,10 @@
   resolved "https://registry.yarnpkg.com/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz#d7ebd21b19f1c6b0395e50d78da4416941c57f7c"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
 
-"@galoymoney/client@^0.1.33":
-  version "0.1.37"
-  resolved "https://registry.yarnpkg.com/@galoymoney/client/-/client-0.1.37.tgz#8b80e80e5322720735a872a3ec449a16c8a2d9ef"
-  integrity sha512-DRRUWKKM5SR9onJknnGI2eRUf1xbBVQvvGi8yvll7t7hZDAzkFngY+MRZXPSi53g48yXiP/pnu8LA699E4jHtg==
+"@galoymoney/client@^0.1.39":
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/@galoymoney/client/-/client-0.1.39.tgz#e879ee5de4f30139e3dc2342c76c7277b1af7e83"
+  integrity sha512-uI/rJL1/xP8iK5ZQA80Akb+bc/dDeTFl254E7yT7nOQfXAbDOpjN/n3hbeC8BLSk7ptmZj5BQk20OGPAbOykJA==
 
 "@galoymoney/react-native-geetest-module@^0.1.3":
   version "0.1.3"


### PR DESCRIPTION
We saw some behaviour differences when trying to parse the pay urls on android/ios.  This PR upgrades the client which has a [fix for the issue](https://github.com/GaloyMoney/galoy-client/pull/67).