### PR TITLE
ci: fix issues with release versions

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -338,16 +338,22 @@ jobs:
         path: pipeline-tasks/ci/tasks/prerelease.sh
       params:
         ARTIFACTS_BUCKET_SA_JSON_KEY: #@ data.values.build_artifacts_bucket_creds
-  - put: testflight-version
-    params:
-      file: testflight-version/version
-  - put: gh-prerelease
-    params:
-      name: artifacts/gh-release-name
-      tag: artifacts/gh-release-tag
-      body: artifacts/gh-release-notes.md
-      globs:
-        - artifacts/files/*
+  - in_parallel:
+    - put: repo-tagged
+      params:
+        repository: repo
+        tag: artifacts/new-version
+        only_tag: true
+    - put: testflight-version
+      params:
+        file: testflight-version/version
+    - put: gh-prerelease
+      params:
+        name: artifacts/gh-release-name
+        tag: artifacts/gh-release-tag
+        body: artifacts/gh-release-notes.md
+        globs:
+          - artifacts/files/*
 
 - name: prod-build-android
   serial: true
@@ -861,6 +867,13 @@ resources:
     - ".github/*"
     - "docs/*"
     - "README.md"
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+
+- name: repo-tagged
+  type: git
+  source:
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_branch
     private_key: #@ data.values.github_private_key

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -398,7 +398,7 @@ jobs:
         WAIT_FOR_BUILD_MINS: 20
         BUILD_NUMBER_FILE: build-number-android/android
         GIT_REF_FILE: built-dev-apk/url
-        GIT_REF_PATTERN: dev/android/galoy-mobile-.+-v(.+)/apk
+        GIT_REF_PATTERN: dev/android/galoy-mobile-.+-v(.+)-b.+/apk
         VERSION_FILE: testflight-version/version
         GCS_DIRECTORY: prod/android
         CIRCLECI_TOKEN: #@ data.values.circleci_token
@@ -457,7 +457,7 @@ jobs:
         WAIT_FOR_BUILD_MINS: 30
         BUILD_NUMBER_FILE: build-number-ios/ios
         GIT_REF_FILE: built-dev-ipa/url
-        GIT_REF_PATTERN: dev/ios/galoy-mobile-.+-v(.+)/Bitcoin
+        GIT_REF_PATTERN: dev/ios/galoy-mobile-.+-v(.+)-b.+/Bitcoin
         VERSION_FILE: testflight-version/version
         GCS_DIRECTORY: prod/ios
         CIRCLECI_TOKEN: #@ data.values.circleci_token

--- a/ci/tasks/bump-testflight-to-beta-pr.sh
+++ b/ci/tasks/bump-testflight-to-beta-pr.sh
@@ -4,14 +4,14 @@ set -eu
 
 . pipeline-tasks/ci/tasks/helpers.sh
 
-if [[ $(cat ./built-prod-apk/version) != $(cat ./built-prod-ipa/version) ]]; then
+if [[ $(version_part_from_build_url_apk $(cat ./built-prod-apk/url)) != $(version_part_from_build_url_ipa $(cat ./built-prod-ipa/url)) ]]; then
   echo "Version mismatch, one of the upload tasks must be running!"
   exit 1
 fi
 
 pushd deployments
 
-cat ../built-prod-apk/version > beta-version
+cat ../version_part_from_build_url_ipa $(cat ../built-prod-ipa/url) > beta-version
 
 OLD_BETA_VERSION=$(cat ../beta-version/version)
 NEW_BETA_VERSION=$(cat beta-version)

--- a/ci/tasks/helpers.sh
+++ b/ci/tasks/helpers.sh
@@ -150,3 +150,13 @@ function bump_rc() {
     echo $(version_part $1)"-rc."$RC_NUM_NEW
   fi
 }
+
+function version_part_from_build_url_ipa() {
+  [[ $1 =~ ios/galoy-mobile-.+-v(.+)-b.+/Bitcoin ]]
+  echo "${BASH_REMATCH[1]}"
+}
+
+function version_part_from_build_url_apk() {
+  [[ $1 =~ android/galoy-mobile-.+-v(.+)-b.+/apk/release ]]
+  echo "${BASH_REMATCH[1]}"
+}

--- a/ci/tasks/prerelease.sh
+++ b/ci/tasks/prerelease.sh
@@ -88,3 +88,5 @@ echo "v$(cat testflight-version/version) Prerelease" > artifacts/gh-release-name
 
 echo -n "Testflight Version: "
 cat artifacts/gh-release-tag
+
+version_part $(cat testflight-version/version) > artifacts/new-version

--- a/ci/tasks/upload-to-app-store.sh
+++ b/ci/tasks/upload-to-app-store.sh
@@ -2,7 +2,9 @@
 
 set -eu
 
-git_ref=$(cat ./built-prod-ipa/version) # tag
+. pipeline-tasks/ci/tasks/helpers.sh
+
+git_ref=$(version_part_from_build_url_ipa $(cat ./built-prod-ipa/url)) # tag
 ipa_gcs_url=$(cat ./built-prod-ipa/url)
 
 pipeline_id=$(curl -s --request POST \


### PR DESCRIPTION
- push the newer tag early
- find the tag from gcs url
- use the tag on circleci and bump task cross checks