### PR TITLE
ci: test conventional commit

### DIFF
--- a/.github/workflows/conventional.yaml
+++ b/.github/workflows/conventional.yaml
@@ -11,4 +11,6 @@ jobs:
       uses: Namchee/conventional-pr@v0.12.1
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
-
+        message: this PR needs to be updated to follow conventional commits message
+        body: false
+        issue: false

--- a/.github/workflows/conventional.yaml
+++ b/.github/workflows/conventional.yaml
@@ -1,0 +1,14 @@
+name: "Conventional commits"
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  conventional:
+    name: "Conventional commits"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Conventional PR
+      uses: Namchee/conventional-pr@v0.12.1
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
as we get more open source contributions, we want to enforce the convention commit rules. so adding a github action for it. 