### PR TITLE
fix: prevent usd wallet for onchain send

### DIFF
--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -827,12 +827,14 @@ query sendBitcoinDetailsScreen {
       }
       btcWallet @client {
         id
+        walletCurrency
         balance
         displayBalance
         __typename
       }
       usdWallet @client {
         id
+        walletCurrency
         balance
         displayBalance
         __typename

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1645,7 +1645,7 @@ export type SendBitcoinDestinationQuery = { readonly __typename: 'Query', readon
 export type SendBitcoinDetailsScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type SendBitcoinDetailsScreenQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly displayBalance: number } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly displayBalance: number } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number }> } } | null };
+export type SendBitcoinDetailsScreenQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency } | null, readonly btcWallet?: { readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number, readonly displayBalance: number } | null, readonly usdWallet?: { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number, readonly displayBalance: number } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number } | { readonly __typename: 'UsdWallet', readonly id: string, readonly walletCurrency: WalletCurrency, readonly balance: number }> } } | null };
 
 export type LnNoAmountInvoiceFeeProbeMutationVariables = Exact<{
   input: LnNoAmountInvoiceFeeProbeInput;
@@ -3403,11 +3403,13 @@ export const SendBitcoinDetailsScreenDocument = gql`
       }
       btcWallet @client {
         id
+        walletCurrency
         balance
         displayBalance
       }
       usdWallet @client {
         id
+        walletCurrency
         balance
         displayBalance
       }

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -594,6 +594,7 @@ const en: BaseTranslation = {
     note: "Note or label",
     success: "Payment has been sent successfully",
     title: "Send Bitcoin",
+    walletDoesNotSupportOnchain: "This wallet does not support onchain payments yet. Try using a different wallet.",
     failedToFetchLnurlInvoice: "Failed to fetch lnurl invoice",
     lnurlInvoiceIncorrectAmount: "The lnurl server responded with an invoice with an incorrect amount.",
     lnurlInvoiceIncorrectDescription: "The lnurl server responded with an invoice with an incorrect description hash.",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -1982,6 +1982,10 @@ type RootTranslation = {
 		 */
 		title: string
 		/**
+		 * T​h​i​s​ ​w​a​l​l​e​t​ ​d​o​e​s​ ​n​o​t​ ​s​u​p​p​o​r​t​ ​o​n​c​h​a​i​n​ ​p​a​y​m​e​n​t​s​ ​y​e​t​.​ ​T​r​y​ ​u​s​i​n​g​ ​a​ ​d​i​f​f​e​r​e​n​t​ ​w​a​l​l​e​t​.
+		 */
+		walletDoesNotSupportOnchain: string
+		/**
 		 * F​a​i​l​e​d​ ​t​o​ ​f​e​t​c​h​ ​l​n​u​r​l​ ​i​n​v​o​i​c​e
 		 */
 		failedToFetchLnurlInvoice: string
@@ -4625,6 +4629,10 @@ export type TranslationFunctions = {
 		 * Send Bitcoin
 		 */
 		title: () => LocalizedString
+		/**
+		 * This wallet does not support onchain payments yet. Try using a different wallet.
+		 */
+		walletDoesNotSupportOnchain: () => LocalizedString
 		/**
 		 * Failed to fetch lnurl invoice
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -584,6 +584,7 @@
         "note": "Note or label",
         "success": "Payment has been sent successfully",
         "title": "Send Bitcoin",
+        "walletDoesNotSupportOnchain": "This wallet does not support onchain payments yet. Try using a different wallet.",
         "failedToFetchLnurlInvoice": "Failed to fetch lnurl invoice",
         "lnurlInvoiceIncorrectAmount": "The lnurl server responded with an invoice with an incorrect amount.",
         "lnurlInvoiceIncorrectDescription": "The lnurl server responded with an invoice with an incorrect description hash."


### PR DESCRIPTION
- use btcwallet as default for onchain payments
- alert user when selecting a usd wallet that it is not supported for onchain