### PR TITLE
chore: bump galoy-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.6.6",
-    "@galoymoney/client": "^0.1.56",
+    "@galoymoney/client": "^0.1.57",
     "@galoymoney/react-native-geetest-module": "^0.1.3",
     "@react-native-async-storage/async-storage": "^1.17.7",
     "@react-native-community/clipboard": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,10 +1484,10 @@
   resolved "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz"
   integrity sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==
 
-"@galoymoney/client@^0.1.56":
-  version "0.1.56"
-  resolved "https://registry.yarnpkg.com/@galoymoney/client/-/client-0.1.56.tgz#55984b22a1b9acdefe7812445db7ed27d891078e"
-  integrity sha512-bOI7QeXt284dIWqmGgE01/+bRPpGj366or3B6mFLi+srJl4Bjt+Gq0LQB44dhzeWzVR3DjQlvo5pmXn1vsPyPQ==
+"@galoymoney/client@^0.1.57":
+  version "0.1.57"
+  resolved "https://registry.yarnpkg.com/@galoymoney/client/-/client-0.1.57.tgz#17b8cd0623a3bf9d110ce248c4c3a09d698409f3"
+  integrity sha512-h0RrgakzcvL9qN+MKeSkOqlQ1AURu7rjZ/HBitgb1rdrwj7mTO+Vp3ppAnU/XNk8/qbnaAYdw5tgmN52i8+2TQ==
 
 "@galoymoney/react-native-geetest-module@^0.1.3":
   version "0.1.4"


### PR DESCRIPTION
## Description

This pulls in an upstream fix that allows for case-sensitive lightning addresses