### PR TITLE
chore: refactoring persistent state

### DIFF
--- a/.storybook/views/story-screen.tsx
+++ b/.storybook/views/story-screen.tsx
@@ -7,18 +7,11 @@ export const PersistentStateWrapper: React.FC<React.PropsWithChildren> = ({ chil
   <PersistentStateContext.Provider
     value={{
       persistentState: {
-        schemaVersion: 4,
-        hasShownStableSatsWelcome: true,
-        isUsdDisabled: false,
+        schemaVersion: 5,
         galoyInstance: {
           name: "BBW",
-          graphqlUri: "",
-          graphqlWsUri: "",
-          posUrl: "",
-          lnAddressHostname: "",
         },
         galoyAuthToken: "",
-        isAnalyticsEnabled: true,
       },
       updateState: () => {},
       resetState: () => {},

--- a/.storybook/views/story-screen.tsx
+++ b/.storybook/views/story-screen.tsx
@@ -9,7 +9,7 @@ export const PersistentStateWrapper: React.FC<React.PropsWithChildren> = ({ chil
       persistentState: {
         schemaVersion: 5,
         galoyInstance: {
-          name: "BBW",
+          id: "Main",
         },
         galoyAuthToken: "",
       },

--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -20,6 +20,7 @@ it("get a full object with Custom", () => {
     graphqlWsUri: "ws://ws.custom.com/graphql",
     posUrl: "https://pay.custom.com/",
     lnAddressHostname: "custom.com",
+    blockExplorer: "https://mempool.space/tx/",
   } as const
 
   const res = maybeAddDefault(CustomInstance)

--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -1,13 +1,13 @@
-import { maybeAddDefault, GALOY_INSTANCES } from "@app/config"
+import { resolveGaloyInstanceOrDefault, GALOY_INSTANCES } from "@app/config"
 
 it("get a full object with BBW", () => {
-  const res = maybeAddDefault({ id: "Main" })
+  const res = resolveGaloyInstanceOrDefault({ id: "Main" })
 
   expect(res).toBe(GALOY_INSTANCES[0])
 })
 
 it("get a full object with Staging", () => {
-  const res = maybeAddDefault({ id: "Staging" })
+  const res = resolveGaloyInstanceOrDefault({ id: "Staging" })
 
   expect(res).toBe(GALOY_INSTANCES[1])
 })
@@ -23,7 +23,7 @@ it("get a full object with Custom", () => {
     blockExplorer: "https://mempool.space/tx/",
   } as const
 
-  const res = maybeAddDefault(CustomInstance)
+  const res = resolveGaloyInstanceOrDefault(CustomInstance)
 
   expect(res).toBe(CustomInstance)
 })

--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -1,19 +1,20 @@
 import { maybeAddDefault, GALOY_INSTANCES } from "@app/config"
 
 it("get a full object with BBW", () => {
-  const res = maybeAddDefault({ name: "BBW" })
+  const res = maybeAddDefault({ id: "Main" })
 
   expect(res).toBe(GALOY_INSTANCES[0])
 })
 
 it("get a full object with Staging", () => {
-  const res = maybeAddDefault({ name: "Staging" })
+  const res = maybeAddDefault({ id: "Staging" })
 
   expect(res).toBe(GALOY_INSTANCES[1])
 })
 
 it("get a full object with Custom", () => {
   const CustomInstance = {
+    id: "Custom",
     name: "Custom",
     graphqlUri: "https://api.custom.com/graphql",
     graphqlWsUri: "ws://ws.custom.com/graphql",

--- a/__tests__/config/galoy-instances.spec.ts
+++ b/__tests__/config/galoy-instances.spec.ts
@@ -1,0 +1,27 @@
+import { maybeAddDefault, GALOY_INSTANCES } from "@app/config"
+
+it("get a full object with BBW", () => {
+  const res = maybeAddDefault({ name: "BBW" })
+
+  expect(res).toBe(GALOY_INSTANCES[0])
+})
+
+it("get a full object with Staging", () => {
+  const res = maybeAddDefault({ name: "Staging" })
+
+  expect(res).toBe(GALOY_INSTANCES[1])
+})
+
+it("get a full object with Custom", () => {
+  const CustomInstance = {
+    name: "Custom",
+    graphqlUri: "https://api.custom.com/graphql",
+    graphqlWsUri: "ws://ws.custom.com/graphql",
+    posUrl: "https://pay.custom.com/",
+    lnAddressHostname: "custom.com",
+  } as const
+
+  const res = maybeAddDefault(CustomInstance)
+
+  expect(res).toBe(CustomInstance)
+})

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -33,6 +33,7 @@ it("migration from 4 to 5", async () => {
     hasShownStableSatsWelcome: false,
     isUsdDisabled: false,
     galoyInstance: {
+      id: "Main",
       name: "BBW",
       graphqlUri: "https://api.mainnet.galoy.io/graphql",
       graphqlWsUri: "wss://api.mainnet.galoy.io/graphql",
@@ -46,7 +47,7 @@ it("migration from 4 to 5", async () => {
 
   const state5 = {
     schemaVersion: 5,
-    galoyInstance: { name: "BBW" },
+    galoyInstance: { id: "Main" },
     galoyAuthToken: "myToken",
   }
 

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -1,27 +1,56 @@
 import {
   defaultPersistentState,
-  deserializeAndMigratePersistentState,
+  migrateAndGetPersistentState,
 } from "../app/store/persistent-state/state-migrations"
 
 it("uses default state when none is present", async () => {
-  const state = await deserializeAndMigratePersistentState({})
+  const state = await migrateAndGetPersistentState({})
   expect(state).toEqual(defaultPersistentState)
 })
 
 it("migrates persistent state", async () => {
-  const state = await deserializeAndMigratePersistentState({
+  const state = await migrateAndGetPersistentState({
     schemaVersion: 0,
     isUsdDisabled: true,
   })
   expect(state).toEqual({
     ...defaultPersistentState,
-    isUsdDisabled: true,
   })
 })
 
 it("returns default when schema is not present", async () => {
-  const state = await deserializeAndMigratePersistentState({
+  const state = await migrateAndGetPersistentState({
     schemaVersion: -2,
   })
   expect(state).toEqual(defaultPersistentState)
+})
+
+import { defaultTheme } from "@app/theme/default-theme"
+
+it("migration from 4 to 5", async () => {
+  const state4 = {
+    schemaVersion: 4,
+    hasShownStableSatsWelcome: false,
+    isUsdDisabled: false,
+    galoyInstance: {
+      name: "BBW",
+      graphqlUri: "https://api.mainnet.galoy.io/graphql",
+      graphqlWsUri: "wss://api.mainnet.galoy.io/graphql",
+      posUrl: "https://pay.bbw.sv",
+      lnAddressHostname: "pay.bbw.sv",
+    },
+    galoyAuthToken: "myToken",
+    isAnalyticsEnabled: true,
+    theme: defaultTheme,
+  }
+
+  const state5 = {
+    schemaVersion: 5,
+    galoyInstance: { name: "BBW" },
+    galoyAuthToken: "myToken",
+  }
+
+  const res = await migrateAndGetPersistentState(state4)
+
+  expect(res).toStrictEqual(state5)
 })

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,4 +41,4 @@ newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
-hermesEnabled=false
+hermesEnabled=true

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -41,4 +41,4 @@ newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
-hermesEnabled=true
+hermesEnabled=false

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -100,6 +100,10 @@ export const BalanceHeader: React.FC<Props> = ({ loading }) => {
   // so there is no need to pass loading from parent?
   const { data } = useBalanceHeaderQuery({ skip: !isAuthed })
 
+  // TODO: check that there are 2 wallets.
+  // otherwise fail (account with more/less 2 wallets will not be working with the current mobile app)
+  // some tests accounts have only 1 wallet
+
   let balanceInDisplayCurrency = "$0.00"
 
   if (isAuthed) {

--- a/app/components/stablesats-modal/stablesats-modal.tsx
+++ b/app/components/stablesats-modal/stablesats-modal.tsx
@@ -1,4 +1,3 @@
-import { usePersistentStateContext } from "@app/store/persistent-state"
 import { palette } from "@app/theme"
 import * as React from "react"
 import { Image, Linking, Text, View } from "react-native"
@@ -63,22 +62,12 @@ const STABLESATS_LINK = "https://www.stablesats.com"
 const STABLESATS_TERMS_LINK = "https://www.bbw.sv/terms"
 
 export const StableSatsModal: React.FC = () => {
-  const persistentStateContext = usePersistentStateContext()
   const { LL } = useI18nContext()
-  const isModalVisible = !persistentStateContext.persistentState.hasShownStableSatsWelcome
-  // FIXME antipattern to have have write access to persistentState,
-  // and also logic on persistentStateContext update in stablsats modal
-  const acknowledgeModal = () => {
-    persistentStateContext.updateState((state) => {
-      if (state) {
-        return {
-          ...state,
-          hasShownStableSatsWelcome: true,
-        }
-      }
-      return undefined
-    })
-  }
+
+  // no longer showing stablesats modal in new version
+  // keeping the code around for the next modal we're going to show
+  const isModalVisible = false
+  const acknowledgeModal = () => {}
 
   return (
     <Modal isVisible={isModalVisible} backdropOpacity={0.3}>

--- a/app/config/appinfo.ts
+++ b/app/config/appinfo.ts
@@ -1,5 +1,4 @@
 export const WHATSAPP_CONTACT_NUMBER = "+50369835117"
-export const BLOCKCHAIN_EXPLORER_URL = "https://mempool.space/tx/"
 export const CONTACT_EMAIL_ADDRESS = "support@bbw.sv"
 export const APP_STORE_LINK =
   "https://apps.apple.com/app/bitcoin-beach-wallet/id1531383905"

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -1,13 +1,30 @@
 import { NativeModules } from "react-native"
 
+// this is used for local development
+// will typically return localhost
 const scriptHostname = (): string => {
   const { scriptURL } = NativeModules.SourceCode
   const scriptHostname = scriptURL?.split("://")[1].split(":")[0] ?? ""
   return scriptHostname
 }
 
-export const possibleGaloyInstanceNames = ["BBW", "Staging", "Local", "Custom"] as const
+export const standardInstances = ["BBW", "Staging", "Local"] as const
+export const possibleGaloyInstanceNames = [...standardInstances, "Custom"] as const
 export type GaloyInstanceName = (typeof possibleGaloyInstanceNames)[number]
+
+export type StandardInstance = {
+  name: "BBW" | "Staging" | "Local"
+}
+
+export type CustomInstance = {
+  name: "Custom"
+  graphqlUri: string
+  graphqlWsUri: string
+  posUrl: string
+  lnAddressHostname: string
+}
+
+export type GaloyInstanceInput = StandardInstance | CustomInstance
 
 export type GaloyInstance = {
   name: GaloyInstanceName
@@ -15,6 +32,21 @@ export type GaloyInstance = {
   graphqlWsUri: string
   posUrl: string
   lnAddressHostname: string
+}
+
+export const maybeAddDefault = (input: GaloyInstanceInput): GaloyInstance => {
+  if (input.name === "Custom") {
+    return input
+  }
+
+  const instance = GALOY_INSTANCES.find((instance) => instance.name === input.name)
+
+  if (instance) {
+    return instance
+  }
+
+  console.error("instance not found") // should not happen
+  return GALOY_INSTANCES[0]
 }
 
 export const GALOY_INSTANCES: GaloyInstance[] = [

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -23,6 +23,7 @@ export type CustomInstance = {
   graphqlWsUri: string
   posUrl: string
   lnAddressHostname: string
+  blockExplorer: string
 }
 
 export type GaloyInstanceInput = StandardInstance | CustomInstance
@@ -34,6 +35,7 @@ export type GaloyInstance = {
   graphqlWsUri: string
   posUrl: string
   lnAddressHostname: string
+  blockExplorer: string
 }
 
 export const maybeAddDefault = (input: GaloyInstanceInput): GaloyInstance => {
@@ -59,6 +61,7 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     graphqlWsUri: "wss://api.mainnet.galoy.io/graphql",
     posUrl: "https://pay.bbw.sv",
     lnAddressHostname: "pay.bbw.sv",
+    blockExplorer: "https://mempool.space/tx/",
   },
   {
     id: "Staging",
@@ -67,6 +70,7 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     graphqlWsUri: "wss://api.staging.galoy.io/graphql",
     posUrl: "https://pay.staging.galoy.io",
     lnAddressHostname: "pay.staging.galoy.io",
+    blockExplorer: "https://mempool.space/signet/tx/",
   },
   {
     id: "Local",
@@ -75,5 +79,6 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     graphqlWsUri: `ws://${scriptHostname()}:4002/graphql`,
     posUrl: `http://${scriptHostname()}:3000`,
     lnAddressHostname: `${scriptHostname()}:3000`,
+    blockExplorer: "https://mempool.space/signet/tx/",
   },
 ]

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -8,8 +8,7 @@ const scriptHostname = (): string => {
   return scriptHostname
 }
 
-export const standardInstances = ["Main", "Staging", "Local"] as const
-export const possibleGaloyInstanceNames = [...standardInstances, "Custom"] as const
+export const possibleGaloyInstanceNames = ["Main", "Staging", "Local", "Custom"] as const
 export type GaloyInstanceName = (typeof possibleGaloyInstanceNames)[number]
 
 export type StandardInstance = {
@@ -38,22 +37,25 @@ export type GaloyInstance = {
   blockExplorer: string
 }
 
-export const maybeAddDefault = (input: GaloyInstanceInput): GaloyInstance => {
+export const resolveGaloyInstanceOrDefault = (
+  input: GaloyInstanceInput,
+): GaloyInstance => {
   if (input.id === "Custom") {
     return input
   }
 
-  const instance = GALOY_INSTANCES.find((instance) => instance.name === input.id)
+  const instance = GALOY_INSTANCES.find((instance) => instance.id === input.id)
 
-  if (instance) {
-    return instance
+  // branch only to please typescript. Array,find have T | undefined as return type
+  if (instance === undefined) {
+    console.error("instance not found") // should not happen
+    return GALOY_INSTANCES[0]
   }
 
-  console.error("instance not found") // should not happen
-  return GALOY_INSTANCES[0]
+  return instance
 }
 
-export const GALOY_INSTANCES: GaloyInstance[] = [
+export const GALOY_INSTANCES: readonly GaloyInstance[] = [
   {
     id: "Main",
     name: "BBW",
@@ -81,4 +83,4 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     lnAddressHostname: `${scriptHostname()}:3000`,
     blockExplorer: "https://mempool.space/signet/tx/",
   },
-]
+] as const

--- a/app/config/galoy-instances.ts
+++ b/app/config/galoy-instances.ts
@@ -8,16 +8,17 @@ const scriptHostname = (): string => {
   return scriptHostname
 }
 
-export const standardInstances = ["BBW", "Staging", "Local"] as const
+export const standardInstances = ["Main", "Staging", "Local"] as const
 export const possibleGaloyInstanceNames = [...standardInstances, "Custom"] as const
 export type GaloyInstanceName = (typeof possibleGaloyInstanceNames)[number]
 
 export type StandardInstance = {
-  name: "BBW" | "Staging" | "Local"
+  id: "Main" | "Staging" | "Local"
 }
 
 export type CustomInstance = {
-  name: "Custom"
+  id: "Custom"
+  name: string
   graphqlUri: string
   graphqlWsUri: string
   posUrl: string
@@ -27,7 +28,8 @@ export type CustomInstance = {
 export type GaloyInstanceInput = StandardInstance | CustomInstance
 
 export type GaloyInstance = {
-  name: GaloyInstanceName
+  id: GaloyInstanceName
+  name: string
   graphqlUri: string
   graphqlWsUri: string
   posUrl: string
@@ -35,11 +37,11 @@ export type GaloyInstance = {
 }
 
 export const maybeAddDefault = (input: GaloyInstanceInput): GaloyInstance => {
-  if (input.name === "Custom") {
+  if (input.id === "Custom") {
     return input
   }
 
-  const instance = GALOY_INSTANCES.find((instance) => instance.name === input.name)
+  const instance = GALOY_INSTANCES.find((instance) => instance.name === input.id)
 
   if (instance) {
     return instance
@@ -51,6 +53,7 @@ export const maybeAddDefault = (input: GaloyInstanceInput): GaloyInstance => {
 
 export const GALOY_INSTANCES: GaloyInstance[] = [
   {
+    id: "Main",
     name: "BBW",
     graphqlUri: "https://api.mainnet.galoy.io/graphql",
     graphqlWsUri: "wss://api.mainnet.galoy.io/graphql",
@@ -58,6 +61,7 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     lnAddressHostname: "pay.bbw.sv",
   },
   {
+    id: "Staging",
     name: "Staging",
     graphqlUri: "https://api.staging.galoy.io/graphql",
     graphqlWsUri: "wss://api.staging.galoy.io/graphql",
@@ -65,6 +69,7 @@ export const GALOY_INSTANCES: GaloyInstance[] = [
     lnAddressHostname: "pay.staging.galoy.io",
   },
   {
+    id: "Local",
     name: "Local",
     graphqlUri: `http://${scriptHostname()}:4002/graphql`,
     graphqlWsUri: `ws://${scriptHostname()}:4002/graphql`,

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -210,10 +210,17 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
         cache,
         storage: new AsyncStorageWrapper(AsyncStorage),
         debug: __DEV__,
+
+        persistenceMapper: async (_data) => {
+          // TODO:
+          // we should only store the last 20 transactions to keep the cache small
+          // there could be other data to filter as well
+          // filter your cached data and queries
+          // return filteredData
+        },
       })
 
       const readableVersion = DeviceInfo.getReadableVersion()
-      const buildVersion = DeviceInfo.getBuildNumber()
 
       const client = new ApolloClient({
         cache,
@@ -222,6 +229,8 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
         version: readableVersion,
         connectToDevTools: true,
       })
+
+      const buildVersion = DeviceInfo.getBuildNumber()
 
       // Read the current version from AsyncStorage.
       const currentVersion = await loadString(BUILD_VERSION)

--- a/app/hooks/use-app-config.ts
+++ b/app/hooks/use-app-config.ts
@@ -1,11 +1,6 @@
-import { GaloyInstance } from "@app/config"
+import { GaloyInstance, maybeAddDefault } from "@app/config"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import { useCallback, useMemo } from "react"
-
-export type AppConfiguration = {
-  isUsdDisabled: boolean
-  galoyInstance: GaloyInstance
-}
 
 export const useAppConfig = () => {
   const { persistentState, updateState } = usePersistentStateContext()
@@ -13,26 +8,10 @@ export const useAppConfig = () => {
   const appConfig = useMemo(
     () => ({
       token: persistentState.galoyAuthToken,
-      isUsdDisabled: persistentState.isUsdDisabled,
-      galoyInstance: persistentState.galoyInstance,
+      galoyInstance: maybeAddDefault(persistentState.galoyInstance),
     }),
-    [
-      persistentState.isUsdDisabled,
-      persistentState.galoyInstance,
-      persistentState.galoyAuthToken,
-    ],
+    [persistentState.galoyAuthToken, persistentState.galoyInstance],
   )
-
-  const toggleUsdDisabled = useCallback(() => {
-    updateState((state) => {
-      if (state)
-        return {
-          ...state,
-          isUsdDisabled: !state.isUsdDisabled,
-        }
-      return undefined
-    })
-  }, [updateState])
 
   const setGaloyInstance = useCallback(
     (newInstance: GaloyInstance) => {
@@ -79,7 +58,6 @@ export const useAppConfig = () => {
 
   return {
     appConfig,
-    toggleUsdDisabled,
     setGaloyInstance,
     saveToken,
     saveTokenAndInstance,

--- a/app/hooks/use-app-config.ts
+++ b/app/hooks/use-app-config.ts
@@ -1,4 +1,4 @@
-import { GaloyInstance, maybeAddDefault } from "@app/config"
+import { GaloyInstance, resolveGaloyInstanceOrDefault } from "@app/config"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import { useCallback, useMemo } from "react"
 
@@ -8,7 +8,7 @@ export const useAppConfig = () => {
   const appConfig = useMemo(
     () => ({
       token: persistentState.galoyAuthToken,
-      galoyInstance: maybeAddDefault(persistentState.galoyInstance),
+      galoyInstance: resolveGaloyInstanceOrDefault(persistentState.galoyInstance),
     }),
     [persistentState.galoyAuthToken, persistentState.galoyInstance],
   )

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -722,8 +722,6 @@ const en: BaseTranslation = {
     fee: "fee",
     Fee: "Fee",
     fees: "Fees",
-    feeSats: "Fees (sats)",
-    feesUsd: "Fees (USD)",
     firstName: "First Name",
     from: "From",
     hour: "hour",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2405,14 +2405,6 @@ type RootTranslation = {
 		 */
 		fees: string
 		/**
-		 * F​e​e​s​ ​(​s​a​t​s​)
-		 */
-		feeSats: string
-		/**
-		 * F​e​e​s​ ​(​U​S​D​)
-		 */
-		feesUsd: string
-		/**
 		 * F​i​r​s​t​ ​N​a​m​e
 		 */
 		firstName: string
@@ -5086,14 +5078,6 @@ export type TranslationFunctions = {
 		 * Fees
 		 */
 		fees: () => LocalizedString
-		/**
-		 * Fees (sats)
-		 */
-		feeSats: () => LocalizedString
-		/**
-		 * Fees (USD)
-		 */
-		feesUsd: () => LocalizedString
 		/**
 		 * First Name
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -705,8 +705,6 @@
         "fee": "fee",
         "Fee": "Fee",
         "fees": "Fees",
-        "feeSats": "Fees (sats)",
-        "feesUsd": "Fees (USD)",
         "firstName": "First Name",
         "from": "From",
         "hour": "hour",

--- a/app/screens/debug-screen/debug-screen.tsx
+++ b/app/screens/debug-screen/debug-screen.tsx
@@ -101,11 +101,12 @@ export const DebugScreen: React.FC = () => {
       saveTokenAndInstance({
         instance: {
           id: "Custom",
-          name: "Custom", // TODO: make configurable
           graphqlUri: newGraphqlUri,
           graphqlWsUri: newGraphqlWslUri,
           posUrl: newPosUrl,
           lnAddressHostname: newLnAddressHostname,
+          name: "Custom", // TODO: make configurable
+          blockExplorer: "https://mempool.space/tx/", // TODO make configurable
         },
         token: newToken || "",
       })

--- a/app/screens/debug-screen/debug-screen.tsx
+++ b/app/screens/debug-screen/debug-screen.tsx
@@ -100,7 +100,8 @@ export const DebugScreen: React.FC = () => {
     if (newGaloyInstance === "Custom") {
       saveTokenAndInstance({
         instance: {
-          name: "Custom",
+          id: "Custom",
+          name: "Custom", // TODO: make configurable
           graphqlUri: newGraphqlUri,
           graphqlWsUri: newGraphqlWslUri,
           posUrl: newPosUrl,

--- a/app/screens/debug-screen/debug-screen.tsx
+++ b/app/screens/debug-screen/debug-screen.tsx
@@ -49,7 +49,7 @@ export const DebugScreen: React.FC = () => {
   const { usdPerSat } = usePriceConversion()
   const { logout } = useLogout()
 
-  const { appConfig, toggleUsdDisabled, saveToken, saveTokenAndInstance } = useAppConfig()
+  const { appConfig, saveToken, saveTokenAndInstance } = useAppConfig()
   const token = appConfig.token
 
   const [newToken, setNewToken] = React.useState(token)
@@ -133,11 +133,6 @@ export const DebugScreen: React.FC = () => {
             Alert.alert("state successfully deleted. Restart your app")
           }}
           {...testProps("logout button")}
-        />
-        <Button
-          title={appConfig.isUsdDisabled ? "Enable USD" : "Disable USD"}
-          containerStyle={styles.button}
-          onPress={toggleUsdDisabled}
         />
         <Button
           title="Send device token"

--- a/app/screens/phone-auth-screen/phone-input.tsx
+++ b/app/screens/phone-auth-screen/phone-input.tsx
@@ -212,7 +212,7 @@ export const PhoneInputScreen: React.FC = () => {
     setPhoneNumber,
     captchaRequestAuthCode,
     resetValidationData,
-    appConfig.galoyInstance.name,
+    appConfig.galoyInstance.id,
     LL,
     channel,
   ])

--- a/app/screens/phone-auth-screen/phone-input.tsx
+++ b/app/screens/phone-auth-screen/phone-input.tsx
@@ -160,7 +160,7 @@ export const PhoneInputScreen: React.FC = () => {
             channel,
           } as const
           resetValidationData()
-          logRequestAuthCode(appConfig.galoyInstance.name)
+          logRequestAuthCode(appConfig.galoyInstance.id)
 
           const { data } = await captchaRequestAuthCode({ variables: { input } })
 

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -23,14 +23,10 @@ import { Divider } from "@rneui/base"
 
 import { IconTransaction } from "../../components/icon-transactions"
 import { Screen } from "../../components/screen"
-import { BLOCKCHAIN_EXPLORER_URL } from "../../config/appinfo"
 import { palette } from "../../theme"
 
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import { useAppConfig } from "@app/hooks"
-
-const viewInExplorer = (hash: string): Promise<Linking> =>
-  Linking.openURL(BLOCKCHAIN_EXPLORER_URL + hash)
 
 const styles = EStyleSheet.create({
   closeIconContainer: {
@@ -150,6 +146,9 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
     appConfig: { galoyInstance },
   } = useAppConfig()
   const { txid } = route.params
+
+  const viewInExplorer = (hash: string): Promise<Linking> =>
+    Linking.openURL(galoyInstance.blockExplorer + hash)
 
   const { data: tx } = useFragment_experimental<TransactionFragment>({
     fragment: TransactionFragmentDoc,

--- a/app/store/persistent-state/index.tsx
+++ b/app/store/persistent-state/index.tsx
@@ -2,7 +2,7 @@ import { loadJson, saveJson } from "@app/utils/storage"
 import { createContext, useContext, PropsWithChildren } from "react"
 import {
   defaultPersistentState,
-  deserializeAndMigratePersistentState,
+  migrateAndGetPersistentState,
   PersistentState,
 } from "./state-migrations"
 import * as React from "react"
@@ -11,7 +11,7 @@ const PERSISTENT_STATE_KEY = "persistentState"
 
 const loadPersistentState = async (): Promise<PersistentState> => {
   const data = await loadJson(PERSISTENT_STATE_KEY)
-  return deserializeAndMigratePersistentState(data)
+  return migrateAndGetPersistentState(data)
 }
 
 const savePersistentState = async (state: PersistentState) => {

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -78,15 +78,23 @@ const migrate4ToCurrent = (state: PersistentState_4): Promise<PersistentState> =
     throw new Error("Galoy instance not found")
   }
 
+  let galoyInstance: GaloyInstanceInput
+
+  if (state.galoyInstance.name === "Custom") {
+    // we only keep the full object if we are on Custom
+    // otherwise data will be stored in GaloyInstancesInput[]
+    galoyInstance = { ...state.galoyInstance, id: "Custom" }
+  } else if (state.galoyInstance.name === "BBW") {
+    // we are using "Main" instead of "BBW", so that the bankName is not hardcoded in the saved json
+    galoyInstance = { id: "Main" } as const
+  } else {
+    galoyInstance = { id: state.galoyInstance.name as "Staging" | "Local" }
+  }
+
   return migrate5ToCurrent({
     schemaVersion: 5,
     galoyAuthToken: state.galoyAuthToken,
-    galoyInstance:
-      // we only keep the full object if we are on Custom
-      // otherwise data will be stored in GaloyInstancesInput[]
-      state.galoyInstance.name === "Custom"
-        ? state.galoyInstance
-        : { name: state.galoyInstance.name },
+    galoyInstance,
   })
 }
 
@@ -179,7 +187,7 @@ export type PersistentState = PersistentState_5
 
 export const defaultPersistentState: PersistentState = {
   schemaVersion: 5,
-  galoyInstance: { name: "BBW" },
+  galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }
 

--- a/e2e/01-welcome-screen-flow.e2e.spec.ts
+++ b/e2e/01-welcome-screen-flow.e2e.spec.ts
@@ -29,11 +29,4 @@ describe("Welcome Screen Flow", () => {
     await getStartedButton.click()
     expect(true).toBeTruthy()
   })
-
-  it("remove stablesats menu", async () => {
-    const getStartedButton = await $(selector("Back home", "Button"))
-    await getStartedButton.waitForDisplayed({ timeout })
-    await getStartedButton.click()
-    expect(true).toBeTruthy()
-  })
 })


### PR DESCRIPTION
- less bloated implementation of PersistentState:
-- only store id, token (and custom property if `id === Custom`)
-- for default network, use value from Array instead of story them
--- will make it easier to change bank name (ie: for forks)
--- less need for migration going forward
-- custom property like theme or Modals  like stablesatsModals who have been discarded will be stored eventually as apollo-client client-only data. not that critical if the value are been reseted eventually

- fix https://github.com/GaloyMoney/galoy-mobile/issues/684

-- TODO in a future PR: do not reset the apollo-client on every app update. but only on schema changes. 