### PR TITLE
fix: screen navigation quirk

### DIFF
--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -1,4 +1,4 @@
-import { useIsFocused, useNavigationState } from "@react-navigation/native"
+import { useIsFocused } from "@react-navigation/native"
 import * as React from "react"
 import {
   Alert,
@@ -118,7 +118,6 @@ const galoyAddressFromLnurlParams = (
 export const ScanningQRCodeScreen: ScreenType = ({
   navigation,
 }: ScanningQRCodeScreenProps) => {
-  const index = useNavigationState((state) => state.index)
   const [pending, setPending] = React.useState(false)
   const { appConfig } = useAppConfig()
   const bitcoinNetwork = appConfig.galoyInstance.network
@@ -173,15 +172,9 @@ export const ScanningQRCodeScreen: ScreenType = ({
 
             switch (lnurlParams.tag) {
               case "payRequest":
-                if (index <= 1) {
-                  navigation.replace("sendBitcoinDestination", {
-                    payment: galoyAddressFromLnurlParams(lnurlParams) || data,
-                  })
-                } else {
-                  navigation.navigate("sendBitcoinDestination", {
-                    payment: galoyAddressFromLnurlParams(lnurlParams) || data,
-                  })
-                }
+                navigation.replace("sendBitcoinDestination", {
+                  payment: galoyAddressFromLnurlParams(lnurlParams) || data,
+                })
                 break
               default:
                 Alert.alert(
@@ -198,15 +191,8 @@ export const ScanningQRCodeScreen: ScreenType = ({
                 )
                 break
             }
-          } else if (index <= 1) {
-            navigation.replace("sendBitcoinDestination", {
-              payment:
-                parsedDestination.paymentType === PaymentType.Intraledger
-                  ? parsedDestination.handle
-                  : data,
-            })
           } else {
-            navigation.navigate("sendBitcoinDestination", {
+            navigation.replace("sendBitcoinDestination", {
               payment:
                 parsedDestination.paymentType === PaymentType.Intraledger
                   ? parsedDestination.handle
@@ -232,22 +218,14 @@ export const ScanningQRCodeScreen: ScreenType = ({
         Alert.alert(err.toString())
       }
     },
-    [
-      LL.ScanningQRCodeScreen,
-      LL.common,
-      index,
-      myPubKey,
-      navigation,
-      pending,
-      bitcoinNetwork,
-    ],
+    [LL.ScanningQRCodeScreen, LL.common, myPubKey, navigation, pending, bitcoinNetwork],
   )
 
   React.useEffect(() => {
-    if (barcodes.length > 0 && barcodes[0].rawValue) {
+    if (barcodes.length > 0 && barcodes[0].rawValue && isFocused) {
       decodeInvoice(barcodes[0].rawValue)
     }
-  }, [barcodes, decodeInvoice])
+  }, [barcodes, decodeInvoice, isFocused])
 
   const handleInvoicePaste = async () => {
     try {


### PR DESCRIPTION
- When navigating from scan screen to send-bitcoin-destination the scan screen keeps operating in the background and causes several navigation actions to occur, this causes quirks in the send-bitcoin-destination-screen. This PR uses `navigation.replace` and `isFocused` to ensure that the scan screen does not operate in the background