### PR TITLE
fix: Fixed language parsing issue on settings page

### DIFF
--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -69,21 +69,13 @@ export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
 
   const username = data?.me?.username ?? undefined
   const phone = data?.me?.phone ?? undefined
-  const languageQuery = data?.me?.language
-
-  // The server responds with "" if the user has set their language to DEFAULT
-  let parsedLanguageFromQuery
-  if (languageQuery) {
-    parsedLanguageFromQuery = languageQuery
-  } else {
-    parsedLanguageFromQuery = "DEFAULT"
-  }
+  const userPreferredLanguage = data?.me?.language || "DEFAULT"
 
   // FIXME: having an enum for language on the API would fix this issue
   let language = "FIXME: error missing language" // should not appear unless there is a bug
-  if (Object.keys(LL.Languages).indexOf(parsedLanguageFromQuery) !== -1) {
+  if (Object.keys(LL.Languages).indexOf(userPreferredLanguage) !== -1) {
     type LanguageQuery = keyof typeof LL.Languages
-    const languageQueryTyped = parsedLanguageFromQuery as LanguageQuery
+    const languageQueryTyped = userPreferredLanguage as LanguageQuery
     language = LL.Languages[languageQueryTyped]()
   }
 

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -69,13 +69,21 @@ export const SettingsScreen: React.FC<Props> = ({ navigation }) => {
 
   const username = data?.me?.username ?? undefined
   const phone = data?.me?.phone ?? undefined
-  const languageQuery = data?.me?.language ?? "DEFAULT"
+  const languageQuery = data?.me?.language
+
+  // The server responds with "" if the user has set their language to DEFAULT
+  let parsedLanguageFromQuery
+  if (languageQuery) {
+    parsedLanguageFromQuery = languageQuery
+  } else {
+    parsedLanguageFromQuery = "DEFAULT"
+  }
 
   // FIXME: having an enum for language on the API would fix this issue
   let language = "FIXME: error missing language" // should not appear unless there is a bug
-  if (Object.keys(LL.Languages).indexOf(languageQuery) !== -1) {
+  if (Object.keys(LL.Languages).indexOf(parsedLanguageFromQuery) !== -1) {
     type LanguageQuery = keyof typeof LL.Languages
-    const languageQueryTyped = languageQuery as LanguageQuery
+    const languageQueryTyped = parsedLanguageFromQuery as LanguageQuery
     language = LL.Languages[languageQueryTyped]()
   }
 


### PR DESCRIPTION
The server responds with an [empty string](https://github.com/GaloyMoney/galoy/blob/6bbbbb46ed3e196ab362c7c875207dbff7059ba2/src/graphql/types/scalar/language.ts#L30) if the language is set as default and the code doesn't deal with this at the moment.  I was seeing the `FIXME: error missing language` message in the settings page when my language was set as default.