### PR TITLE
fix: Added momentjs translation files for locales

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -51,6 +51,11 @@ import {
   AppConfiguration,
   loadAppConfig,
 } from "./context/app-configuration"
+// import moment locale files so we can display dates in the user's language
+import "moment/locale/es"
+import "moment/locale/fr-ca"
+import "moment/locale/pt-br"
+
 export const BUILD_VERSION = "build_version"
 
 export const { link: linkNetworkStatusNotifier, useApolloNetworkStatus } =

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -1,5 +1,4 @@
 import { InMemoryCache } from "@apollo/client"
-import "moment/locale/es"
 
 export const cache = new InMemoryCache({
   typePolicies: {


### PR DESCRIPTION
Momentjs isn't currently displaying dates correctly for French Canadian or Brazilian Portuguese translations.  We need to import the translation files from momentjs library.