### PR TITLE
fix: Fixed default language selection

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -55,6 +55,7 @@ import { AuthenticationContext } from "./store/authentication-context"
 import { LocalizationContextProvider } from "./store/localization-context"
 import { loadAllLocales } from "./i18n/i18n-util.sync"
 import TypesafeI18n from "./i18n/i18n-react"
+import { customLocaleDetector } from "./utils/locale-detector"
 export const BUILD_VERSION = "build_version"
 
 export const { link: linkNetworkStatusNotifier, useApolloNetworkStatus } =
@@ -308,7 +309,7 @@ export const App = (): JSX.Element => {
     <AuthenticationContext.Provider value={{ isAppLocked, setAppUnlocked, setAppLocked }}>
       <ApolloProvider client={apolloClient}>
         <PriceContextProvider>
-          <TypesafeI18n locale={"en"}>
+          <TypesafeI18n locale={customLocaleDetector()}>
             <LocalizationContextProvider>
               <ErrorBoundary FallbackComponent={ErrorScreen}>
                 <NavigationContainer

--- a/app/utils/locale-detector.ts
+++ b/app/utils/locale-detector.ts
@@ -1,12 +1,19 @@
 import * as RNLocalize from "react-native-localize"
 
 export const customLocaleDetector = () => {
-  if (RNLocalize.getLocales()) {
-    return RNLocalize.getLocales()?.map((locale) => {
-      return getLanguageFromLocale(locale.languageCode)
-    })
+  if (
+    RNLocalize.getLocales() &&
+    RNLocalize.getLocales().some(
+      (locale) =>
+        locale.languageCode?.startsWith("en") ||
+        locale.languageCode?.startsWith("es") ||
+        locale.languageCode?.startsWith("fr") ||
+        locale.languageCode?.startsWith("pt"),
+    )
+  ) {
+    return getLanguageFromLocale(RNLocalize.getLocales()[0].languageCode)
   }
-  return ["es"]
+  return "en"
 }
 
 export const getLanguageFromLocale = (locale: string) => {


### PR DESCRIPTION
I tested the translation changes on a device using browserstack and changed the locale to Spanish at the OS level - this should have made the default language Spanish on a device which wasn't logged in (and so didn't have a preferred language set using the API), but it defaulted to English instead.  I realised that I forgot to use the `customLocaleDetector` which I wrote when initially setting the locale.  I think this should fix it.