### PR TITLE
chore: mark nightly build as prerelease by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
       - run: git pull origin main
       - run: git commit -a -m "ci$COLON new ios build [ci skip]"
       - run: git push -q -f
-      - run: gh release upload $CIRCLE_TAG "ios/output/gym/Bitcoin Beach.ipa" --clobber
+      - run: gh release upload $CIRCLE_TAG "ios/output/gym/Bitcoin Beach.ipa" --clobber --prerelease
       - store_artifacts:
           path: ios/output
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,12 +110,12 @@ jobs:
       - run: git add --force android/app/build/generated/sourcemaps/react/release
       - run: git commit -a -m "ci$COLON new android build [ci skip]"
       - run: git push -q -f
-      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-arm64-v8a-release.apk" --clobber
-      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-armeabi-v7a-release.apk" --clobber
-      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-universal-release.apk" --clobber
-      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-x86-release.apk" --clobber
-      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-x86_64-release.apk" --clobber
-      - run: gh release upload $CIRCLE_TAG "android/app/build/generated/sourcemaps/react/release/index.android.bundle.map" --clobber
+      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-arm64-v8a-release.apk" --clobber --prerelease
+      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-armeabi-v7a-release.apk" --clobber --prerelease
+      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-universal-release.apk" --clobber --prerelease
+      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-x86-release.apk" --clobber --prerelease
+      - run: gh release upload $CIRCLE_TAG "android/app/build/outputs/apk/release/app-x86_64-release.apk" --clobber --prerelease
+      - run: gh release upload $CIRCLE_TAG "android/app/build/generated/sourcemaps/react/release/index.android.bundle.map" --clobber --prerelease
       - store_artifacts:
           path: android/app/build/outputs
 


### PR DESCRIPTION
right now nightly build are marked as normal release. if someone were to install the app manually from github, they should now it's not a vetted version and could expect some newly introduced bugs