### PR TITLE
chore: do test_ios on every build, including in PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,12 +220,7 @@ jobs:
 workflows:
   mobile:
     jobs:
-      - test_ios:
-          filters:
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+/
-            branches:
-              ignore: /.*/
+      - test_ios
       - build_ios:
           requires:
             - test_ios
@@ -234,12 +229,7 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
-      - test_android:
-          filters:
-            tags:
-              only: /^[0-9]+\.[0-9]+\.[0-9]+/
-            branches:
-              ignore: /.*/
+      - test_android
       - build_android:
           requires:
             - test_android
@@ -248,19 +238,3 @@ workflows:
               only: /^[0-9]+\.[0-9]+\.[0-9]+/
             branches:
               ignore: /.*/
-  main-branch:
-    jobs:
-      - test_android:
-          filters:
-            branches:
-              only: main
-      - test_ios:
-          filters:
-            branches:
-              only: main
-  in-pr:
-    jobs:
-      - test_android:
-          filters:
-            branches:
-              ignore: main


### PR DESCRIPTION
if we don't do test also for iOS, what will most likely happen is that while iOS will likely be working just fine, the e2e tests will be the one to break, before there often need some custom attributes to be set for webdriverio for the tests to pass successfully on iOS.

this PR is a good example of the issue https://github.com/GaloyMoney/galoy-mobile/pull/821

while tests were passing in the PR, they didn't pass on main.