### PR TITLE
fix: prevent extra renders on client change

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -251,7 +251,7 @@ export const App = (): JSX.Element => {
       setApolloClient(client)
     }
     fn()
-  }, [appConfig.galoyInstance, token, saveToken, hasToken])
+  }, [appConfig.galoyInstance, token, hasToken])
 
   // Before we show the app, we have to wait for our state to be ready.
   // In the meantime, don't render anything. This will be the background

--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -10,14 +10,17 @@ const useLogout = () => {
 
   const logout = async (shouldClearToken = true): Promise<void> => {
     try {
-      await client.clearStore()
+      await Promise.all([
+        client.clearStore(),
+        AsyncStorage.multiRemove([BUILD_VERSION]),
+        KeyStoreWrapper.removeIsBiometricsEnabled(),
+        KeyStoreWrapper.removePin(),
+        KeyStoreWrapper.removePinAttempts(),
+      ])
+
       if (shouldClearToken) {
         clearToken()
       }
-      await AsyncStorage.multiRemove([BUILD_VERSION]) // use storage.ts wrapper
-      await KeyStoreWrapper.removeIsBiometricsEnabled()
-      await KeyStoreWrapper.removePin()
-      await KeyStoreWrapper.removePinAttempts()
     } catch (err) {
       console.debug({ err }, `error resetting RootStore`)
     }

--- a/app/screens/debug-screen/debug-screen.tsx
+++ b/app/screens/debug-screen/debug-screen.tsx
@@ -78,8 +78,8 @@ export const DebugScreen: ScreenType = () => {
         newPosUrl !== currentGaloyInstance.posUrl ||
         newLnAddressHostname !== currentGaloyInstance.lnAddressHostname))
 
-  const handleSave = async () => {
-    await logout(false)
+  const handleSave = () => {
+    logout(false)
 
     saveToken(newToken)
 


### PR DESCRIPTION
- remove async method used in galoy config changes that was preventing batching of state updates