### PR TITLE
chore: revert change on font

### DIFF
--- a/app/rne-theme/theme.ts
+++ b/app/rne-theme/theme.ts
@@ -38,9 +38,8 @@ const theme = createTheme({
     Text: (props, theme) => {
       const universalStyle = {
         color: props.color || theme.colors.grey5,
-        // FIXME: is it automatically selecting the right font?
-        // because there is only one?
-        // fontFamily: "SourceSansPro",
+        fontWeight: props.bold ? "600" : "400",
+        fontFamily: "SourceSansPro-Regular",
       }
 
       const sizeStyle = props.type


### PR DESCRIPTION
the red screen issue only appears on iOS. there is no error message on android.

but also if I have a random typo on android there is no error shown.