### PR TITLE
chore: make it possible to parse build number more easily

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,10 +143,8 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                    versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
-        // new:     defaultConfig.versionCode * 1000 + versionCodes.get(abi)
+                    versionCodes.get(abi) * 1000000 + defaultConfig.versionCode
             }
-
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,7 +143,7 @@ android {
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =
-                    versionCodes.get(abi) * 1000000 + defaultConfig.versionCode
+                    versionCodes.get(abi) * 10000000 + defaultConfig.versionCode
             }
         }
     }


### PR DESCRIPTION
not sure why implication this may have on the build if new build on a same arch have lower version