### PR TITLE
ci: disable circleci test_in_pr workflow on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,9 @@ workflows:
     jobs:
       - build_ios
   test_in_pr:
+    when:
+      not:
+        equal: [main, << pipeline.git.branch >>]
     jobs:
       - test_android_in_pr
       - test_ios_in_pr


### PR DESCRIPTION
This will disable the test in pr workflow on the main branch as it's redundant: we do it via concourse on every merge to main anyway.
