### PR TITLE
fix: Fixed crash when english is selected language

### DIFF
--- a/app/components/transaction-date/transaction-date.tsx
+++ b/app/components/transaction-date/transaction-date.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Text } from "react-native"
 import moment from "moment"
-import { GaloyGQL, getLocale, translateUnknown as translate } from "@galoymoney/client"
+import { GaloyGQL, translateUnknown as translate } from "@galoymoney/client"
 
 type TransactionDateProps = {
   tx: GaloyGQL.Transaction
@@ -14,7 +14,6 @@ export const TransactionDate = ({
   friendly = false,
   diffDate = false,
 }: TransactionDateProps) => {
-  moment.locale(getLocale())
   const { status, createdAt } = tx
   if (status === "PENDING") {
     return <Text>{translate("common.pending")?.toUpperCase()}</Text>


### PR DESCRIPTION
The client returns the locale as `en-US` when English is the preferred user language.  This causes errors in moment which completely crashes the app as can be seen here https://stackoverflow.com/a/69605154.  I don't think setting the locale is actually necessary because the format operation we are using is aware of timezones.