### PR TITLE
fix: send flow when switching wallets

### DIFF
--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1165,6 +1165,7 @@ export type Transaction = {
   readonly settlementCurrency: WalletCurrency;
   readonly settlementDisplayAmount: Scalars['SignedDisplayMajorAmount'];
   readonly settlementDisplayCurrency: Scalars['DisplayCurrency'];
+  readonly settlementDisplayFee: Scalars['SignedDisplayMajorAmount'];
   readonly settlementFee: Scalars['SignedAmount'];
   /** Price in USDCENT/SETTLEMENTUNIT at time of settlement. */
   readonly settlementPrice: Price;

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -387,12 +387,22 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
       toggleModal()
       return
     }
-    setPaymentDetail(
-      paymentDetail.setSendingWalletDescriptor({
-        id: wallet.id,
-        currency: wallet.walletCurrency,
-      }),
-    )
+
+    let updatedPaymentDetail = paymentDetail.setSendingWalletDescriptor({
+      id: wallet.id,
+      currency: wallet.walletCurrency,
+    })
+
+    // switch back to the display currency
+    if (updatedPaymentDetail.canSetAmount) {
+      const displayAmount = updatedPaymentDetail.convertPaymentAmount(
+        paymentDetail.unitOfAccountAmount,
+        DisplayCurrency,
+      )
+      updatedPaymentDetail = updatedPaymentDetail.setAmount(displayAmount)
+    }
+
+    setPaymentDetail(updatedPaymentDetail)
     toggleModal()
   }
 


### PR DESCRIPTION
- fixes issue when switching between usd and btc wallets in the send flow where the currency was stuck in the settlement amount for the previous wallet