### PR TITLE
tests: first test for useDisplayCurrency

### DIFF
--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -3,76 +3,141 @@ import { renderHook } from "@testing-library/react-hooks"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { MockedProvider } from "@apollo/client/testing"
 import { PropsWithChildren } from "react"
-import mocks from "@app/graphql/mocks"
 import * as React from "react"
 import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { CurrencyListDocument, RealtimePriceDocument } from "@app/graphql/generated"
 
+const mocksNgn = [
+  {
+    request: {
+      query: RealtimePriceDocument,
+    },
+    result: {
+      data: {
+        me: {
+          __typename: "User",
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            __typename: "Account",
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            realtimePrice: {
+              btcSatPrice: {
+                base: 24015009766,
+                offset: 12,
+                currencyUnit: "USDCENT",
+                __typename: "PriceOfOneSat",
+              },
+              denominatorCurrency: "NGN",
+              id: "67b6e1d2-04c8-509a-abbd-b1cab08575d5",
+              timestamp: 1677184189,
+              usdCentPrice: {
+                base: 100000000,
+                offset: 6,
+                currencyUnit: "USDCENT",
+                __typename: "PriceOfOneUsdCent",
+              },
+              __typename: "RealtimePrice",
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: CurrencyListDocument,
+    },
+    result: {
+      data: {
+        currencyList: [
+          {
+            flag: "🇳🇬",
+            id: "NGN",
+            name: "Nigerian Naira",
+            symbol: "₦",
+            fractionDigits: 2,
+            __typename: "Currency",
+          },
+        ],
+      },
+    },
+  },
+]
+
+const mocksJpy = [
+  {
+    request: {
+      query: RealtimePriceDocument,
+    },
+    result: {
+      data: {
+        me: {
+          __typename: "User",
+          id: "70df9822-efe0-419c-b864-c9efa99872ea",
+          defaultAccount: {
+            __typename: "Account",
+            id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+            realtimePrice: {
+              btcSatPrice: {
+                base: 24015009766,
+                offset: 12,
+                __typename: "PriceOfOneSat",
+              },
+              denominatorCurrency: "JPY",
+              id: "67b6e1d2-04c8-509a-abbd-b1cab08575d5",
+              timestamp: 1677184189,
+              usdCentPrice: {
+                base: 100000000,
+                offset: 6,
+                __typename: "PriceOfOneUsdCent",
+              },
+              __typename: "RealtimePrice",
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: CurrencyListDocument,
+    },
+    result: {
+      data: {
+        currencyList: [
+          {
+            flag: "",
+            id: "JPY",
+            name: "Japanese Yen",
+            symbol: "¥",
+            fractionDigits: 0,
+            __typename: "Currency",
+          },
+        ],
+      },
+    },
+  },
+]
+
+/* eslint-disable react/display-name */
+/* eslint @typescript-eslint/ban-ts-comment: "off" */
+const wrapper =
+  // @ts-ignore-next-line no-implicit-any error
+
+
+    (mocks) =>
+    ({ children }: PropsWithChildren) =>
+      (
+        <IsAuthedContextProvider value={true}>
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        </IsAuthedContextProvider>
+      )
+
 describe("usePriceConversion", () => {
   describe("testing moneyAmountToMajorUnitOrSats", () => {
     it("with 0 digits", async () => {
-      const mocksJpy = [
-        {
-          request: {
-            query: RealtimePriceDocument,
-          },
-          result: {
-            data: {
-              me: {
-                __typename: "User",
-                id: "70df9822-efe0-419c-b864-c9efa99872ea",
-                defaultAccount: {
-                  __typename: "Account",
-                  id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
-                  realtimePrice: {
-                    btcSatPrice: {
-                      base: 24015009766,
-                      offset: 12,
-                      __typename: "PriceOfOneSat",
-                    },
-                    denominatorCurrency: "JPY",
-                    id: "67b6e1d2-04c8-509a-abbd-b1cab08575d5",
-                    timestamp: 1677184189,
-                    usdCentPrice: {
-                      base: 100000000,
-                      offset: 6,
-                      __typename: "PriceOfOneUsdCent",
-                    },
-                    __typename: "RealtimePrice",
-                  },
-                },
-              },
-            },
-          },
-        },
-        {
-          request: {
-            query: CurrencyListDocument,
-          },
-          result: {
-            data: {
-              currencyList: [
-                {
-                  flag: "",
-                  id: "JPY",
-                  name: "Japanese Yen",
-                  symbol: "¥",
-                  fractionDigits: 0,
-                  __typename: "Currency",
-                },
-              ],
-            },
-          },
-        },
-      ]
-
-      const wrapper = ({ children }: PropsWithChildren) => (
-        <IsAuthedContextProvider value={true}>
-          <MockedProvider mocks={mocksJpy}>{children}</MockedProvider>
-        </IsAuthedContextProvider>
-      )
       const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
-        wrapper,
+        wrapper: wrapper(mocksJpy),
       })
 
       await waitForNextUpdate()
@@ -86,13 +151,8 @@ describe("usePriceConversion", () => {
     })
 
     it("with 2 digits", async () => {
-      const wrapper = ({ children }: PropsWithChildren) => (
-        <IsAuthedContextProvider value={true}>
-          <MockedProvider mocks={mocks}>{children}</MockedProvider>
-        </IsAuthedContextProvider>
-      )
       const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
-        wrapper,
+        wrapper: wrapper(mocksNgn),
       })
 
       await waitForNextUpdate()
@@ -107,13 +167,8 @@ describe("usePriceConversion", () => {
   })
 
   it("unAuthed should return default value", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <IsAuthedContextProvider value={false}>
-        <MockedProvider mocks={[]}>{children}</MockedProvider>
-      </IsAuthedContextProvider>
-    )
     const { result } = renderHook(() => useDisplayCurrency(), {
-      wrapper,
+      wrapper: wrapper([]),
     })
 
     expect(result.current).toMatchObject({
@@ -124,13 +179,8 @@ describe("usePriceConversion", () => {
   })
 
   it("authed but empty query should return default value", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <IsAuthedContextProvider value={true}>
-        <MockedProvider mocks={[]}>{children}</MockedProvider>
-      </IsAuthedContextProvider>
-    )
     const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
-      wrapper,
+      wrapper: wrapper([]),
     })
 
     expect(result.current).toMatchObject({
@@ -149,13 +199,8 @@ describe("usePriceConversion", () => {
   })
 
   it("authed should return NGN from mock", async () => {
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <IsAuthedContextProvider value={true}>
-        <MockedProvider mocks={mocks}>{children}</MockedProvider>
-      </IsAuthedContextProvider>
-    )
     const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
-      wrapper,
+      wrapper: wrapper(mocksNgn),
     })
 
     expect(result.current).toMatchObject({

--- a/__tests__/hooks/use-display-currency.spec.tsx
+++ b/__tests__/hooks/use-display-currency.spec.tsx
@@ -1,0 +1,175 @@
+import { renderHook } from "@testing-library/react-hooks"
+
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
+import { MockedProvider } from "@apollo/client/testing"
+import { PropsWithChildren } from "react"
+import mocks from "@app/graphql/mocks"
+import * as React from "react"
+import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
+import { CurrencyListDocument, RealtimePriceDocument } from "@app/graphql/generated"
+
+describe("usePriceConversion", () => {
+  describe("testing moneyAmountToMajorUnitOrSats", () => {
+    it("with 0 digits", async () => {
+      const mocksJpy = [
+        {
+          request: {
+            query: RealtimePriceDocument,
+          },
+          result: {
+            data: {
+              me: {
+                __typename: "User",
+                id: "70df9822-efe0-419c-b864-c9efa99872ea",
+                defaultAccount: {
+                  __typename: "Account",
+                  id: "84b26b88-89b0-5c6f-9d3d-fbead08f79d8",
+                  realtimePrice: {
+                    btcSatPrice: {
+                      base: 24015009766,
+                      offset: 12,
+                      __typename: "PriceOfOneSat",
+                    },
+                    denominatorCurrency: "JPY",
+                    id: "67b6e1d2-04c8-509a-abbd-b1cab08575d5",
+                    timestamp: 1677184189,
+                    usdCentPrice: {
+                      base: 100000000,
+                      offset: 6,
+                      __typename: "PriceOfOneUsdCent",
+                    },
+                    __typename: "RealtimePrice",
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          request: {
+            query: CurrencyListDocument,
+          },
+          result: {
+            data: {
+              currencyList: [
+                {
+                  flag: "",
+                  id: "JPY",
+                  name: "Japanese Yen",
+                  symbol: "¥",
+                  fractionDigits: 0,
+                  __typename: "Currency",
+                },
+              ],
+            },
+          },
+        },
+      ]
+
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <IsAuthedContextProvider value={true}>
+          <MockedProvider mocks={mocksJpy}>{children}</MockedProvider>
+        </IsAuthedContextProvider>
+      )
+      const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
+        wrapper,
+      })
+
+      await waitForNextUpdate()
+
+      const res = result.current.moneyAmountToMajorUnitOrSats({
+        amount: 100,
+        currency: "DisplayCurrency",
+      })
+
+      expect(res).toBe(100)
+    })
+
+    it("with 2 digits", async () => {
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <IsAuthedContextProvider value={true}>
+          <MockedProvider mocks={mocks}>{children}</MockedProvider>
+        </IsAuthedContextProvider>
+      )
+      const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
+        wrapper,
+      })
+
+      await waitForNextUpdate()
+
+      const res = result.current.moneyAmountToMajorUnitOrSats({
+        amount: 10,
+        currency: "DisplayCurrency",
+      })
+
+      expect(res).toBe(0.1)
+    })
+  })
+
+  it("unAuthed should return default value", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <IsAuthedContextProvider value={false}>
+        <MockedProvider mocks={[]}>{children}</MockedProvider>
+      </IsAuthedContextProvider>
+    )
+    const { result } = renderHook(() => useDisplayCurrency(), {
+      wrapper,
+    })
+
+    expect(result.current).toMatchObject({
+      fractionDigits: 2,
+      fiatSymbol: "$",
+      displayCurrency: "USD",
+    })
+  })
+
+  it("authed but empty query should return default value", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <IsAuthedContextProvider value={true}>
+        <MockedProvider mocks={[]}>{children}</MockedProvider>
+      </IsAuthedContextProvider>
+    )
+    const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
+      wrapper,
+    })
+
+    expect(result.current).toMatchObject({
+      fractionDigits: 2,
+      fiatSymbol: "$",
+      displayCurrency: "USD",
+    })
+
+    await waitForNextUpdate()
+
+    expect(result.current).toMatchObject({
+      fractionDigits: 2,
+      fiatSymbol: "$",
+      displayCurrency: "USD",
+    })
+  })
+
+  it("authed should return NGN from mock", async () => {
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <IsAuthedContextProvider value={true}>
+        <MockedProvider mocks={mocks}>{children}</MockedProvider>
+      </IsAuthedContextProvider>
+    )
+    const { result, waitForNextUpdate } = renderHook(() => useDisplayCurrency(), {
+      wrapper,
+    })
+
+    expect(result.current).toMatchObject({
+      fractionDigits: 2,
+      fiatSymbol: "$",
+      displayCurrency: "USD",
+    })
+
+    await waitForNextUpdate()
+
+    expect(result.current).toMatchObject({
+      fractionDigits: 2,
+      fiatSymbol: "₦",
+      displayCurrency: "NGN",
+    })
+  })
+})


### PR DESCRIPTION
- adding test for useDisplayCurrency
- using a different pattern than the tests used for usePriceConversion (we should eventually converge to way of mocking up the gql calls)
-- Note that I ran into some randomness issue with mocking. if the tests for the 0 digits is at the end, it's failing. not sure why but now re-order solves it. 

maybe more function can be tests on this hooks. this is a start. 