### PR TITLE
chore: Fix android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ yalc.lock
 .env
 .envrc
 .dependencies
-android/app/src/main
 ios/assets
 ios/GaloyApp/assets
+android/app/src/main/assets
+android/app/src/main/res

--- a/android/app/src/main/java/com/galoyapp/MainApplication.java
+++ b/android/app/src/main/java/com/galoyapp/MainApplication.java
@@ -19,6 +19,9 @@ public class MainApplication extends Application implements ReactApplication {
       new ReactNativeHost(this) {
         @Override
         public boolean getUseDeveloperSupport() {
+          if(System.getenv("CI")){
+            return false;
+          }
           return BuildConfig.DEBUG;
         }
 

--- a/android/app/src/main/java/com/galoyapp/MainApplication.java
+++ b/android/app/src/main/java/com/galoyapp/MainApplication.java
@@ -19,7 +19,7 @@ public class MainApplication extends Application implements ReactApplication {
       new ReactNativeHost(this) {
         @Override
         public boolean getUseDeveloperSupport() {
-          if(System.getenv("CI")){
+          if(Boolean.parseBoolean(System.getenv("CI"))){
             return false;
           }
           return BuildConfig.DEBUG;


### PR DESCRIPTION
I noticed sometimes the android build will connect to metro during e2e tests in browserstack - this is probably related to the change I made recently as setup work to enable camera testing.  It could be that it's trying to connect to metro dev services in the android native code so I've disabled that when building in a CI env.