### PR TITLE
fix: Fixed issue with btc wallet balance

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -575,12 +575,20 @@ const SendBitcoinDetailsScreen = ({
                 <View style={Styles.walletSelectorBalanceContainer}>
                   {sendingWalletDescriptor.currency === WalletCurrency.Btc ? (
                     <>
-                      <Text style={Styles.walletBalanceText}>
+                      <Text
+                        style={Styles.walletBalanceText}
+                        {...testProps("BTC Wallet Balance in USD")}
+                      >
                         {typeof btcBalanceInUsd === "number"
                           ? formatToDisplayCurrency(btcBalanceInUsd) + " - "
                           : ""}
+                      </Text>
+                      <Text
+                        style={Styles.walletBalanceText}
+                        {...testProps("BTC Wallet Balance in sats")}
+                      >
                         {typeof btcWalletBalance === "number"
-                          ? Number(satAmountDisplay(btcWalletBalance))
+                          ? satAmountDisplay(btcWalletBalance)
                           : ""}
                       </Text>
                     </>

--- a/e2e/04-username-payments-flow.e2e.spec.ts
+++ b/e2e/04-username-payments-flow.e2e.spec.ts
@@ -54,6 +54,23 @@ describe("Username Payment Flow", async () => {
     await nextButton.click()
   })
 
+  it("Wallet contains balances", async () => {
+    const btcWalletBalanceInUsd = await $(
+      selector("BTC Wallet Balance in USD", "StaticText"),
+    )
+    await expect(btcWalletBalanceInUsd).toBeDisplayed()
+    const btcWalletBalanceInUsdValue = await btcWalletBalanceInUsd.getText()
+    expect(btcWalletBalanceInUsdValue).toHaveText(
+      new RegExp("^$(0|[1-9][0-9]{0,2})(,d{3})*(.d{1,2})?$"),
+    )
+    const btcWalletBalanceInSats = await $(
+      selector("BTC Wallet Balance in sats", "StaticText"),
+    )
+    await expect(btcWalletBalanceInSats).toBeDisplayed()
+    const btcWalletBalanceInSatsValue = await btcWalletBalanceInSats.getText()
+    expect(btcWalletBalanceInSatsValue).toHaveText(new RegExp("^[0-9,]* sats$"))
+  })
+
   it("Add amount", async () => {
     try {
       const amountInput = await $(selector("USD Amount", "TextField"))


### PR DESCRIPTION
BTC wallet sat balance was showing as `NaN` on the send flow.  I also added a new test to look out for this in future.

<img width="410" alt="image" src="https://user-images.githubusercontent.com/3502409/216358699-61942e48-273e-459f-aaca-dc65c0653489.png">
