### PR TITLE
fix: dont trigger clipboard on own invoice

### DIFF
--- a/app/components/modal-clipboard/modal-clipboard.tsx
+++ b/app/components/modal-clipboard/modal-clipboard.tsx
@@ -84,8 +84,15 @@ export const ModalClipboard: ComponentType = () => {
   const { myPubKey, username } = useMainQuery()
   const open = async () => {
     modalClipboardVisibleVar(false)
+    const clipboardString = await Clipboard.getString()
+    cache.writeQuery({
+      query: LAST_CLIPBOARD_PAYMENT,
+      data: {
+        lastClipboardPayment: clipboardString,
+      },
+    })
     navigation.navigate("sendBitcoinDestination", {
-      payment: await Clipboard.getString(),
+      payment: clipboardString,
     })
   }
 

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -2,7 +2,6 @@ import { usePriceConversion, useSubscriptionUpdates } from "@app/hooks"
 import useMainQuery from "@app/hooks/use-main-query"
 import { getFullUri, TYPE_LIGHTNING_BTC, TYPE_BITCOIN_ONCHAIN } from "@app/utils/wallet"
 import { GaloyGQL, useMutation } from "@galoymoney/client"
-import Clipboard from "@react-native-community/clipboard"
 import React, { useCallback, useEffect, useState } from "react"
 import { Alert, Pressable, Share, TextInput, View } from "react-native"
 import { Button, Text } from "react-native-elements"
@@ -20,6 +19,7 @@ import ChainIcon from "@app/assets/icons/chain.svg"
 import NoteIcon from "@app/assets/icons/note.svg"
 import { toastShow } from "@app/utils/toast"
 import { translate } from "@app/utils/translate"
+import { copyPaymentInfoToClipboard } from "@app/utils/clipboard"
 
 const styles = EStyleSheet.create({
   container: {
@@ -297,7 +297,7 @@ const ReceiveBtc = () => {
   })
 
   const copyToClipboard = useCallback(() => {
-    Clipboard.setString(paymentFullUri)
+    copyPaymentInfoToClipboard(paymentFullUri)
     toastShow({
       message: translate("ReceiveBitcoinScreen.copyClipboard"),
       type: "success",

--- a/app/screens/receive-bitcoin-screen/receive-usd.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-usd.tsx
@@ -14,7 +14,6 @@ import { Button, Text } from "react-native-elements"
 import EStyleSheet from "react-native-extended-stylesheet"
 import QRView from "./qr-view"
 import Icon from "react-native-vector-icons/Ionicons"
-import Clipboard from "@react-native-community/clipboard"
 import { FakeCurrencyInput } from "react-native-currency-input"
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view"
 import { usdAmountDisplay } from "@app/utils/currencyConversion"
@@ -22,6 +21,7 @@ import CalculatorIcon from "@app/assets/icons/calculator.svg"
 import ChevronIcon from "@app/assets/icons/chevron.svg"
 import NoteIcon from "@app/assets/icons/note.svg"
 import { toastShow } from "@app/utils/toast"
+import { copyPaymentInfoToClipboard } from "@app/utils/clipboard"
 import moment from "moment"
 import { translate } from "@app/utils/translate"
 
@@ -284,7 +284,9 @@ const ReceiveUsd = () => {
   }, [invoice?.paymentRequest])
 
   const copyToClipboard = () => {
-    Clipboard.setString(getFullUri({ input: invoice?.paymentRequest, prefix: false }))
+    copyPaymentInfoToClipboard(
+      getFullUri({ input: invoice?.paymentRequest, prefix: false }),
+    )
     toastShow({
       message: translate("ReceiveBitcoinScreen.copyClipboard"),
       type: "success",

--- a/app/screens/settings-screen/lnurl-screen.tsx
+++ b/app/screens/settings-screen/lnurl-screen.tsx
@@ -15,11 +15,11 @@ import { GALOY_PAY_DOMAIN } from "../../constants/support"
 import { bech32 } from "bech32"
 import QRCode from "react-native-qrcode-svg"
 import { Button, Text } from "react-native-elements"
-import Clipboard from "@react-native-community/clipboard"
 import Icon from "react-native-vector-icons/MaterialCommunityIcons"
 import { color } from "@app/theme"
 import { toastShow } from "@app/utils/toast"
 import { translate } from "@app/utils/translate"
+import { copyPaymentInfoToClipboard } from "@app/utils/clipboard"
 
 const styles = EStyleSheet.create({
   container: {
@@ -57,7 +57,7 @@ type Props = {
 }
 
 const copyToClipboard = (str) => {
-  Clipboard.setString(str)
+  copyPaymentInfoToClipboard(str)
   toastShow({
     message: translate("SettingsScreen.copyClipboardLnurl"),
     type: "success",

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -21,6 +21,7 @@ import useMainQuery from "@app/hooks/use-main-query"
 import crashlytics from "@react-native-firebase/crashlytics"
 import ContactModal from "@app/components/contact-modal/contact-modal"
 import { translate } from "@app/utils/translate"
+import { copyPaymentInfoToClipboard } from "@app/utils/clipboard"
 
 type Props = {
   navigation: StackNavigationProp<RootStackParamList, "settings">
@@ -189,7 +190,7 @@ export const SettingsScreenJSX: ScreenType = (params: SettingsScreenProps) => {
     loadingCsvTransactions,
   } = params
   const copyToClipBoard = (username) => {
-    Clipboard.setString(GALOY_PAY_DOMAIN + username)
+    copyPaymentInfoToClipboard(GALOY_PAY_DOMAIN + username)
     Clipboard.getString().then((data) =>
       toastShow({ message: translate("tippingLink.copied", { data }), type: "success" }),
     )

--- a/app/utils/clipboard.ts
+++ b/app/utils/clipboard.ts
@@ -46,3 +46,13 @@ export const showModalClipboardIfValidPayment = async ({
 
   modalClipboardVisibleVar(true)
 }
+
+export const copyPaymentInfoToClipboard = (paymentInfo: string): void => {
+  cache.writeQuery({
+    query: LAST_CLIPBOARD_PAYMENT,
+    data: {
+      lastClipboardPayment: paymentInfo,
+    },
+  })
+  Clipboard.setString(paymentInfo)
+}


### PR DESCRIPTION
Currently if a user creates an invoice, leaves the app, and then returns, the clipboard modal will ask if they want to open the invoice. This PR prevents the clipboard modal from being triggered for invoices created by the application.