### PR TITLE
fix: settings / contact support appearance modal screen

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -1,7 +1,14 @@
 // Welcome to the main entry point of the app.
 //
-// In this file, we'll be kicking off our app or storybook.
+// In this file, we'll be kicking off our app
+
+// language related import
 import "intl-pluralrules"
+import "./utils/polyfill"
+import "moment/locale/es"
+import "moment/locale/fr-ca"
+import "moment/locale/pt-br"
+
 import "react-native-reanimated"
 
 import "@react-native-firebase/crashlytics"
@@ -14,12 +21,7 @@ import { RootSiblingParent } from "react-native-root-siblings"
 import { GlobalErrorToast } from "./components/global-error"
 import { RootStack } from "./navigation/root-navigator"
 import { ErrorScreen } from "./screens/error-screen"
-import "./utils/polyfill"
-// import moment locale files so we can display dates in the user's language
 import { ThemeProvider } from "@rneui/themed"
-import "moment/locale/es"
-import "moment/locale/fr-ca"
-import "moment/locale/pt-br"
 import { GaloyToast } from "./components/galoy-toast"
 import { GaloyClient } from "./graphql/client"
 import TypesafeI18n from "./i18n/i18n-react"

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -37,29 +37,31 @@ EStyleSheet.build({
   // $textColor: '#0275d8'
 })
 
+// FIXME should we only load the currently used local?
+// this would help to make the app load faster
+// this will become more important when we add more languages
+// and when the earn section will be added
 loadAllLocales()
 
 /**
  * This is the root component of our app.
  */
-export const App = () => {
-  return (
-    <PersistentStateProvider>
-      <ThemeProvider theme={theme}>
-        <TypesafeI18n locale={detectDefaultLocale()}>
-          <GaloyClient>
-            <ErrorBoundary FallbackComponent={ErrorScreen}>
-              <NavigationContainerWrapper>
-                <RootSiblingParent>
-                  <GlobalErrorToast />
-                  <RootStack />
-                  <GaloyToast />
-                </RootSiblingParent>
-              </NavigationContainerWrapper>
-            </ErrorBoundary>
-          </GaloyClient>
-        </TypesafeI18n>
-      </ThemeProvider>
-    </PersistentStateProvider>
-  )
-}
+export const App = () => (
+  <PersistentStateProvider>
+    <ThemeProvider theme={theme}>
+      <TypesafeI18n locale={detectDefaultLocale()}>
+        <GaloyClient>
+          <ErrorBoundary FallbackComponent={ErrorScreen}>
+            <NavigationContainerWrapper>
+              <RootSiblingParent>
+                <GlobalErrorToast />
+                <RootStack />
+                <GaloyToast />
+              </RootSiblingParent>
+            </NavigationContainerWrapper>
+          </ErrorBoundary>
+        </GaloyClient>
+      </TypesafeI18n>
+    </ThemeProvider>
+  </PersistentStateProvider>
+)

--- a/app/app.tsx
+++ b/app/app.tsx
@@ -41,6 +41,8 @@ EStyleSheet.build({
 // this would help to make the app load faster
 // this will become more important when we add more languages
 // and when the earn section will be added
+//
+// alternatively, could try loadAllLocalesAsync()
 loadAllLocales()
 
 /**

--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -12,7 +12,7 @@ const styles = EStyleSheet.create({
   modal: {
     justifyContent: "flex-end",
     margin: 0,
-    flexDirection: "row",
+    flexGrow: 1,
   },
   content: {
     backgroundColor: palette.white,

--- a/app/screens/settings-screen/settings-row.tsx
+++ b/app/screens/settings-screen/settings-row.tsx
@@ -4,12 +4,12 @@ import React from "react"
 import { Divider, Icon, ListItem, Text } from "@rneui/base"
 import { testProps } from "../../utils/testProps"
 
-export const SettingsRow = ({ setting }: { setting: SettingRow }) => {
+export const SettingsRow: React.FC<{ setting: SettingRow }> = ({ setting }) => {
   if (setting.hidden) {
     return null
   }
-  let settingColor
-  let settingStyle
+  let settingColor: string
+  let settingStyle: { color: string }
   if (setting?.dangerous) {
     settingColor = setting.greyed ? palette.midGrey : palette.red
     settingStyle = { color: palette.red }
@@ -29,11 +29,11 @@ export const SettingsRow = ({ setting }: { setting: SettingRow }) => {
         )}
         <ListItem.Content>
           <ListItem.Title {...testProps(setting.category)} style={settingStyle}>
-            <Text>{setting.category}</Text>
+            <Text style={settingStyle}>{setting.category}</Text>
           </ListItem.Title>
           {setting.subTitleText && (
             <ListItem.Subtitle {...testProps(setting.subTitleText)} style={settingStyle}>
-              <Text>{setting.subTitleText}</Text>
+              <Text style={settingStyle}>{setting.subTitleText}</Text>
             </ListItem.Subtitle>
           )}
         </ListItem.Content>

--- a/app/screens/settings-screen/settings-screen.story.tsx
+++ b/app/screens/settings-screen/settings-screen.story.tsx
@@ -5,8 +5,6 @@ import { StoryScreen } from "../../../storybook/views"
 import { SettingsScreenJSX } from "./settings-screen"
 import { action } from "@storybook/addon-actions"
 
-declare let module
-
 const propsDefault = {
   navigation: action("navigate"),
   language: "en",

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -203,14 +203,6 @@ export const SettingsScreenJSX: React.FC<SettingsScreenProps> = (params) => {
       greyed: !isAuthed || loadingCsvTransactions,
     },
     {
-      category: LL.support.contactUs(),
-      icon: "help-circle",
-      id: "contact-us",
-      action: toggleIsContactModalVisible,
-      enabled: true,
-      greyed: false,
-    },
-    {
       category: LL.common.account(),
       icon: "person-outline",
       id: "account",
@@ -218,6 +210,14 @@ export const SettingsScreenJSX: React.FC<SettingsScreenProps> = (params) => {
       enabled: isAuthed,
       greyed: !isAuthed,
       styleDivider: { backgroundColor: palette.lighterGrey, height: 18 },
+    },
+    {
+      category: LL.support.contactUs(),
+      icon: "help-circle",
+      id: "contact-us",
+      action: toggleIsContactModalVisible,
+      enabled: true,
+      greyed: false,
     },
   ]
 

--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "jetifier": "^2.0.0",
     "metro-config": "0.75.0",
     "mocha": "^10.2.0",
-    "mock-apollo-client": "^1.2.0",
     "npm-run-all": "4.1.5",
     "patch-package": "6.5.1",
     "prettier": "^2.8.3",

--- a/storybook/storybook-registry.ts
+++ b/storybook/storybook-registry.ts
@@ -1,3 +1,4 @@
+require("../app/screens/settings-screen/settings-screen.story")
 require("../app/components/large-button/large-button.story")
 require("../app/components/wallet-overview/wallet-overview.story")
 require("../app/components/wallet-summary/wallet-summary.story")
@@ -10,8 +11,8 @@ require("../app/components/atomic/galoy-icon-button/galoy-icon-button.story")
 require("../app/components/atomic/galoy-currency-bubble/galoy-currency-bubble.story")
 require("../app/components/atomic/galoy-button-field/galoy-button-field.story")
 require("../app/components/atomic/galoy-checkbox-button/galoy-checkbox-button.story")
+require("../app/components/atomic/galoy-input/galoy-input.story")
 require("./defaults/text.story")
 require("./defaults/colors.story")
-require("../app/components/atomic/galoy-input/galoy-input.story")
 
 export {}

--- a/storybook/storybook.tsx
+++ b/storybook/storybook.tsx
@@ -6,13 +6,10 @@ import { NavigationContainer } from "@react-navigation/native"
 import { ThemeProvider } from "@rneui/themed"
 import { createStackNavigator } from "@react-navigation/stack"
 import theme from "@app/rne-theme/theme"
-import { loadAllLocales } from "@app/i18n/i18n-util.sync"
 
 configure(() => {
   require("./storybook-registry")
 }, module)
-
-loadAllLocales()
 
 const StorybookUI = getStorybookUI({
   port: 9001,

--- a/storybook/storybook.tsx
+++ b/storybook/storybook.tsx
@@ -6,10 +6,13 @@ import { NavigationContainer } from "@react-navigation/native"
 import { ThemeProvider } from "@rneui/themed"
 import { createStackNavigator } from "@react-navigation/stack"
 import theme from "@app/rne-theme/theme"
+import { loadAllLocales } from "@app/i18n/i18n-util.sync"
 
 configure(() => {
   require("./storybook-registry")
 }, module)
+
+loadAllLocales()
 
 const StorybookUI = getStorybookUI({
   port: 9001,

--- a/storybook/storybook.tsx
+++ b/storybook/storybook.tsx
@@ -20,17 +20,12 @@ const StorybookUI = getStorybookUI({
 
 const Stack = createStackNavigator()
 
-// RN hot module must be in a class for HMR
-export class StorybookUIRoot extends React.Component {
-  render() {
-    return (
-      <ThemeProvider theme={theme}>
-        <NavigationContainer>
-          <Stack.Navigator>
-            <Stack.Screen name="Home" component={StorybookUI} />
-          </Stack.Navigator>
-        </NavigationContainer>
-      </ThemeProvider>
-    )
-  }
-}
+export const StorybookUIRoot: React.FC = () => (
+  <ThemeProvider theme={theme}>
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={StorybookUI} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  </ThemeProvider>
+)

--- a/storybook/views/story-screen.tsx
+++ b/storybook/views/story-screen.tsx
@@ -1,13 +1,11 @@
 import * as React from "react"
 import { ViewStyle, KeyboardAvoidingView, Platform } from "react-native"
-import { ApolloProvider } from "@apollo/client"
-import { createMockClient } from "mock-apollo-client"
+import { MockedProvider } from "@apollo/client/testing"
 const ROOT: ViewStyle = { backgroundColor: "#f0f0f0", flex: 1 }
 
 export interface StoryScreenProps {
   children?: React.ReactNode
 }
-const mockClient = createMockClient()
 const behavior = Platform.OS === "ios" ? "padding" : null
 export const StoryScreen = (props: StoryScreenProps) => (
   <KeyboardAvoidingView
@@ -15,6 +13,6 @@ export const StoryScreen = (props: StoryScreenProps) => (
     behavior={behavior || undefined}
     keyboardVerticalOffset={50}
   >
-    <ApolloProvider client={mockClient}>{props.children}</ApolloProvider>
+    <MockedProvider>{props.children}</MockedProvider>
   </KeyboardAvoidingView>
 )

--- a/storybook/views/story-screen.tsx
+++ b/storybook/views/story-screen.tsx
@@ -1,18 +1,20 @@
 import * as React from "react"
 import { ViewStyle, KeyboardAvoidingView, Platform } from "react-native"
+import TypesafeI18n from "@app/i18n/i18n-react"
+import { detectDefaultLocale } from "../../app/utils/locale-detector"
 import { MockedProvider } from "@apollo/client/testing"
-const ROOT: ViewStyle = { backgroundColor: "#f0f0f0", flex: 1 }
 
-export interface StoryScreenProps {
-  children?: React.ReactNode
-}
+const ROOT: ViewStyle = { backgroundColor: "#f0f0f0", flex: 1 }
 const behavior = Platform.OS === "ios" ? "padding" : null
-export const StoryScreen = (props: StoryScreenProps) => (
+
+export const StoryScreen: React.FC<React.PropsWithChildren> = ({ children }) => (
   <KeyboardAvoidingView
     style={ROOT}
     behavior={behavior || undefined}
     keyboardVerticalOffset={50}
   >
-    <MockedProvider>{props.children}</MockedProvider>
+    <MockedProvider>
+      <TypesafeI18n locale={detectDefaultLocale()}>{children}</TypesafeI18n>
+    </MockedProvider>
   </KeyboardAvoidingView>
 )

--- a/storybook/views/story.tsx
+++ b/storybook/views/story.tsx
@@ -1,16 +1,9 @@
 import * as React from "react"
 import { ScrollView, View, ViewStyle } from "react-native"
 
-export interface StoryProps {
-  children?: React.ReactNode
-}
-
 const ROOT: ViewStyle = { flex: 1 }
 
-export function Story(props: StoryProps) {
-  return (
+export const Story: React.FC<React.PropsWithChildren> = (props) => 
     <View style={ROOT}>
       <ScrollView>{props.children}</ScrollView>
     </View>
-  )
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13595,11 +13595,6 @@ mocha@^10.0.0, mocha@^10.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
-mock-apollo-client@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/mock-apollo-client/-/mock-apollo-client-1.2.1.tgz#e3bfdc3ff73b1fea28fa7e91ec82e43ba8cbfa39"
-  integrity sha512-QYQ6Hxo+t7hard1bcHHbsHxlNQYTQsaMNsm2Psh/NbwLMi2R4tGzplJKt97MUWuARHMq3GHB4PTLj/gxej4Caw==
-
 modal-react-native-web@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/modal-react-native-web/-/modal-react-native-web-0.2.0.tgz#5daaa76213218fd25df739a267b11aed37e8c0c2"


### PR DESCRIPTION
also:
- remove `mock-apollo-client`. a better version is already included with apollo
- make settings screen works back with storybook
- add i18n wrapper for storybook so that component that depend on LL are working property within storybooks