### PR TITLE
chore: include ids in queries

### DIFF
--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -63,12 +63,6 @@ fragment TransactionList on TransactionConnection {
   }
 }
 
-fragment WalletMeta on Wallet {
-  id
-  walletCurrency
-  balance
-}
-
 mutation accountUpdateDefaultWalletId($input: AccountUpdateDefaultWalletIdInput!) {
   accountUpdateDefaultWalletId(input: $input) {
     errors {
@@ -312,7 +306,9 @@ mutation userUpdateUsername($input: UserUpdateUsernameInput!) {
 
 query accountLimits {
   me {
+    id
     defaultAccount {
+      id
       limits {
         withdrawal {
           totalLimit
@@ -336,12 +332,14 @@ query accountLimits {
 
 query accountScreen {
   me {
+    id
     phone
   }
 }
 
 query addressScreen {
   me {
+    id
     username
   }
 }
@@ -373,6 +371,7 @@ query businessMapMarkers {
 
 query contacts {
   me {
+    id
     contacts {
       id
       username
@@ -384,7 +383,9 @@ query contacts {
 
 query conversionScreen {
   me {
+    id
     defaultAccount {
+      id
       usdWallet @client {
         id
         balance
@@ -411,15 +412,9 @@ query hideBalance {
   hideBalance @client
 }
 
-query languageScreen {
+query language {
   me {
-    language
     id
-  }
-}
-
-query localizationContextProvider {
-  me {
     language
   }
 }
@@ -497,7 +492,9 @@ query quizQuestions($hasToken: Boolean!) {
 
 query receiveBitcoinScreen {
   me {
+    id
     defaultAccount {
+      id
       defaultWallet @client {
         walletCurrency
       }
@@ -510,7 +507,9 @@ query receiveBitcoinScreen {
 
 query receiveBtc {
   me {
+    id
     defaultAccount {
+      id
       btcWallet @client {
         id
       }
@@ -523,7 +522,9 @@ query receiveUsd {
     network
   }
   me {
+    id
     defaultAccount {
+      id
       usdWallet @client {
         id
       }
@@ -549,7 +550,9 @@ query scanningQRCodeScreen {
 
 query sendBitcoinConfirmationScreen {
   me {
+    id
     defaultAccount {
+      id
       btcWallet @client {
         balance
         usdBalance
@@ -566,6 +569,7 @@ query sendBitcoinDestination {
     network
   }
   me {
+    id
     username
     contacts {
       id
@@ -581,7 +585,9 @@ query sendBitcoinDetailsScreen {
     network
   }
   me {
+    id
     defaultAccount {
+      id
       defaultWallet @client {
         id
         walletCurrency
@@ -606,8 +612,9 @@ query sendBitcoinDetailsScreen {
   }
 }
 
-query setDefaultWallet {
+query setDefaultWalletScreen {
   me {
+    id
     defaultAccount {
       id
       defaultWalletId
@@ -623,10 +630,12 @@ query setDefaultWallet {
 
 query settingsScreen {
   me {
+    id
     phone
     username
     language
     defaultAccount {
+      id
       btcWallet @client {
         id
       }
@@ -676,7 +685,9 @@ query walletCSVTransactions($walletIds: [WalletId!]!) {
 
 query wallets {
   me {
+    id
     defaultAccount {
+      id
       wallets {
         walletCurrency
         id

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1425,12 +1425,12 @@ export type UserContactUpdateAliasMutation = { readonly __typename: 'Mutation', 
 export type ContactsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ContactsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly contacts: ReadonlyArray<{ readonly __typename: 'UserContact', readonly id: string, readonly username: string, readonly alias?: string | null, readonly transactionsCount: number }> } | null };
+export type ContactsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly contacts: ReadonlyArray<{ readonly __typename: 'UserContact', readonly id: string, readonly username: string, readonly alias?: string | null, readonly transactionsCount: number }> } | null };
 
 export type ConversionScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ConversionScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number } | null } } | null };
+export type ConversionScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number } | null } } | null };
 
 export type QuizQuestionsQueryVariables = Exact<{
   hasToken: Scalars['Boolean'];
@@ -1449,7 +1449,7 @@ export type QuizCompletedMutation = { readonly __typename: 'Mutation', readonly 
 export type AddressScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AddressScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null } | null };
+export type AddressScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null } | null };
 
 export type UserUpdateUsernameMutationVariables = Exact<{
   input: UserUpdateUsernameInput;
@@ -1465,10 +1465,10 @@ export type AccountUpdateDefaultWalletIdMutationVariables = Exact<{
 
 export type AccountUpdateDefaultWalletIdMutation = { readonly __typename: 'Mutation', readonly accountUpdateDefaultWalletId: { readonly __typename: 'AccountUpdateDefaultWalletIdPayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly account?: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWalletId: string } | null } };
 
-export type SetDefaultWalletQueryVariables = Exact<{ [key: string]: never; }>;
+export type SetDefaultWalletScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SetDefaultWalletQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWalletId: string, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
+export type SetDefaultWalletScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWalletId: string, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
 
 export type BusinessMapMarkersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1499,12 +1499,12 @@ export type UserLoginMutation = { readonly __typename: 'Mutation', readonly user
 export type ReceiveBitcoinScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReceiveBitcoinScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
+export type ReceiveBitcoinScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
 
 export type ReceiveBtcQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReceiveBtcQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null } } | null };
+export type ReceiveBtcQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null } } | null };
 
 export type LnNoAmountInvoiceCreateMutationVariables = Exact<{
   input: LnNoAmountInvoiceCreateInput;
@@ -1535,7 +1535,7 @@ export type MyUpdatesSubscription = { readonly __typename: 'Subscription', reado
 export type ReceiveUsdQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReceiveUsdQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
+export type ReceiveUsdQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
 
 export type LnUsdInvoiceCreateMutationVariables = Exact<{
   input: LnUsdInvoiceCreateInput;
@@ -1552,7 +1552,7 @@ export type ScanningQrCodeScreenQuery = { readonly __typename: 'Query', readonly
 export type SendBitcoinConfirmationScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SendBitcoinConfirmationScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly balance: number, readonly usdBalance?: number | null } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly balance: number } | null } } | null };
+export type SendBitcoinConfirmationScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly balance: number, readonly usdBalance?: number | null } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly balance: number } | null } } | null };
 
 export type IntraLedgerPaymentSendMutationVariables = Exact<{
   input: IntraLedgerPaymentSendInput;
@@ -1599,7 +1599,7 @@ export type OnChainPaymentSendMutation = { readonly __typename: 'Mutation', read
 export type SendBitcoinDestinationQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SendBitcoinDestinationQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly username?: string | null, readonly contacts: ReadonlyArray<{ readonly __typename: 'UserContact', readonly id: string, readonly username: string, readonly alias?: string | null, readonly transactionsCount: number }> } | null };
+export type SendBitcoinDestinationQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null, readonly contacts: ReadonlyArray<{ readonly __typename: 'UserContact', readonly id: string, readonly username: string, readonly alias?: string | null, readonly transactionsCount: number }> } | null };
 
 export type UserDefaultWalletIdQueryVariables = Exact<{
   username: Scalars['Username'];
@@ -1611,13 +1611,7 @@ export type UserDefaultWalletIdQuery = { readonly __typename: 'Query', readonly 
 export type SendBitcoinDetailsScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SendBitcoinDetailsScreenQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency, readonly usdBalance?: number | null } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number }> } } | null };
-
-type WalletMeta_BtcWallet_Fragment = { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number };
-
-type WalletMeta_UsdWallet_Fragment = { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number };
-
-export type WalletMetaFragment = WalletMeta_BtcWallet_Fragment | WalletMeta_UsdWallet_Fragment;
+export type SendBitcoinDetailsScreenQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency, readonly usdBalance?: number | null } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number }> } } | null };
 
 export type LnNoAmountInvoiceFeeProbeMutationVariables = Exact<{
   input: LnNoAmountInvoiceFeeProbeInput;
@@ -1660,12 +1654,12 @@ export type OnChainTxFeeQuery = { readonly __typename: 'Query', readonly onChain
 export type AccountScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AccountScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly phone?: string | null } | null };
+export type AccountScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly phone?: string | null } | null };
 
-export type LanguageScreenQueryVariables = Exact<{ [key: string]: never; }>;
+export type LanguageQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type LanguageScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly language: string, readonly id: string } | null };
+export type LanguageQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly language: string } | null };
 
 export type UserUpdateLanguageMutationVariables = Exact<{
   input: UserUpdateLanguageInput;
@@ -1684,12 +1678,12 @@ export type WalletCsvTransactionsQuery = { readonly __typename: 'Query', readonl
 export type SettingsScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SettingsScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly phone?: string | null, readonly username?: string | null, readonly language: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
+export type SettingsScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly phone?: string | null, readonly username?: string | null, readonly language: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
 
 export type AccountLimitsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AccountLimitsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly limits: { readonly __typename: 'AccountLimits', readonly withdrawal: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly internalSend: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly convert: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }> } } } | null };
+export type AccountLimitsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly limits: { readonly __typename: 'AccountLimits', readonly withdrawal: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly internalSend: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }>, readonly convert: ReadonlyArray<{ readonly __typename: 'OneDayAccountLimit', readonly totalLimit: number, readonly remainingLimit?: number | null, readonly interval?: number | null }> } } } | null };
 
 export type TransactionListForDefaultAccountQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']>;
@@ -1700,11 +1694,6 @@ export type TransactionListForDefaultAccountQueryVariables = Exact<{
 
 
 export type TransactionListForDefaultAccountQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementCurrency: WalletCurrency, readonly settlementPrice: { readonly __typename: 'Price', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } } }> | null } | null } } | null };
-
-export type LocalizationContextProviderQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type LocalizationContextProviderQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly language: string } | null };
 
 export type PriceSubscriptionVariables = Exact<{
   input: PriceInput;
@@ -1723,7 +1712,7 @@ export type DeviceNotificationTokenCreateMutation = { readonly __typename: 'Muta
 export type WalletsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type WalletsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency, readonly id: string } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency, readonly id: string }> } } | null };
+export type WalletsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency, readonly id: string } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency, readonly id: string }> } } | null };
 
 export const MyWalletsFragmentDoc = gql`
     fragment MyWallets on ConsumerAccount {
@@ -1793,13 +1782,6 @@ export const TransactionListFragmentDoc = gql`
   }
 }
     ${TransactionFragmentDoc}`;
-export const WalletMetaFragmentDoc = gql`
-    fragment WalletMeta on Wallet {
-  id
-  walletCurrency
-  balance
-}
-    `;
 export const BtcPriceListDocument = gql`
     query btcPriceList($range: PriceGraphRange!) {
   btcPriceList(range: $range) {
@@ -2104,6 +2086,7 @@ export type UserContactUpdateAliasMutationOptions = Apollo.BaseMutationOptions<U
 export const ContactsDocument = gql`
     query contacts {
   me {
+    id
     contacts {
       id
       username
@@ -2143,7 +2126,9 @@ export type ContactsQueryResult = Apollo.QueryResult<ContactsQuery, ContactsQuer
 export const ConversionScreenDocument = gql`
     query conversionScreen {
   me {
+    id
     defaultAccount {
+      id
       usdWallet @client {
         id
         balance
@@ -2270,6 +2255,7 @@ export type QuizCompletedMutationOptions = Apollo.BaseMutationOptions<QuizComple
 export const AddressScreenDocument = gql`
     query addressScreen {
   me {
+    id
     username
   }
 }
@@ -2379,9 +2365,10 @@ export function useAccountUpdateDefaultWalletIdMutation(baseOptions?: Apollo.Mut
 export type AccountUpdateDefaultWalletIdMutationHookResult = ReturnType<typeof useAccountUpdateDefaultWalletIdMutation>;
 export type AccountUpdateDefaultWalletIdMutationResult = Apollo.MutationResult<AccountUpdateDefaultWalletIdMutation>;
 export type AccountUpdateDefaultWalletIdMutationOptions = Apollo.BaseMutationOptions<AccountUpdateDefaultWalletIdMutation, AccountUpdateDefaultWalletIdMutationVariables>;
-export const SetDefaultWalletDocument = gql`
-    query setDefaultWallet {
+export const SetDefaultWalletScreenDocument = gql`
+    query setDefaultWalletScreen {
   me {
+    id
     defaultAccount {
       id
       defaultWalletId
@@ -2397,31 +2384,31 @@ export const SetDefaultWalletDocument = gql`
     `;
 
 /**
- * __useSetDefaultWalletQuery__
+ * __useSetDefaultWalletScreenQuery__
  *
- * To run a query within a React component, call `useSetDefaultWalletQuery` and pass it any options that fit your needs.
- * When your component renders, `useSetDefaultWalletQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useSetDefaultWalletScreenQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSetDefaultWalletScreenQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useSetDefaultWalletQuery({
+ * const { data, loading, error } = useSetDefaultWalletScreenQuery({
  *   variables: {
  *   },
  * });
  */
-export function useSetDefaultWalletQuery(baseOptions?: Apollo.QueryHookOptions<SetDefaultWalletQuery, SetDefaultWalletQueryVariables>) {
+export function useSetDefaultWalletScreenQuery(baseOptions?: Apollo.QueryHookOptions<SetDefaultWalletScreenQuery, SetDefaultWalletScreenQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<SetDefaultWalletQuery, SetDefaultWalletQueryVariables>(SetDefaultWalletDocument, options);
+        return Apollo.useQuery<SetDefaultWalletScreenQuery, SetDefaultWalletScreenQueryVariables>(SetDefaultWalletScreenDocument, options);
       }
-export function useSetDefaultWalletLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SetDefaultWalletQuery, SetDefaultWalletQueryVariables>) {
+export function useSetDefaultWalletScreenLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SetDefaultWalletScreenQuery, SetDefaultWalletScreenQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<SetDefaultWalletQuery, SetDefaultWalletQueryVariables>(SetDefaultWalletDocument, options);
+          return Apollo.useLazyQuery<SetDefaultWalletScreenQuery, SetDefaultWalletScreenQueryVariables>(SetDefaultWalletScreenDocument, options);
         }
-export type SetDefaultWalletQueryHookResult = ReturnType<typeof useSetDefaultWalletQuery>;
-export type SetDefaultWalletLazyQueryHookResult = ReturnType<typeof useSetDefaultWalletLazyQuery>;
-export type SetDefaultWalletQueryResult = Apollo.QueryResult<SetDefaultWalletQuery, SetDefaultWalletQueryVariables>;
+export type SetDefaultWalletScreenQueryHookResult = ReturnType<typeof useSetDefaultWalletScreenQuery>;
+export type SetDefaultWalletScreenLazyQueryHookResult = ReturnType<typeof useSetDefaultWalletScreenLazyQuery>;
+export type SetDefaultWalletScreenQueryResult = Apollo.QueryResult<SetDefaultWalletScreenQuery, SetDefaultWalletScreenQueryVariables>;
 export const BusinessMapMarkersDocument = gql`
     query businessMapMarkers {
   businessMapMarkers {
@@ -2610,7 +2597,9 @@ export type UserLoginMutationOptions = Apollo.BaseMutationOptions<UserLoginMutat
 export const ReceiveBitcoinScreenDocument = gql`
     query receiveBitcoinScreen {
   me {
+    id
     defaultAccount {
+      id
       defaultWallet @client {
         walletCurrency
       }
@@ -2651,7 +2640,9 @@ export type ReceiveBitcoinScreenQueryResult = Apollo.QueryResult<ReceiveBitcoinS
 export const ReceiveBtcDocument = gql`
     query receiveBtc {
   me {
+    id
     defaultAccount {
+      id
       btcWallet @client {
         id
       }
@@ -2863,7 +2854,9 @@ export const ReceiveUsdDocument = gql`
     network
   }
   me {
+    id
     defaultAccount {
+      id
       usdWallet @client {
         id
       }
@@ -2976,7 +2969,9 @@ export type ScanningQrCodeScreenQueryResult = Apollo.QueryResult<ScanningQrCodeS
 export const SendBitcoinConfirmationScreenDocument = gql`
     query sendBitcoinConfirmationScreen {
   me {
+    id
     defaultAccount {
+      id
       btcWallet @client {
         balance
         usdBalance
@@ -3237,6 +3232,7 @@ export const SendBitcoinDestinationDocument = gql`
     network
   }
   me {
+    id
     username
     contacts {
       id
@@ -3313,7 +3309,9 @@ export const SendBitcoinDetailsScreenDocument = gql`
     network
   }
   me {
+    id
     defaultAccount {
+      id
       defaultWallet @client {
         id
         walletCurrency
@@ -3556,6 +3554,7 @@ export type OnChainTxFeeQueryResult = Apollo.QueryResult<OnChainTxFeeQuery, OnCh
 export const AccountScreenDocument = gql`
     query accountScreen {
   me {
+    id
     phone
   }
 }
@@ -3587,41 +3586,41 @@ export function useAccountScreenLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type AccountScreenQueryHookResult = ReturnType<typeof useAccountScreenQuery>;
 export type AccountScreenLazyQueryHookResult = ReturnType<typeof useAccountScreenLazyQuery>;
 export type AccountScreenQueryResult = Apollo.QueryResult<AccountScreenQuery, AccountScreenQueryVariables>;
-export const LanguageScreenDocument = gql`
-    query languageScreen {
+export const LanguageDocument = gql`
+    query language {
   me {
-    language
     id
+    language
   }
 }
     `;
 
 /**
- * __useLanguageScreenQuery__
+ * __useLanguageQuery__
  *
- * To run a query within a React component, call `useLanguageScreenQuery` and pass it any options that fit your needs.
- * When your component renders, `useLanguageScreenQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useLanguageQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLanguageQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useLanguageScreenQuery({
+ * const { data, loading, error } = useLanguageQuery({
  *   variables: {
  *   },
  * });
  */
-export function useLanguageScreenQuery(baseOptions?: Apollo.QueryHookOptions<LanguageScreenQuery, LanguageScreenQueryVariables>) {
+export function useLanguageQuery(baseOptions?: Apollo.QueryHookOptions<LanguageQuery, LanguageQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<LanguageScreenQuery, LanguageScreenQueryVariables>(LanguageScreenDocument, options);
+        return Apollo.useQuery<LanguageQuery, LanguageQueryVariables>(LanguageDocument, options);
       }
-export function useLanguageScreenLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LanguageScreenQuery, LanguageScreenQueryVariables>) {
+export function useLanguageLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LanguageQuery, LanguageQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<LanguageScreenQuery, LanguageScreenQueryVariables>(LanguageScreenDocument, options);
+          return Apollo.useLazyQuery<LanguageQuery, LanguageQueryVariables>(LanguageDocument, options);
         }
-export type LanguageScreenQueryHookResult = ReturnType<typeof useLanguageScreenQuery>;
-export type LanguageScreenLazyQueryHookResult = ReturnType<typeof useLanguageScreenLazyQuery>;
-export type LanguageScreenQueryResult = Apollo.QueryResult<LanguageScreenQuery, LanguageScreenQueryVariables>;
+export type LanguageQueryHookResult = ReturnType<typeof useLanguageQuery>;
+export type LanguageLazyQueryHookResult = ReturnType<typeof useLanguageLazyQuery>;
+export type LanguageQueryResult = Apollo.QueryResult<LanguageQuery, LanguageQueryVariables>;
 export const UserUpdateLanguageDocument = gql`
     mutation userUpdateLanguage($input: UserUpdateLanguageInput!) {
   userUpdateLanguage(input: $input) {
@@ -3703,10 +3702,12 @@ export type WalletCsvTransactionsQueryResult = Apollo.QueryResult<WalletCsvTrans
 export const SettingsScreenDocument = gql`
     query settingsScreen {
   me {
+    id
     phone
     username
     language
     defaultAccount {
+      id
       btcWallet @client {
         id
       }
@@ -3747,7 +3748,9 @@ export type SettingsScreenQueryResult = Apollo.QueryResult<SettingsScreenQuery, 
 export const AccountLimitsDocument = gql`
     query accountLimits {
   me {
+    id
     defaultAccount {
+      id
       limits {
         withdrawal {
           totalLimit
@@ -3840,40 +3843,6 @@ export function useTransactionListForDefaultAccountLazyQuery(baseOptions?: Apoll
 export type TransactionListForDefaultAccountQueryHookResult = ReturnType<typeof useTransactionListForDefaultAccountQuery>;
 export type TransactionListForDefaultAccountLazyQueryHookResult = ReturnType<typeof useTransactionListForDefaultAccountLazyQuery>;
 export type TransactionListForDefaultAccountQueryResult = Apollo.QueryResult<TransactionListForDefaultAccountQuery, TransactionListForDefaultAccountQueryVariables>;
-export const LocalizationContextProviderDocument = gql`
-    query localizationContextProvider {
-  me {
-    language
-  }
-}
-    `;
-
-/**
- * __useLocalizationContextProviderQuery__
- *
- * To run a query within a React component, call `useLocalizationContextProviderQuery` and pass it any options that fit your needs.
- * When your component renders, `useLocalizationContextProviderQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useLocalizationContextProviderQuery({
- *   variables: {
- *   },
- * });
- */
-export function useLocalizationContextProviderQuery(baseOptions?: Apollo.QueryHookOptions<LocalizationContextProviderQuery, LocalizationContextProviderQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<LocalizationContextProviderQuery, LocalizationContextProviderQueryVariables>(LocalizationContextProviderDocument, options);
-      }
-export function useLocalizationContextProviderLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LocalizationContextProviderQuery, LocalizationContextProviderQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<LocalizationContextProviderQuery, LocalizationContextProviderQueryVariables>(LocalizationContextProviderDocument, options);
-        }
-export type LocalizationContextProviderQueryHookResult = ReturnType<typeof useLocalizationContextProviderQuery>;
-export type LocalizationContextProviderLazyQueryHookResult = ReturnType<typeof useLocalizationContextProviderLazyQuery>;
-export type LocalizationContextProviderQueryResult = Apollo.QueryResult<LocalizationContextProviderQuery, LocalizationContextProviderQueryVariables>;
 export const PriceDocument = gql`
     subscription price($input: PriceInput!) {
   price(input: $input) {
@@ -3951,7 +3920,9 @@ export type DeviceNotificationTokenCreateMutationOptions = Apollo.BaseMutationOp
 export const WalletsDocument = gql`
     query wallets {
   me {
+    id
     defaultAccount {
+      id
       wallets {
         walletCurrency
         id

--- a/app/screens/contacts-screen/contacts.tsx
+++ b/app/screens/contacts-screen/contacts.tsx
@@ -86,6 +86,7 @@ type Props = {
 gql`
   query contacts {
     me {
+      id
       contacts {
         id
         username

--- a/app/screens/conversion-flow/conversion-confirmation-screen.tsx
+++ b/app/screens/conversion-flow/conversion-confirmation-screen.tsx
@@ -25,7 +25,9 @@ import { StyleSheet, Text, View } from "react-native"
 gql`
   query conversionScreen {
     me {
+      id
       defaultAccount {
+        id
         usdWallet @client {
           id
           balance

--- a/app/screens/galoy-address-screen/galoy-address-screen.tsx
+++ b/app/screens/galoy-address-screen/galoy-address-screen.tsx
@@ -86,6 +86,7 @@ const styles = EStyleSheet.create({
 gql`
   query addressScreen {
     me {
+      id
       username
     }
   }

--- a/app/screens/galoy-address-screen/merchants-dropdown.tsx
+++ b/app/screens/galoy-address-screen/merchants-dropdown.tsx
@@ -13,7 +13,7 @@ import EStyleSheet from "react-native-extended-stylesheet"
 import { TouchableWithoutFeedback } from "react-native-gesture-handler"
 import { PayCodeExplainerModal } from "./paycode-explainer-modal"
 import { PosExplainerModal } from "./pos-explainer-modal"
-import { SetDefaultWallet } from "./set-default-wallet"
+import { SetDefaultWalletScreen } from "./set-default-wallet"
 
 const styles = EStyleSheet.create({
   title: {
@@ -213,7 +213,7 @@ export const MerchantsDropdown = ({ username }: { username: string }) => {
           {payCodeUrl}
         </Text>
       </View>
-      <SetDefaultWallet />
+      <SetDefaultWalletScreen />
       <PosExplainerModal
         modalVisible={isPosExplainerModalOpen}
         toggleModal={togglePosExplainerModal}

--- a/app/screens/galoy-address-screen/set-default-wallet.tsx
+++ b/app/screens/galoy-address-screen/set-default-wallet.tsx
@@ -9,7 +9,7 @@ import { toastShow } from "@app/utils/toast"
 import { DefaultWalletExplainerModal } from "./default-wallet-explainer-modal"
 import {
   useAccountUpdateDefaultWalletIdMutation,
-  useSetDefaultWalletQuery,
+  useSetDefaultWalletScreenQuery,
 } from "@app/graphql/generated"
 import { gql } from "@apollo/client"
 
@@ -57,8 +57,9 @@ gql`
     }
   }
 
-  query setDefaultWallet {
+  query setDefaultWalletScreen {
     me {
+      id
       defaultAccount {
         id
         defaultWalletId
@@ -73,10 +74,10 @@ gql`
   }
 `
 
-export const SetDefaultWallet = () => {
+export const SetDefaultWalletScreen = () => {
   const { LL } = useI18nContext()
 
-  const { data } = useSetDefaultWalletQuery({ fetchPolicy: "cache-first" })
+  const { data } = useSetDefaultWalletScreenQuery({ fetchPolicy: "cache-first" })
 
   const accountId = data?.me?.defaultAccount?.id
   const btcWalletId = data?.me?.defaultAccount?.btcWallet?.id

--- a/app/screens/map-screen/map-screen.tsx
+++ b/app/screens/map-screen/map-screen.tsx
@@ -41,6 +41,7 @@ type Props = {
 }
 
 gql`
+  # TODO: caching
   query businessMapMarkers {
     businessMapMarkers {
       username

--- a/app/screens/receive-bitcoin-screen/receive-bitcoin.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-bitcoin.tsx
@@ -63,7 +63,9 @@ const styles = EStyleSheet.create({
 gql`
   query receiveBitcoinScreen {
     me {
+      id
       defaultAccount {
+        id
         defaultWallet @client {
           walletCurrency
         }

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -162,7 +162,9 @@ const styles = EStyleSheet.create({
 gql`
   query receiveBtc {
     me {
+      id
       defaultAccount {
+        id
         btcWallet @client {
           id
         }

--- a/app/screens/receive-bitcoin-screen/receive-usd.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-usd.tsx
@@ -151,7 +151,9 @@ gql`
       network
     }
     me {
+      id
       defaultAccount {
+        id
         usdWallet @client {
           id
         }

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -189,7 +189,9 @@ const styles = StyleSheet.create({
 gql`
   query sendBitcoinConfirmationScreen {
     me {
+      id
       defaultAccount {
+        id
         btcWallet @client {
           balance
           usdBalance

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -229,6 +229,7 @@ gql`
       network
     }
     me {
+      id
       username
       contacts {
         id

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -202,7 +202,9 @@ gql`
       network
     }
     me {
+      id
       defaultAccount {
+        id
         defaultWallet @client {
           id
           walletCurrency
@@ -225,12 +227,6 @@ gql`
         }
       }
     }
-  }
-
-  fragment WalletMeta on Wallet {
-    id
-    walletCurrency
-    balance
   }
 `
 

--- a/app/screens/settings-screen/account-screen.tsx
+++ b/app/screens/settings-screen/account-screen.tsx
@@ -19,6 +19,7 @@ type Props = {
 gql`
   query accountScreen {
     me {
+      id
       phone
     }
   }

--- a/app/screens/settings-screen/language-screen.tsx
+++ b/app/screens/settings-screen/language-screen.tsx
@@ -6,10 +6,7 @@ import { Screen } from "../../components/screen"
 import { palette } from "../../theme/palette"
 import type { ScreenType } from "../../types/jsx"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import {
-  useLanguageScreenQuery,
-  useUserUpdateLanguageMutation,
-} from "@app/graphql/generated"
+import { useLanguageQuery, useUserUpdateLanguageMutation } from "@app/graphql/generated"
 import { testProps } from "../../../utils/testProps"
 import { gql } from "@apollo/client"
 
@@ -20,10 +17,10 @@ const styles = EStyleSheet.create({
 })
 
 gql`
-  query languageScreen {
+  query language {
     me {
-      language
       id
+      language
     }
   }
 
@@ -41,7 +38,7 @@ gql`
 `
 
 export const LanguageScreen: ScreenType = () => {
-  const { data } = useLanguageScreenQuery({ fetchPolicy: "cache-first" })
+  const { data } = useLanguageQuery({ fetchPolicy: "cache-first" })
 
   const languageServer = data?.me?.language
   const userId = data?.me?.id

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -39,10 +39,12 @@ gql`
 
   query settingsScreen {
     me {
+      id
       phone
       username
       language
       defaultAccount {
+        id
         btcWallet @client {
           id
         }

--- a/app/screens/settings-screen/transaction-limits-screen.tsx
+++ b/app/screens/settings-screen/transaction-limits-screen.tsx
@@ -73,7 +73,9 @@ const accountLimitsPeriodInHrs = {
 gql`
   query accountLimits {
     me {
+      id
       defaultAccount {
+        id
         limits {
           withdrawal {
             totalLimit

--- a/app/store/localization-context.tsx
+++ b/app/store/localization-context.tsx
@@ -1,21 +1,12 @@
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { getLanguageFromLocale } from "@app/utils/locale-detector"
 import React, { createContext, useEffect, useState } from "react"
-import { gql } from "@apollo/client"
-import { useLocalizationContextProviderQuery } from "@app/graphql/generated"
+import { useLanguageQuery } from "@app/graphql/generated"
 
 type LocalizationContextType = {
   displayCurrency: string
   setDisplayCurrency: React.Dispatch<React.SetStateAction<string>>
 }
-
-gql`
-  query localizationContextProvider {
-    me {
-      language
-    }
-  }
-`
 
 export const LocalizationContext = createContext<LocalizationContextType>({
   displayCurrency: "USD",
@@ -24,7 +15,7 @@ export const LocalizationContext = createContext<LocalizationContextType>({
 })
 
 export const LocalizationContextProvider = ({ children }) => {
-  const { data } = useLocalizationContextProviderQuery({ fetchPolicy: "cache-first" })
+  const { data } = useLanguageQuery({ fetchPolicy: "cache-first" })
 
   const userPreferredLanguage = data?.me?.language
 

--- a/e2e/utils/graphql.ts
+++ b/e2e/utils/graphql.ts
@@ -46,7 +46,9 @@ export const mobileUserToken = randomizeTokens(authTokens)
 gql`
   query wallets {
     me {
+      id
       defaultAccount {
+        id
         wallets {
           walletCurrency
           id


### PR DESCRIPTION
this should help with caching

I don't know what is the effect of object which don't have an id, like:
```
globals {
  network
}
me {
...
}
```

does the globals request force a network request because `globals.networks` is not cache properly because there is no `globals.id` ? I will dive in this later.