### PR TITLE
fix: refresh on send

### DIFF
--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -1,4 +1,5 @@
 import {
+  MainAuthedDocument,
   PaymentSendResult,
   useIntraLedgerPaymentSendMutation,
   useIntraLedgerUsdPaymentSendMutation,
@@ -11,7 +12,7 @@ import { useMemo } from "react"
 import { SendPayment } from "./payment-details/index.types"
 import { gql } from "@apollo/client"
 
-export type UseSendPaymentResult = {
+type UseSendPaymentResult = {
   loading: boolean
   sendPayment:
     | (() => Promise<{
@@ -82,19 +83,25 @@ export const useSendPayment = (
   sendPaymentFn?: SendPayment | null,
 ): UseSendPaymentResult => {
   const [intraLedgerPaymentSend, { loading: intraLedgerPaymentSendLoading }] =
-    useIntraLedgerPaymentSendMutation()
+    useIntraLedgerPaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const [intraLedgerUsdPaymentSend, { loading: intraLedgerUsdPaymentSendLoading }] =
-    useIntraLedgerUsdPaymentSendMutation()
+    useIntraLedgerUsdPaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const [lnInvoicePaymentSend, { loading: lnInvoicePaymentSendLoading }] =
-    useLnInvoicePaymentSendMutation()
+    useLnInvoicePaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const [lnNoAmountInvoicePaymentSend, { loading: lnNoAmountInvoicePaymentSendLoading }] =
-    useLnNoAmountInvoicePaymentSendMutation()
+    useLnNoAmountInvoicePaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const [
     lnNoAmountUsdInvoicePaymentSend,
     { loading: lnNoAmountUsdInvoicePaymentSendLoading },
-  ] = useLnNoAmountUsdInvoicePaymentSendMutation()
+  ] = useLnNoAmountUsdInvoicePaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const [onChainPaymentSend, { loading: onChainPaymentSendLoading }] =
-    useOnChainPaymentSendMutation()
+    useOnChainPaymentSendMutation({ refetchQueries: [MainAuthedDocument] })
+
   const loading =
     intraLedgerPaymentSendLoading ||
     intraLedgerUsdPaymentSendLoading ||


### PR DESCRIPTION
I don't quite get yet how all the send flow is working from a type perspective and the `sendPayment`, `sendPaymentFn` and `useSendPayment` and how it's flowing between screen and where argument are been set

in essence, the goal of this PR is to add `refetchQueries` as an argument to the payment mutation, but I don't think this is where it should be set because I would guess the argument are been passed somewhere else. 

I think my approach may work but @UncleSamtoshi can you double check?