### PR TITLE
chore: remove sub for unauth client

### DIFF
--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -212,7 +212,7 @@ const GaloyClient: React.FC<{ children: React.ReactNode }> = ({ children }) => {
       <IsAuthedContextProvider value={apolloClient.isAuthed}>
         <LanguageSync />
         <AnalyticsContainer />
-        <PriceSub />
+        {apolloClient.isAuthed && <PriceSub />}
         {children}
       </IsAuthedContextProvider>
     </ApolloProvider>


### PR DESCRIPTION
there is no need to subscribe to the price sub when a client is not auth. no action requires it.

this will save ressources server side and limiit bandwiith on the phone