### PR TITLE
fix: Fixed lnurl payments issue

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -415,7 +415,7 @@ const SendBitcoinDetailsScreen = ({
     }
     navigation.navigate("sendBitcoinConfirmation", {
       lnurlInvoice: invoice,
-      fixedAmount,
+      fixedAmount: paymentType === "lnurl" ? paymentAmountInBtc : fixedAmount,
       paymentAmountInBtc,
       paymentAmountInUsd,
       recipientWalletId,


### PR DESCRIPTION
lnurl payments were broken since the refactor since the `useFee` hook was being passed a null value.  The fix was to ensure that lnurl invoices are being treated as fixed amount invoices.