### PR TITLE
chore: first version of storybook for receive screen

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -47,6 +47,7 @@ const getStories = () => {
     require("../app/screens/phone-auth-screen/phone-validation.stories.tsx"),
     require("../app/screens/settings-screen/display-currency-screen.stories.tsx"),
     require("../app/screens/settings-screen/language-screen.stories.tsx"),
+    require("../app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx"),
     require("../app/screens/settings-screen/settings-screen.stories.tsx"),
     require("../app/screens/transaction-detail-screen/transaction-detail-screen.stories.tsx"),
     require("../app/screens/transaction-screen/transaction-screen.stories.tsx"),

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -21,7 +21,6 @@ gql`
 
   query realtimePrice {
     realtimePrice {
-      id
       btcSatPrice {
         base
         offset

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -21,6 +21,7 @@ gql`
 
   query realtimePrice {
     realtimePrice {
+      id
       btcSatPrice {
         base
         offset

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -727,10 +727,6 @@ query receiveWrapperScreen {
         walletCurrency
         __typename
       }
-      usdWallet @client {
-        id
-        __typename
-      }
       __typename
     }
     __typename

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -661,6 +661,7 @@ query quizSats {
 
 query realtimePrice {
   realtimePrice {
+    id
     btcSatPrice {
       base
       offset

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -515,11 +515,11 @@ query conversionScreen {
 
 query currencyList {
   currencyList {
+    __typename
     code
     flag
     name
     symbol
-    __typename
   }
 }
 
@@ -661,7 +661,6 @@ query quizSats {
 
 query realtimePrice {
   realtimePrice {
-    id
     btcSatPrice {
       base
       offset

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1429,7 +1429,7 @@ export type MyWalletsFragment = { readonly __typename: 'ConsumerAccount', readon
 export type RealtimePriceQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly denominatorCurrency: string, readonly id: string, readonly timestamp: number, readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly offset: number, readonly currencyUnit: string }, readonly usdCentPrice: { readonly __typename: 'PriceOfOneUsdCent', readonly base: number, readonly offset: number, readonly currencyUnit: string } } };
+export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly id: string, readonly denominatorCurrency: string, readonly timestamp: number, readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly offset: number, readonly currencyUnit: string }, readonly usdCentPrice: { readonly __typename: 'PriceOfOneUsdCent', readonly base: number, readonly offset: number, readonly currencyUnit: string } } };
 
 export type HideBalanceQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1925,6 +1925,7 @@ export type AnalyticsQueryResult = Apollo.QueryResult<AnalyticsQuery, AnalyticsQ
 export const RealtimePriceDocument = gql`
     query realtimePrice {
   realtimePrice {
+    id
     btcSatPrice {
       base
       offset

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1429,7 +1429,7 @@ export type MyWalletsFragment = { readonly __typename: 'ConsumerAccount', readon
 export type RealtimePriceQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly id: string, readonly denominatorCurrency: string, readonly timestamp: number, readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly offset: number, readonly currencyUnit: string }, readonly usdCentPrice: { readonly __typename: 'PriceOfOneUsdCent', readonly base: number, readonly offset: number, readonly currencyUnit: string } } };
+export type RealtimePriceQuery = { readonly __typename: 'Query', readonly realtimePrice: { readonly __typename: 'RealtimePrice', readonly denominatorCurrency: string, readonly id: string, readonly timestamp: number, readonly btcSatPrice: { readonly __typename: 'PriceOfOneSat', readonly base: number, readonly offset: number, readonly currencyUnit: string }, readonly usdCentPrice: { readonly __typename: 'PriceOfOneUsdCent', readonly base: number, readonly offset: number, readonly currencyUnit: string } } };
 
 export type HideBalanceQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1454,6 +1454,11 @@ export type DisplayCurrencyQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type DisplayCurrencyQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly displayCurrency: string } } | null };
+
+export type CurrencyListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type CurrencyListQuery = { readonly __typename: 'Query', readonly currencyList: ReadonlyArray<{ readonly __typename: 'Currency', readonly code: string, readonly flag: string, readonly name: string, readonly symbol: string }> };
 
 export type CaptchaCreateChallengeMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -1713,11 +1718,6 @@ export type AccountScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type AccountScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly phone?: string | null } | null };
 
-export type CurrencyListQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type CurrencyListQuery = { readonly __typename: 'Query', readonly currencyList: ReadonlyArray<{ readonly __typename: 'Currency', readonly code: string, readonly flag: string, readonly name: string, readonly symbol: string }> };
-
 export type AccountUpdateDisplayCurrencyMutationVariables = Exact<{
   input: AccountUpdateDisplayCurrencyInput;
 }>;
@@ -1925,7 +1925,6 @@ export type AnalyticsQueryResult = Apollo.QueryResult<AnalyticsQuery, AnalyticsQ
 export const RealtimePriceDocument = gql`
     query realtimePrice {
   realtimePrice {
-    id
     btcSatPrice {
       base
       offset
@@ -2134,6 +2133,44 @@ export function useDisplayCurrencyLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
 export type DisplayCurrencyQueryHookResult = ReturnType<typeof useDisplayCurrencyQuery>;
 export type DisplayCurrencyLazyQueryHookResult = ReturnType<typeof useDisplayCurrencyLazyQuery>;
 export type DisplayCurrencyQueryResult = Apollo.QueryResult<DisplayCurrencyQuery, DisplayCurrencyQueryVariables>;
+export const CurrencyListDocument = gql`
+    query currencyList {
+  currencyList {
+    __typename
+    code
+    flag
+    name
+    symbol
+  }
+}
+    `;
+
+/**
+ * __useCurrencyListQuery__
+ *
+ * To run a query within a React component, call `useCurrencyListQuery` and pass it any options that fit your needs.
+ * When your component renders, `useCurrencyListQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useCurrencyListQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useCurrencyListQuery(baseOptions?: Apollo.QueryHookOptions<CurrencyListQuery, CurrencyListQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CurrencyListQuery, CurrencyListQueryVariables>(CurrencyListDocument, options);
+      }
+export function useCurrencyListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrencyListQuery, CurrencyListQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CurrencyListQuery, CurrencyListQueryVariables>(CurrencyListDocument, options);
+        }
+export type CurrencyListQueryHookResult = ReturnType<typeof useCurrencyListQuery>;
+export type CurrencyListLazyQueryHookResult = ReturnType<typeof useCurrencyListLazyQuery>;
+export type CurrencyListQueryResult = Apollo.QueryResult<CurrencyListQuery, CurrencyListQueryVariables>;
 export const CaptchaCreateChallengeDocument = gql`
     mutation captchaCreateChallenge {
   captchaCreateChallenge {
@@ -3796,43 +3833,6 @@ export function useAccountScreenLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
 export type AccountScreenQueryHookResult = ReturnType<typeof useAccountScreenQuery>;
 export type AccountScreenLazyQueryHookResult = ReturnType<typeof useAccountScreenLazyQuery>;
 export type AccountScreenQueryResult = Apollo.QueryResult<AccountScreenQuery, AccountScreenQueryVariables>;
-export const CurrencyListDocument = gql`
-    query currencyList {
-  currencyList {
-    code
-    flag
-    name
-    symbol
-  }
-}
-    `;
-
-/**
- * __useCurrencyListQuery__
- *
- * To run a query within a React component, call `useCurrencyListQuery` and pass it any options that fit your needs.
- * When your component renders, `useCurrencyListQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useCurrencyListQuery({
- *   variables: {
- *   },
- * });
- */
-export function useCurrencyListQuery(baseOptions?: Apollo.QueryHookOptions<CurrencyListQuery, CurrencyListQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<CurrencyListQuery, CurrencyListQueryVariables>(CurrencyListDocument, options);
-      }
-export function useCurrencyListLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrencyListQuery, CurrencyListQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<CurrencyListQuery, CurrencyListQueryVariables>(CurrencyListDocument, options);
-        }
-export type CurrencyListQueryHookResult = ReturnType<typeof useCurrencyListQuery>;
-export type CurrencyListLazyQueryHookResult = ReturnType<typeof useCurrencyListLazyQuery>;
-export type CurrencyListQueryResult = Apollo.QueryResult<CurrencyListQuery, CurrencyListQueryVariables>;
 export const AccountUpdateDisplayCurrencyDocument = gql`
     mutation accountUpdateDisplayCurrency($input: AccountUpdateDisplayCurrencyInput!) {
   accountUpdateDisplayCurrency(input: $input) {

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1571,7 +1571,7 @@ export type ReceiveUsdQuery = { readonly __typename: 'Query', readonly globals?:
 export type ReceiveWrapperScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReceiveWrapperScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string } | null } } | null };
+export type ReceiveWrapperScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly walletCurrency: WalletCurrency } | null } } | null };
 
 export type LnNoAmountInvoiceCreateMutationVariables = Exact<{
   input: LnNoAmountInvoiceCreateInput;
@@ -2935,9 +2935,6 @@ export const ReceiveWrapperScreenDocument = gql`
       id
       defaultWallet @client {
         walletCurrency
-      }
-      usdWallet @client {
-        id
       }
     }
   }

--- a/app/hooks/use-display-currency.ts
+++ b/app/hooks/use-display-currency.ts
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client"
-import { useDisplayCurrencyQuery } from "@app/graphql/generated"
+import { useCurrencyListQuery, useDisplayCurrencyQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useCallback } from "react"
 
@@ -13,12 +13,25 @@ gql`
       }
     }
   }
+
+  query currencyList {
+    currencyList {
+      __typename
+      code
+      flag
+      name
+      symbol
+    }
+  }
 `
 
 export const useDisplayCurrency = () => {
   const isAuthed = useIsAuthed()
   const { data } = useDisplayCurrencyQuery({ skip: !isAuthed })
+  const { data: dataCurrencyList } = useCurrencyListQuery({ skip: !isAuthed })
   const displayCurrency = data?.me?.defaultAccount?.displayCurrency || "USD"
+
+  const currencyList = dataCurrencyList?.currencyList || []
 
   const formatToDisplayCurrency = useCallback(
     (amount: number) => {
@@ -30,7 +43,11 @@ export const useDisplayCurrency = () => {
     [displayCurrency],
   )
 
+  const fiatSymbol =
+    currencyList.find((currency) => currency.code === displayCurrency)?.symbol ?? "$"
+
   return {
     formatToDisplayCurrency,
+    fiatSymbol,
   }
 }

--- a/app/hooks/use-price-conversion.ts
+++ b/app/hooks/use-price-conversion.ts
@@ -9,7 +9,6 @@ import * as React from "react"
 export const usePriceConversion = () => {
   const { data } = useRealtimePriceQuery({
     query: RealtimePriceDocument,
-    fetchPolicy: "cache-only",
   })
 
   const base = data?.realtimePrice.btcSatPrice.base

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -66,9 +66,7 @@ export type RootStackParamList = {
   sectionCompleted: { amount: number; sectionTitle: string }
   priceHistory: undefined
   Profile: undefined
-  receiveBitcoin: {
-    receiveCurrency?: WalletCurrency
-  }
+  receiveBitcoin: undefined
   redeemBitcoinDetail: {
     receiveDestination: ReceiveDestination
   }

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -30,6 +30,7 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useReceiveBitcoin } from "./use-payment-request"
 import { PaymentRequestState } from "./use-payment-request.types"
 import { PaymentRequest } from "./payment-requests/index.types"
+import { BtcPaymentAmount } from "@app/types/amounts"
 
 const styles = EStyleSheet.create({
   container: {
@@ -198,7 +199,18 @@ const ReceiveBtc = () => {
 
   // initialize useReceiveBitcoin hook
   useEffect(() => {
-    if (!createPaymentRequestDetailsParams && network && btcWalletId) {
+    if (
+      !createPaymentRequestDetailsParams &&
+      network &&
+      btcWalletId &&
+      // TODO: improve readability on when this function is available
+      !isNaN(
+        _convertPaymentAmount(
+          { amount: 0, currency: WalletCurrency.Btc } as BtcPaymentAmount,
+          WalletCurrency.Btc,
+        ).amount,
+      )
+    ) {
       setCreatePaymentRequestDetailsParams(
         {
           bitcoinNetwork: network,

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -311,6 +311,12 @@ const ReceiveBtc = () => {
   if (showAmountInput && unitOfAccountAmount && btcAmount && usdAmount) {
     const validAmount = Boolean(paymentRequestDetails.unitOfAccountAmount.amount)
 
+    console.log({
+      btcAmount,
+      usdAmount,
+      paymentRequestDetails,
+    })
+
     return (
       <View style={[styles.inputForm, styles.container]}>
         <View style={styles.currencyInputContainer}>

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -326,12 +326,6 @@ const ReceiveBtc = () => {
   if (showAmountInput && unitOfAccountAmount && btcAmount && usdAmount) {
     const validAmount = Boolean(paymentRequestDetails.unitOfAccountAmount.amount)
 
-    console.log({
-      btcAmount,
-      usdAmount,
-      paymentRequestDetails,
-    })
-
     return (
       <View style={[styles.inputForm, styles.container]}>
         <View style={styles.currencyInputContainer}>

--- a/app/screens/receive-bitcoin-screen/receive-btc.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-btc.tsx
@@ -31,6 +31,7 @@ import { useReceiveBitcoin } from "./use-payment-request"
 import { PaymentRequestState } from "./use-payment-request.types"
 import { PaymentRequest } from "./payment-requests/index.types"
 import { BtcPaymentAmount } from "@app/types/amounts"
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 
 const styles = EStyleSheet.create({
   container: {
@@ -174,6 +175,8 @@ gql`
 `
 
 const ReceiveBtc = () => {
+  const { fiatSymbol } = useDisplayCurrency()
+
   const [showMemoInput, setShowMemoInput] = useState(false)
   const [showAmountInput, setShowAmountInput] = useState(false)
   const {
@@ -349,7 +352,7 @@ const ReceiveBtc = () => {
                 />
                 <FakeCurrencyInput
                   value={paymentAmountToDollarsOrSats(usdAmount)}
-                  prefix="$"
+                  prefix={fiatSymbol}
                   delimiter=","
                   separator="."
                   precision={2}
@@ -364,7 +367,7 @@ const ReceiveBtc = () => {
                 <FakeCurrencyInput
                   value={paymentAmountToDollarsOrSats(usdAmount)}
                   onChangeValue={setAmountsWithUsd}
-                  prefix="$"
+                  prefix={fiatSymbol}
                   delimiter=","
                   separator="."
                   precision={2}

--- a/app/screens/receive-bitcoin-screen/receive-usd.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-usd.tsx
@@ -31,6 +31,7 @@ import {
 } from "@app/utils/currencyConversion"
 import { PaymentRequestState } from "./use-payment-request.types"
 import { TranslationFunctions } from "@app/i18n/i18n-types"
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 
 const styles = EStyleSheet.create({
   container: {
@@ -161,6 +162,8 @@ gql`
 `
 
 const ReceiveUsd = () => {
+  const { fiatSymbol } = useDisplayCurrency()
+
   const [showMemoInput, setShowMemoInput] = useState(false)
   const [showAmountInput, setShowAmountInput] = useState(false)
   const { data } = useReceiveUsdQuery({ skip: !useIsAuthed() })
@@ -274,7 +277,7 @@ const ReceiveUsd = () => {
             <FakeCurrencyInput
               value={paymentAmountToDollarsOrSats(unitOfAccountAmount)}
               onChangeValue={setAmountsWithUsd}
-              prefix="$"
+              prefix={fiatSymbol}
               delimiter=","
               separator="."
               precision={2}

--- a/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
@@ -1,0 +1,151 @@
+import React from "react"
+import { PersistentStateWrapper, StoryScreen } from "../../../.storybook/views"
+import { ComponentMeta } from "@storybook/react"
+import { MockedProvider } from "@apollo/client/testing"
+import {
+  LnNoAmountInvoiceCreateDocument,
+  ReceiveBtcDocument,
+  ReceiveUsdDocument,
+  ReceiveWrapperScreenDocument,
+} from "../../graphql/generated"
+import { createCache } from "../../graphql/cache"
+import { IsAuthedContextProvider } from "../../graphql/is-authed-context"
+import ReceiveWrapperScreen from "./receive-wrapper"
+
+const mocks = [
+  {
+    request: {
+      query: ReceiveWrapperScreenDocument,
+    },
+    result: {
+      data: {
+        // realtimePrice: {
+        //   btcSatPrice: {
+        //     base: 24120080078,
+        //     offset: 12,
+        //     currencyUnit: "USDCENT",
+        //     __typename: "PriceOfOneSat",
+        //   },
+        //   denominatorCurrency: "USD",
+        //   id: "c3a56244-1000-5c36-a92f-493557e73f05",
+        //   timestamp: 1677060131,
+        //   usdCentPrice: {
+        //     base: 100000000,
+        //     offset: 6,
+        //     currencyUnit: "USDCENT",
+        //     __typename: "PriceOfOneUsdCent",
+        //   },
+        //   __typename: "RealtimePrice",
+        // },
+        me: {
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            defaultWallet: {
+              walletCurrency: "BTC",
+              __typename: "BTCWallet",
+              id: "f79792e3-282b-45d4-85d5-7486d020def5",
+            },
+            __typename: "ConsumerAccount",
+          },
+          __typename: "User",
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: ReceiveUsdDocument,
+    },
+    result: {
+      data: {
+        globals: {
+          __typename: "Globals",
+          network: "mainnet",
+        },
+        me: {
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            usdWallet: {
+              __typename: "UsdWallet",
+              id: "f091c102-6277-4cc6-8d81-87ebf6aaad1b",
+            },
+            __typename: "ConsumerAccount",
+          },
+          __typename: "User",
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: ReceiveBtcDocument,
+    },
+    result: {
+      data: {
+        globals: {
+          network: "mainnet",
+          __typename: "Globals",
+        },
+        me: {
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            __typename: "ConsumerAccount",
+            btcWallet: {
+              id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+              __typename: "BTCWallet",
+            },
+          },
+          __typename: "User",
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: LnNoAmountInvoiceCreateDocument,
+      variables: {
+        input: { walletId: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8", memo: undefined },
+      },
+    },
+    result: {
+      data: {
+        lnNoAmountInvoiceCreate: {
+          invoice: {
+            paymentRequest:
+              "lnbc1p3lwh3npp5z5wkmy86gcww9u2h8tuekqmfz4pwlpkk4rfst8cm7jwzm8fklldsdqqcqzpuxqyz5vqsp52fv968tprd3dqkuqsq78nw8s0xr9zn7rx686ukq2rfnsdf27pwtq9qyyssqhc7m7d3gfvdsywx956d3u3h45xyf7xurc6yv5qxysspjnhhxstl3wet525ldxn3x6xd0g58nk6wuvwle0fhn5sul396za3qs5ma7zxsqjvklym",
+            paymentHash:
+              "0ab7a842956c260e1270a46d09e964ac15e0623d4f2d8d4b62af5a608f4c5e06",
+            paymentSecret:
+              "8c92e0f1db2374806ec11e8fea3d1513171bee9304dd54e33a4f2c0347b42006",
+            __typename: "LnNoAmountInvoice",
+          },
+          errors: [],
+          __typename: "LnNoAmountInvoicePayload",
+        },
+      },
+    },
+  },
+]
+
+export default {
+  title: "Receive",
+  component: ReceiveWrapperScreen,
+  decorators: [
+    (Story) => (
+      <PersistentStateWrapper>
+        <MockedProvider mocks={mocks} cache={createCache()}>
+          <StoryScreen>{Story()}</StoryScreen>
+        </MockedProvider>
+      </PersistentStateWrapper>
+    ),
+  ],
+} as ComponentMeta<typeof ReceiveWrapperScreen>
+
+export const Main = () => (
+  <IsAuthedContextProvider value={true}>
+    <ReceiveWrapperScreen />
+  </IsAuthedContextProvider>
+)

--- a/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
@@ -3,6 +3,8 @@ import { PersistentStateWrapper, StoryScreen } from "../../../.storybook/views"
 import { ComponentMeta } from "@storybook/react"
 import { MockedProvider } from "@apollo/client/testing"
 import {
+  CurrencyListDocument,
+  DisplayCurrencyDocument,
   LnNoAmountInvoiceCreateDocument,
   RealtimePriceDocument,
   ReceiveBtcDocument,
@@ -113,20 +115,96 @@ const mocks = [
   },
   {
     request: {
+      query: LnNoAmountInvoiceCreateDocument,
+      variables: {
+        input: { walletId: "f091c102-6277-4cc6-8d81-87ebf6aaad1b", memo: undefined },
+      },
+    },
+    result: {
+      data: {
+        lnNoAmountInvoiceCreate: {
+          invoice: {
+            paymentRequest:
+              "lnbc1p3lwh3npp5z5wkmy86gcww9u2h8tuekqmfz4pwlpkk4rfst8cm7jwzm8fklldsdqqcqzpuxqyz5vqsp52fv968tprd3dqkuqsq78nw8s0xr9zn7rx686ukq2rfnsdf27pwtq9qyyssqhc7m7d3gfvdsywx956d3u3h45xyf7xurc6yv5qxysspjnhhxstl3wet525ldxn3x6xd0g58nk6wuvwle0fhn5sul396za3qs5ma7zxsqjvklym",
+            paymentHash:
+              "0ab7a842956c260e1270a46d09e964ac15e0623d4f2d8d4b62af5a608f4c5e06",
+            paymentSecret:
+              "8c92e0f1db2374806ec11e8fea3d1513171bee9304dd54e33a4f2c0347b42006",
+            __typename: "LnNoAmountInvoice",
+          },
+          errors: [],
+          __typename: "LnNoAmountInvoicePayload",
+        },
+      },
+    },
+  },
+  {
+    request: {
       query: RealtimePriceDocument,
     },
     result: {
       data: {
         realtimePrice: {
-          id: "c3a56244-1000-5c36-a92f-493557e73f05",
           btcSatPrice: {
-            base: 24120080078,
+            base: 24015009766,
             offset: 12,
             currencyUnit: "USDCENT",
             __typename: "PriceOfOneSat",
           },
+          denominatorCurrency: "USD",
+          id: "67b6e1d2-04c8-509a-abbd-b1cab08575d5",
+          timestamp: 1677184189,
+          usdCentPrice: {
+            base: 100000000,
+            offset: 6,
+            currencyUnit: "USDCENT",
+            __typename: "PriceOfOneUsdCent",
+          },
           __typename: "RealtimePrice",
         },
+      },
+    },
+  },
+  {
+    request: {
+      query: DisplayCurrencyDocument,
+    },
+    result: {
+      data: {
+        me: {
+          __typename: "User",
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            __typename: "ConsumerAccount",
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            displayCurrency: "EUR",
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: CurrencyListDocument,
+    },
+    result: {
+      data: {
+        currencyList: [
+          {
+            __typename: "Currency",
+            code: "USD",
+            flag: "🇺🇸",
+            name: "US Dollar",
+            symbol: "$",
+          },
+          {
+            __typename: "Currency",
+            code: "EUR",
+            flag: "🇪🇺",
+            name: "Euro",
+            symbol: "€",
+          },
+        ],
       },
     },
   },

--- a/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-wrapper.stories.tsx
@@ -4,6 +4,7 @@ import { ComponentMeta } from "@storybook/react"
 import { MockedProvider } from "@apollo/client/testing"
 import {
   LnNoAmountInvoiceCreateDocument,
+  RealtimePriceDocument,
   ReceiveBtcDocument,
   ReceiveUsdDocument,
   ReceiveWrapperScreenDocument,
@@ -19,24 +20,6 @@ const mocks = [
     },
     result: {
       data: {
-        // realtimePrice: {
-        //   btcSatPrice: {
-        //     base: 24120080078,
-        //     offset: 12,
-        //     currencyUnit: "USDCENT",
-        //     __typename: "PriceOfOneSat",
-        //   },
-        //   denominatorCurrency: "USD",
-        //   id: "c3a56244-1000-5c36-a92f-493557e73f05",
-        //   timestamp: 1677060131,
-        //   usdCentPrice: {
-        //     base: 100000000,
-        //     offset: 6,
-        //     currencyUnit: "USDCENT",
-        //     __typename: "PriceOfOneUsdCent",
-        //   },
-        //   __typename: "RealtimePrice",
-        // },
         me: {
           id: "70df9822-efe0-419c-b864-c9efa99872ea",
           defaultAccount: {
@@ -124,6 +107,25 @@ const mocks = [
           },
           errors: [],
           __typename: "LnNoAmountInvoicePayload",
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: RealtimePriceDocument,
+    },
+    result: {
+      data: {
+        realtimePrice: {
+          id: "c3a56244-1000-5c36-a92f-493557e73f05",
+          btcSatPrice: {
+            base: 24120080078,
+            offset: 12,
+            currencyUnit: "USDCENT",
+            __typename: "PriceOfOneSat",
+          },
+          __typename: "RealtimePrice",
         },
       },
     },

--- a/app/screens/settings-screen/display-currency-screen.tsx
+++ b/app/screens/settings-screen/display-currency-screen.tsx
@@ -19,15 +19,6 @@ const styles = EStyleSheet.create({
 })
 
 gql`
-  query currencyList {
-    currencyList {
-      code
-      flag
-      name
-      symbol
-    }
-  }
-
   mutation accountUpdateDisplayCurrency($input: AccountUpdateDisplayCurrencyInput!) {
     accountUpdateDisplayCurrency(input: $input) {
       errors {


### PR DESCRIPTION
- adding storybook for receive screen. only query on loaded up been mocked right now. 
- removing the backward compatibility with pre-USD wallet (when I see them). I don't think we want to maintain the complexity of having BTC only wallet going forward. it adds boilerplate. if someone wants a BTC only wallet then they can fork and adapt the code. 