### PR TITLE
chore: force price refresh when sending/receiving a payment

### DIFF
--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -23,8 +23,16 @@ gql`
     realtimePrice {
       btcSatPrice {
         base
-        currencyUnit
         offset
+        currencyUnit
+      }
+      denominatorCurrency
+      id
+      timestamp
+      usdCentPrice {
+        base
+        offset
+        currencyUnit
       }
     }
   }

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -653,8 +653,17 @@ query realtimePrice {
   realtimePrice {
     btcSatPrice {
       base
-      currencyUnit
       offset
+      currencyUnit
+      __typename
+    }
+    denominatorCurrency
+    id
+    timestamp
+    usdCentPrice {
+      base
+      offset
+      currencyUnit
       __typename
     }
     __typename

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1429,7 +1429,7 @@ export type MyWalletsFragment = { readonly __typename: 'ConsumerAccount', readon
 export type RealtimePriceQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly currencyUnit: string, readonly offset: number } } };
+export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly denominatorCurrency: string, readonly id: string, readonly timestamp: number, readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly offset: number, readonly currencyUnit: string }, readonly usdCentPrice: { readonly __typename: 'PriceOfOneUsdCent', readonly base: number, readonly offset: number, readonly currencyUnit: string } } };
 
 export type HideBalanceQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1922,8 +1922,16 @@ export const RealtimePriceDocument = gql`
   realtimePrice {
     btcSatPrice {
       base
-      currencyUnit
       offset
+      currencyUnit
+    }
+    denominatorCurrency
+    id
+    timestamp
+    usdCentPrice {
+      base
+      offset
+      currencyUnit
     }
   }
 }

--- a/app/screens/receive-bitcoin-screen/receive-wrapper.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-wrapper.tsx
@@ -10,7 +10,11 @@ import { Text, View } from "react-native"
 import EStyleSheet from "react-native-extended-stylesheet"
 import { TouchableWithoutFeedback } from "react-native-gesture-handler"
 import ReceiveBtc from "./receive-btc"
-import { WalletCurrency, useReceiveWrapperScreenQuery } from "@app/graphql/generated"
+import {
+  WalletCurrency,
+  useReceiveWrapperScreenQuery,
+  useRealtimePriceQuery,
+} from "@app/graphql/generated"
 import { gql } from "@apollo/client"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { testProps } from "../../utils/testProps"
@@ -90,6 +94,11 @@ const ReceiveWrapperScreen = ({
   const { data } = useReceiveWrapperScreenQuery({
     fetchPolicy: "cache-first",
     skip: !isAuthed,
+  })
+
+  useRealtimePriceQuery({
+    fetchPolicy: "network-only",
+    skip: !useIsAuthed(),
   })
 
   const defaultCurrency = data?.me?.defaultAccount?.defaultWallet?.walletCurrency

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -13,6 +13,7 @@ import Icon from "react-native-vector-icons/Ionicons"
 import { gql } from "@apollo/client"
 import ScanIcon from "@app/assets/icons/scan.svg"
 import {
+  useRealtimePriceQuery,
   useSendBitcoinDestinationQuery,
   useUserDefaultWalletIdLazyQuery,
 } from "@app/graphql/generated"
@@ -171,6 +172,12 @@ const SendBitcoinDestinationScreen = ({
     returnPartialData: true,
     skip: !useIsAuthed(),
   })
+
+  useRealtimePriceQuery({
+    fetchPolicy: "network-only",
+    skip: !useIsAuthed(),
+  })
+
   const wallets = data?.me?.defaultAccount.wallets
   const bitcoinNetwork = data?.globals?.network
   const contacts = useMemo(() => data?.me?.contacts ?? [], [data?.me?.contacts])

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -815,7 +815,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d58428b28fe1f5070fe993495b0e2eaf701d3820
@@ -828,7 +828,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleMLKit: 0017a6a8372e1a182139b9def4d89be5d87ca5a7
@@ -846,7 +846,7 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
-  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
+  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: c154ebcfbf41d6fef86c52674fc1aa08837ff538
   RCTTypeSafety: 3063e5a1e5b1dc2cbeda5c8f8926c0ad1a6b0871
   React: 0a1a36e8e81cfaac244ed88b97f23ab56e5434f0


### PR DESCRIPTION
by fetching `realtimePrice`, we will automatically update the cache. 

if the price is stealth for whatever reason (websocket issue -- something else to debug), then we will have a very recent price in memory.