### PR TITLE
chore: reduce android build size using android app bundles

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,6 +103,22 @@ android {
         versionName "2.1.55"
         missingDimensionStrategy 'react-native-camera', 'general' // React native camera
     }
+    buildFeatures {
+        viewBinding = true
+    }
+    bundle {
+        // use android app bundle instead of apk (https://developer.android.com/guide/app-bundle)
+        // https://developer.android.com/topic/performance/reduce-apk-size#app_bundle
+        language {
+            enableSplit = false
+        }
+        density {
+            enableSplit = true
+        }
+        abi {
+            enableSplit = true
+        }
+    }
     splits {
         abi {
             reset()

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -831,7 +831,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleMLKit: 0017a6a8372e1a182139b9def4d89be5d87ca5a7


### PR DESCRIPTION
This PR is an attempt to reduce the bundle size for android. The last android update (to v2.1.67) was about `89mb` which is too large in my opinion. 
the google docs recommend using Android app bundles instead of Apk's to reduce bundle size and it is new reommended method.
see docs here       https://developer.android.com/topic/performance/reduce-apk-size#app_bundle

One thing we need to do is to update the fastlane commands for uploading to playstore to use the .aab files instead of apk's https://docs.fastlane.tools/actions/upload_to_play_store/

I couldn't test this locally cox i needed to sign the new build (compulsory for aab) for which I dont have the signing certificate.
