### PR TITLE
fix: Fixed typed translations on android

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -2,7 +2,7 @@
 // Welcome to the main entry point of the app.
 //
 // In this file, we'll be kicking off our app or storybook.
-
+import "intl-pluralrules"
 import {
   ApolloClient,
   ApolloProvider,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "currency.js": "^2.0.2",
     "graphql": "^16.5.0",
     "intl": "^1.2.5",
+    "intl-pluralrules": "^1.3.1",
     "js-lnurl": "^0.3.0",
     "jwt-decode": "^3.1.2",
     "lnurl-pay": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9874,6 +9874,11 @@ interpret@^2.0.0:
   resolved "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+intl-pluralrules@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-1.3.1.tgz#304ec4038a597894f6616633cbf5e66fb3dbee04"
+  integrity sha512-sNYPls1Q4fyN0EGLFVJ7TIuaMWln01LupLozfIBt69rHK0DHehghMSz6ejfnSklgRddnyQSEaQPIU6d9TCKH3w==
+
 intl@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"


### PR DESCRIPTION
The `typesafe-i18n` library makes use of [Intl.PluralRules](https://github.com/ivanhofer/typesafe-i18n/blob/3035050922a33d87c817114b0ee3789cd174b5bd/packages/runtime/src/util.object.mts#L25) which currently [isn't supported by hermes](https://hermesengine.dev/docs/intl/#not-yet-supported) (although weirdly seems to be supported by the ios version of hermes).  I've introduced a [polyfill](https://github.com/eemeli/intl-pluralrules) until this namespace is supported in hermes.