### PR TITLE
chore: Build should run when tests pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,8 @@ workflows:
             branches:
               ignore: /.*/
       - build_ios:
+          requires:
+            - test_ios
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+/
@@ -239,6 +241,8 @@ workflows:
             branches:
               ignore: /.*/
       - build_android:
+          requires:
+            - test_android
           filters:
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+/


### PR DESCRIPTION
Right now the build isn't dependant on the tests passing.