### PR TITLE
chore: use -intl version of js for jsc

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -77,7 +77,7 @@ def enableProguardInReleaseBuilds = true
  * give correct results when using with locales other than en-US. Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'org.webkit:android-jsc-intl:+'
 
 /**
  * Private function to get the list of Native Architectures you want to build.


### PR DESCRIPTION
this change is to be able to use react native debugger

currently there are some issues around using react native debugger with hermes.

so hermes should be deactivated when someone wants to use this tool, but the intl flavor needs to be used