### PR TITLE
chore: refactor paymentAmountToText function

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -1,5 +1,5 @@
 import DestinationIcon from "@app/assets/icons/destination.svg"
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from "react-native"
 import { palette } from "@app/theme"
 import { WalletCurrency } from "@app/types/amounts"
@@ -22,6 +22,7 @@ import { CommonActions } from "@react-navigation/native"
 import useMainQuery from "@app/hooks/use-main-query"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
+import crashlytics from "@react-native-firebase/crashlytics"
 
 const styles = StyleSheet.create({
   scrollView: {
@@ -191,6 +192,7 @@ const SendBitcoinConfirmationScreen = ({
   const { usdWalletBalance, btcWalletBalance, btcWalletValueInUsd } = useMainQuery()
   const isNoAmountInvoice = fixedAmount === undefined
   const [, setStatus] = useState<Status>(Status.IDLE)
+  const [feeDisplayText, setFeeDisplayText] = useState<string>("")
 
   const paymentAmountInWalletCurrency =
     payerWalletDescriptor.currency === WalletCurrency.BTC
@@ -231,7 +233,16 @@ const SendBitcoinConfirmationScreen = ({
     paymentAmount: paymentAmountInWalletCurrency,
   })
 
-  const feeDisplayText = fee.amount && paymentAmountToTextWithUnits(fee.amount)
+  useEffect(() => {
+    if (fee.amount) {
+      try {
+        setFeeDisplayText(paymentAmountToTextWithUnits(fee.amount))
+      } catch (error) {
+        setFeeDisplayText("Unable to calculate fee")
+        crashlytics().recordError(error)
+      }
+    }
+  }, [fee])
 
   const payIntraLedger = async () => {
     const { data, errorsMessage } = await intraLedgerPaymentSend({

--- a/app/utils/currencyConversion.ts
+++ b/app/utils/currencyConversion.ts
@@ -1,4 +1,5 @@
 import * as currencyFmt from "currency.js"
+import crashlytics from "@react-native-firebase/crashlytics"
 
 import { PaymentAmount, WalletCurrency } from "@app/types/amounts"
 
@@ -64,19 +65,32 @@ export const paymentAmountToText = (
   locale = "en-US",
 ): string => {
   if (paymentAmount.currency === WalletCurrency.USD) {
-    return (paymentAmount.amount / 100).toLocaleString(locale, {
-      style: "decimal",
-      maximumFractionDigits: 2,
-      minimumFractionDigits: 2,
-    })
+    try {
+      const amount = paymentAmount.amount / 100
+      return amount.toLocaleString(locale, {
+        style: "decimal",
+        maximumFractionDigits: 2,
+        minimumFractionDigits: 2,
+      })
+    } catch (error) {
+      console.error(error)
+      crashlytics().recordError(error)
+      return "USD formating error"
+    }
   }
 
   if (paymentAmount.currency === WalletCurrency.BTC) {
-    return paymentAmount.amount.toLocaleString(locale, {
-      style: "decimal",
-      maximumFractionDigits: 0,
-      minimumFractionDigits: 0,
-    })
+    try {
+      return paymentAmount.amount.toLocaleString(locale, {
+        style: "decimal",
+        maximumFractionDigits: 0,
+        minimumFractionDigits: 0,
+      })
+    } catch (error) {
+      console.error(error)
+      crashlytics().recordError(error)
+      return "Unable to parse amount to"
+    }
   }
 
   throw Error("Currency not supported")


### PR DESCRIPTION
This PR is a draft of my refactor of the paymentAmountToText function. It takes off from this PR [here](https://github.com/GaloyMoney/galoy-mobile/pull/676). It adds extra validation and catches ay errors before it gets to the component level in the send bitcoin screen.
However, it is not robust enough to handle some edge cases present in the parent function `paymentAmountToTextWithUnit` [here](https://github.com/GaloyMoney/galoy-mobile/blob/525cf4f0d6ded12ee4e308583853302be3fbdb17/app/utils/currencyConversion.ts#L45).
It still needs some work in my opinion.