### PR TITLE
fix: update android universal apk path for e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,5 +235,3 @@ workflows:
           filters:
             branches:
               only: main
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,3 +235,14 @@ workflows:
           filters:
             branches:
               only: main
+  in-pr:
+    jobs:
+      - test_android:
+          filters:
+            branches:
+              ignore: main
+      - test_ios:
+          filters:
+            branches:
+              ignore: main
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,14 +235,5 @@ workflows:
           filters:
             branches:
               only: main
-  in-pr:
-    jobs:
-      - test_android:
-          filters:
-            branches:
-              ignore: main
-      - test_ios:
-          filters:
-            branches:
-              ignore: main
+
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -40,6 +40,7 @@ Android
 
 ```
 TEST_DEVICE_ANDROID="Pixel 3 API 29" yarn test:e2e:android
+TEST_APK_PATH="./android/app/build/outputs/apk/debug/app-universal-debug.apk"
 ```
 
 IOS

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -41,13 +41,6 @@ describe("Login Flow", async () => {
     await browser.pause(8000)
   })
 
-  it("click Save Changes", async () => {
-    const changeTokenButton = await $(selector("Save Changes"))
-    await changeTokenButton.waitForDisplayed({ timeout })
-    await changeTokenButton.click()
-    await browser.pause(2000)
-  })
-
   it("input token", async () => {
     try {
       const tokenInput = await $(selector("Input access token", "SecureTextField"))

--- a/e2e/config/wdio.conf.js
+++ b/e2e/config/wdio.conf.js
@@ -1,7 +1,9 @@
 let capabilities = {
   platformName: "Android",
   deviceName: process.env.TEST_DEVICE_ANDROID || "generic_x86",
-  app: "./android/app/build/outputs/apk/debug/app-debug.apk", // "./android/app/release/app-release.apk",
+  app:
+    process.env.TEST_APK_PATH ||
+    "./android/app/build/outputs/apk/debug/app-universal-debug.apk", // "./android/app/release/app-release.apk",
   automationName: "UiAutomator2",
   snapshotMaxDepth: 1000,
   autoGrantPermissions: true,


### PR DESCRIPTION
@nicolasburtey 

This PR should fix the android apk path and use the universal apk or you can configure the path with the env var `TEST_APK_PATH`. It also fixes one of the flakes on ios when logging in