### PR TITLE
fix: set username issue in address screen

### DIFF
--- a/app/screens/galoy-address-screen/galoy-address-screen.tsx
+++ b/app/screens/galoy-address-screen/galoy-address-screen.tsx
@@ -92,7 +92,10 @@ gql`
 export const GaloyAddressScreen = () => {
   const { LL } = useI18nContext()
   const isAuthed = useIsAuthed()
-  const { data } = useAddressScreenQuery({ fetchPolicy: "cache-first", skip: !isAuthed })
+  const { data } = useAddressScreenQuery({
+    fetchPolicy: "cache-and-network",
+    skip: !isAuthed,
+  })
 
   const [chooseAddressModalVisible, setChooseAddressModalVisible] = React.useState(false)
   const { appConfig } = useAppConfig()

--- a/app/screens/galoy-address-screen/galoy-address-screen.tsx
+++ b/app/screens/galoy-address-screen/galoy-address-screen.tsx
@@ -93,7 +93,7 @@ export const GaloyAddressScreen = () => {
   const { LL } = useI18nContext()
   const isAuthed = useIsAuthed()
   const { data } = useAddressScreenQuery({
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: "cache-first",
     skip: !isAuthed,
   })
 

--- a/app/screens/galoy-address-screen/set-address-modal.tsx
+++ b/app/screens/galoy-address-screen/set-address-modal.tsx
@@ -10,7 +10,10 @@ import { useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { useAppConfig } from "@app/hooks/use-app-config"
-import { useUserUpdateUsernameMutation } from "@app/graphql/generated"
+import {
+  useUserUpdateUsernameMutation,
+  AddressScreenDocument,
+} from "@app/graphql/generated"
 import { gql } from "@apollo/client"
 
 const styles = EStyleSheet.create({
@@ -149,6 +152,7 @@ export const SetAddressModal = ({ modalVisible, toggleModal }: SetAddressModalPr
           username: address,
         },
       },
+      refetchQueries: [AddressScreenDocument],
     })
 
     if ((data?.userUpdateUsername?.errors ?? []).length > 0) {


### PR DESCRIPTION
This fix ensures that when the user sets his/her username, we query for an update is that when the user presses the back or home button, the `set address` modal is not rendered as we currently have it.