### PR TITLE
chore: incorrect invoice expiration

### DIFF
--- a/app/screens/receive-bitcoin-screen/receive-usd.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-usd.tsx
@@ -519,7 +519,8 @@ const TimeInformation = ({
     return () => clearInterval(interval)
   }, [checkExpiredAndGetRemainingSeconds, setTimeLeft, timeLeft])
 
-  if (typeof timeLeft !== "number") {
+  const hourInSeconds = 60 * 60
+  if (typeof timeLeft !== "number" || timeLeft > hourInSeconds) {
     return <></>
   }
 


### PR DESCRIPTION
- only show invoice expiration if remaining time is less than an hour