### PR TITLE
chore: misc queries improvments

### DIFF
--- a/app/graphql/analytics.tsx
+++ b/app/graphql/analytics.tsx
@@ -1,11 +1,11 @@
 import analytics from "@react-native-firebase/analytics"
-import { useRootStackQuery } from "@app/graphql/generated"
+import { useAnalyticsQuery } from "@app/graphql/generated"
 import { gql } from "@apollo/client"
 import { useEffect } from "react"
 import { useIsAuthed } from "./is-authed-context"
 
 gql`
-  query rootStack {
+  query analytics {
     me {
       username
       id
@@ -19,7 +19,7 @@ gql`
 export const AnalyticsContainer = () => {
   const isAuthed = useIsAuthed()
 
-  const { data } = useRootStackQuery({
+  const { data } = useAnalyticsQuery({
     skip: !isAuthed,
     fetchPolicy: "cache-first",
   })

--- a/app/graphql/analytics.tsx
+++ b/app/graphql/analytics.tsx
@@ -5,8 +5,8 @@ import { useEffect } from "react"
 import { useIsAuthed } from "./is-authed-context"
 
 gql`
-  query rootStack($isAuthed: Boolean!) {
-    me @include(if: $isAuthed) {
+  query rootStack {
+    me {
       username
       id
     }
@@ -20,7 +20,7 @@ export const AnalyticsContainer = () => {
   const isAuthed = useIsAuthed()
 
   const { data } = useRootStackQuery({
-    variables: { isAuthed },
+    skip: !isAuthed,
     fetchPolicy: "cache-first",
   })
 

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -575,7 +575,7 @@ query mainAuthed {
       id
       defaultWalletId
       displayCurrency
-      transactions(first: 3) {
+      transactions(first: 20) {
         ...TransactionList
         __typename
       }

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -695,8 +695,8 @@ query receiveWrapperScreen {
   }
 }
 
-query rootStack($isAuthed: Boolean!) {
-  me @include(if: $isAuthed) {
+query rootStack {
+  me {
     username
     id
     __typename

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -437,6 +437,18 @@ query addressScreen {
   }
 }
 
+query analytics {
+  me {
+    username
+    id
+    __typename
+  }
+  globals {
+    network
+    __typename
+  }
+}
+
 query btcPrice {
   btcPrice {
     base
@@ -691,18 +703,6 @@ query receiveWrapperScreen {
       }
       __typename
     }
-    __typename
-  }
-}
-
-query rootStack {
-  me {
-    username
-    id
-    __typename
-  }
-  globals {
-    network
     __typename
   }
 }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1371,10 +1371,10 @@ export type BtcPriceListQueryVariables = Exact<{
 
 export type BtcPriceListQuery = { readonly __typename: 'Query', readonly btcPriceList?: ReadonlyArray<{ readonly __typename: 'PricePoint', readonly timestamp: number, readonly price: { readonly __typename: 'Price', readonly base: number, readonly offset: number, readonly currencyUnit: string } } | null> | null };
 
-export type RootStackQueryVariables = Exact<{ [key: string]: never; }>;
+export type AnalyticsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type RootStackQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null, readonly id: string } | null, readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null };
+export type AnalyticsQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null, readonly id: string } | null, readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null };
 
 export type MyWalletsFragment = { readonly __typename: 'ConsumerAccount', readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> };
 
@@ -1838,8 +1838,8 @@ export function useBtcPriceListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type BtcPriceListQueryHookResult = ReturnType<typeof useBtcPriceListQuery>;
 export type BtcPriceListLazyQueryHookResult = ReturnType<typeof useBtcPriceListLazyQuery>;
 export type BtcPriceListQueryResult = Apollo.QueryResult<BtcPriceListQuery, BtcPriceListQueryVariables>;
-export const RootStackDocument = gql`
-    query rootStack {
+export const AnalyticsDocument = gql`
+    query analytics {
   me {
     username
     id
@@ -1851,31 +1851,31 @@ export const RootStackDocument = gql`
     `;
 
 /**
- * __useRootStackQuery__
+ * __useAnalyticsQuery__
  *
- * To run a query within a React component, call `useRootStackQuery` and pass it any options that fit your needs.
- * When your component renders, `useRootStackQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useAnalyticsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAnalyticsQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useRootStackQuery({
+ * const { data, loading, error } = useAnalyticsQuery({
  *   variables: {
  *   },
  * });
  */
-export function useRootStackQuery(baseOptions?: Apollo.QueryHookOptions<RootStackQuery, RootStackQueryVariables>) {
+export function useAnalyticsQuery(baseOptions?: Apollo.QueryHookOptions<AnalyticsQuery, AnalyticsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<RootStackQuery, RootStackQueryVariables>(RootStackDocument, options);
+        return Apollo.useQuery<AnalyticsQuery, AnalyticsQueryVariables>(AnalyticsDocument, options);
       }
-export function useRootStackLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<RootStackQuery, RootStackQueryVariables>) {
+export function useAnalyticsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<AnalyticsQuery, AnalyticsQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<RootStackQuery, RootStackQueryVariables>(RootStackDocument, options);
+          return Apollo.useLazyQuery<AnalyticsQuery, AnalyticsQueryVariables>(AnalyticsDocument, options);
         }
-export type RootStackQueryHookResult = ReturnType<typeof useRootStackQuery>;
-export type RootStackLazyQueryHookResult = ReturnType<typeof useRootStackLazyQuery>;
-export type RootStackQueryResult = Apollo.QueryResult<RootStackQuery, RootStackQueryVariables>;
+export type AnalyticsQueryHookResult = ReturnType<typeof useAnalyticsQuery>;
+export type AnalyticsLazyQueryHookResult = ReturnType<typeof useAnalyticsLazyQuery>;
+export type AnalyticsQueryResult = Apollo.QueryResult<AnalyticsQuery, AnalyticsQueryVariables>;
 export const CurrentPriceDocument = gql`
     query currentPrice {
   btcPrice {

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1371,9 +1371,7 @@ export type BtcPriceListQueryVariables = Exact<{
 
 export type BtcPriceListQuery = { readonly __typename: 'Query', readonly btcPriceList?: ReadonlyArray<{ readonly __typename: 'PricePoint', readonly timestamp: number, readonly price: { readonly __typename: 'Price', readonly base: number, readonly offset: number, readonly currencyUnit: string } } | null> | null };
 
-export type RootStackQueryVariables = Exact<{
-  isAuthed: Scalars['Boolean'];
-}>;
+export type RootStackQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type RootStackQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null, readonly id: string } | null, readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null };
@@ -1841,8 +1839,8 @@ export type BtcPriceListQueryHookResult = ReturnType<typeof useBtcPriceListQuery
 export type BtcPriceListLazyQueryHookResult = ReturnType<typeof useBtcPriceListLazyQuery>;
 export type BtcPriceListQueryResult = Apollo.QueryResult<BtcPriceListQuery, BtcPriceListQueryVariables>;
 export const RootStackDocument = gql`
-    query rootStack($isAuthed: Boolean!) {
-  me @include(if: $isAuthed) {
+    query rootStack {
+  me {
     username
     id
   }
@@ -1864,11 +1862,10 @@ export const RootStackDocument = gql`
  * @example
  * const { data, loading, error } = useRootStackQuery({
  *   variables: {
- *      isAuthed: // value for 'isAuthed'
  *   },
  * });
  */
-export function useRootStackQuery(baseOptions: Apollo.QueryHookOptions<RootStackQuery, RootStackQueryVariables>) {
+export function useRootStackQuery(baseOptions?: Apollo.QueryHookOptions<RootStackQuery, RootStackQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<RootStackQuery, RootStackQueryVariables>(RootStackDocument, options);
       }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -2645,7 +2645,7 @@ export const MainAuthedDocument = gql`
       id
       defaultWalletId
       displayCurrency
-      transactions(first: 3) {
+      transactions(first: 20) {
         ...TransactionList
       }
       wallets {

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -168,7 +168,7 @@ gql`
         defaultWalletId
         displayCurrency
 
-        transactions(first: 3) {
+        transactions(first: 20) {
           ...TransactionList
         }
         wallets {


### PR DESCRIPTION
chore: separate tx query from the rest of the query
this allow to not reset the cache for tx for now on home refresh. this is a tradeoff because now all but the tx are been refetch from the home screen on refresh (ie: scroll down to show the "refresh" wheel)

I also increase the number of tx to 12 so that when someone move to tx they can see the first screen fully populated while the other transactions are been fetched in the background