### PR TITLE
ci: disable colors in fastlane build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,7 @@ jobs:
           command: |
             cd android
             sed -i'' -e "s/versionCode .*$/versionCode $BUILD_NUMBER/g" app/build.gradle
+            export NO_COLOR=1
             bundle exec fastlane android build 2>&1 | tee android_build_output.log
           no_output_timeout: 15m
       - run:
@@ -243,6 +244,7 @@ jobs:
           command: |
             cd ios
             sed -i'' -e "s/MARKETING_VERSION.*/MARKETING_VERSION = $PUBLIC_VERSION;/g" GaloyApp.xcodeproj/project.pbxproj
+            export NO_COLOR=1
             bundle exec fastlane build 2>&1 | tee ios_build_output.log
           no_output_timeout: 15m
       - run:


### PR DESCRIPTION
The color characters are not rendered correctly in the build artifacts, so disabling them to allow for displaying in concourse.
