### PR TITLE
fix: Added max reconnection on websocket

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -168,6 +168,7 @@ export const App = (): JSX.Element => {
         uri: GRAPHQL_WS_URI,
         options: {
           reconnect: true,
+          reconnectionAttempts: 3,
           connectionParams: {
             authorization: getAuthorizationHeader(),
           },


### PR DESCRIPTION
The default for this value is [infinity](https://github.com/apollographql/subscriptions-transport-ws/blob/323e3af83f13512d320125ae2a00be25433fb9d0/src/client.ts#L114).  I'm hoping this will improve the rate limiting of websocket connections we are seeing in the tracing.
