### PR TITLE
chore: improve e2e tests login and welcome screen flow

### DIFF
--- a/app/screens/debug-screen/debug-screen.tsx
+++ b/app/screens/debug-screen/debug-screen.tsx
@@ -186,9 +186,7 @@ export const DebugScreen: React.FC = () => {
           <Text selectable>
             USD per 1 sat: {usdPerSat ? `$${usdPerSat}` : "No price data"}
           </Text>
-          <Text {...testProps("Token Present")}>
-            Token Present: {String(Boolean(token))}
-          </Text>
+          <Text>Token Present: {String(Boolean(token))}</Text>
           <Text>Hermes: {String(Boolean(usingHermes))}</Text>
           <Button
             {...testProps("Save Changes")}

--- a/e2e/01-welcome-screen-flow.e2e.spec.ts
+++ b/e2e/01-welcome-screen-flow.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { i18nObject } from "../app/i18n/i18n-util"
 import { loadLocale } from "../app/i18n/i18n-util.sync"
 import { selector } from "./utils"
-import { payTestUsername, resetLanguage } from "./utils/graphql"
+import { payTestUsername, resetDisplayCurrency, resetLanguage } from "./utils/graphql"
 
 describe("Welcome Screen Flow", () => {
   loadLocale("en")
@@ -14,13 +14,21 @@ describe("Welcome Screen Flow", () => {
   })
 
   it("reset language is case previous test has failed", async () => {
-    const res = await resetLanguage()
-    expect(res.data.userUpdateLanguage.language).toBeFalsy()
+    const result = await resetLanguage()
+    expect(result).toBeTruthy()
+    expect(result.data?.userUpdateLanguage.user?.language).toBeFalsy()
   })
 
   it("Pays Test Username to Create a Contact", async () => {
     const result = await payTestUsername()
+    expect(result).toBeTruthy()
     expect(result.data?.intraLedgerPaymentSend.status).toBe("SUCCESS")
+  })
+
+  it("resets display currency to USD", async () => {
+    const result = await resetDisplayCurrency()
+    expect(result).toBeTruthy()
+    expect(result.data?.accountUpdateDisplayCurrency.account?.displayCurrency).toBe("USD")
   })
 
   it("loads and clicks 'Get Started button'", async () => {

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -62,13 +62,12 @@ describe("Login Flow", () => {
 
   it("click Save Changes", async () => {
     const changeTokenButton = await $(selector("Save Changes", "Button"))
-    await changeTokenButton.waitForEnabled({ timeout })
+    await changeTokenButton.waitForDisplayed({ timeout })
     await changeTokenButton.click()
     // wait for token to be saved
-    await browser.pause(3000)
+    await browser.pause(2000)
     const tokenPresentText = await $(selector("Token Present", "StaticText"))
     const tokenPresent = await tokenPresentText.getText()
-    console.log("tokenPresent", tokenPresent)
     await browser.waitUntil(async () => tokenPresent.includes("true"))
   })
 
@@ -92,8 +91,8 @@ describe("Login Flow", () => {
   })
 
   it("navigates back to move home screen", async () => {
-    // scroll down to show phone setting for small screens
-    await scrollDown()
+    // scroll up to show phone setting for small screens
+    await scrollUp()
     const phoneSetting = await $(selector(LL.common.phoneNumber(), "StaticText"))
     await phoneSetting.waitForDisplayed({ timeout })
     const backButtonOnSettingsScreen = await $(goBack())

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -94,6 +94,7 @@ describe("Login Flow", () => {
     expect(logoutButton.isDisplayed()).toBeTruthy()
     const backButtonOnAccountScreen = await $(goBack())
     await backButtonOnAccountScreen.click()
+    await browser.pause(2000)
   })
 
   it("navigates back to move home screen", async () => {

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -62,10 +62,14 @@ describe("Login Flow", () => {
 
   it("click Save Changes", async () => {
     const changeTokenButton = await $(selector("Save Changes", "Button"))
-    await changeTokenButton.waitForDisplayed({ timeout })
+    await changeTokenButton.waitForEnabled({ timeout })
     await changeTokenButton.click()
+    // wait for token to be saved
+    await browser.pause(3000)
     const tokenPresentText = await $(selector("Token Present", "StaticText"))
-    browser.waitUntil(async () => (await tokenPresentText.getValue()).includes("true"))
+    const tokenPresent = await tokenPresentText.getText()
+    console.log("tokenPresent", tokenPresent)
+    await browser.waitUntil(async () => tokenPresent.includes("true"))
   })
 
   it("click go back to settings screen", async () => {
@@ -76,8 +80,7 @@ describe("Login Flow", () => {
 
   it("are we logged in?", async () => {
     // scroll up for small screens
-    scrollUp()
-
+    await scrollUp()
     const accountButton = await $(selector(LL.common.account(), "StaticText"))
     await accountButton.waitForDisplayed({ timeout })
     await accountButton.click()
@@ -89,6 +92,8 @@ describe("Login Flow", () => {
   })
 
   it("navigates back to move home screen", async () => {
+    // scroll down to show phone setting for small screens
+    await scrollDown()
     const phoneSetting = await $(selector(LL.common.phoneNumber(), "StaticText"))
     await phoneSetting.waitForDisplayed({ timeout })
     const backButtonOnSettingsScreen = await $(goBack())

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -65,8 +65,6 @@ describe("Login Flow", () => {
     const changeTokenButton = await $(selector("Save Changes", "Button"))
     await changeTokenButton.waitForDisplayed({ timeout })
     await changeTokenButton.click()
-    // wait for token to be saved
-    await browser.pause(2000)
     if (process.env.E2E_DEVICE === "ios") {
       tokenPresent = await $(selector("Token Present: true", "StaticText"))
     } else {
@@ -94,6 +92,7 @@ describe("Login Flow", () => {
     expect(logoutButton.isDisplayed()).toBeTruthy()
     const backButtonOnAccountScreen = await $(goBack())
     await backButtonOnAccountScreen.click()
+    // pause to allow the app to navigate back to the settings screen on Android
     await browser.pause(2000)
   })
 

--- a/e2e/02-login-flow.e2e.spec.ts
+++ b/e2e/02-login-flow.e2e.spec.ts
@@ -61,14 +61,20 @@ describe("Login Flow", () => {
   })
 
   it("click Save Changes", async () => {
+    let tokenPresent: WebdriverIO.Element
     const changeTokenButton = await $(selector("Save Changes", "Button"))
     await changeTokenButton.waitForDisplayed({ timeout })
     await changeTokenButton.click()
     // wait for token to be saved
     await browser.pause(2000)
-    const tokenPresentText = await $(selector("Token Present", "StaticText"))
-    const tokenPresent = await tokenPresentText.getText()
-    await browser.waitUntil(async () => tokenPresent.includes("true"))
+    if (process.env.E2E_DEVICE === "ios") {
+      tokenPresent = await $(selector("Token Present: true", "StaticText"))
+    } else {
+      const select = `new UiSelector().text("Token Present: true").className("android.widget.TextView")`
+      tokenPresent = await $(`android=${select}`)
+    }
+    const tokenPresentText = await tokenPresent.getText()
+    expect(tokenPresentText.includes("true")).toBeTruthy()
   })
 
   it("click go back to settings screen", async () => {

--- a/e2e/utils/graphql.ts
+++ b/e2e/utils/graphql.ts
@@ -22,6 +22,9 @@ import {
   WalletCurrency,
   WalletsDocument,
   WalletsQuery,
+  AccountUpdateDisplayCurrencyDocument,
+  AccountUpdateDisplayCurrencyMutation,
+  UserUpdateLanguageMutation,
 } from "../../app/graphql/generated"
 import { RetryLink } from "@apollo/client/link/retry"
 
@@ -199,7 +202,7 @@ export const payNoAmountInvoice = async ({
 export const resetLanguage = async () => {
   const client = createGaloyServerClient(config)(userToken)
 
-  return client.mutate({
+  return client.mutate<UserUpdateLanguageMutation>({
     variables: {
       input: {
         language: "",
@@ -208,6 +211,20 @@ export const resetLanguage = async () => {
     mutation: UserUpdateLanguageDocument,
     fetchPolicy: "no-cache",
   })
+}
+
+export const resetDisplayCurrency = async () => {
+  const client = createGaloyServerClient(config)(userToken)
+  const result = await client.mutate<AccountUpdateDisplayCurrencyMutation>({
+    variables: {
+      input: {
+        currency: "USD",
+      },
+    },
+    mutation: AccountUpdateDisplayCurrencyDocument,
+    fetchPolicy: "no-cache",
+  })
+  return result
 }
 
 export const payTestUsername = async () => {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -805,7 +805,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: d58428b28fe1f5070fe993495b0e2eaf701d3820
@@ -818,7 +818,7 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
   FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   GoogleAppMeasurement: 4c19f031220c72464d460c9daa1fb5d1acce958e
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleMLKit: 0017a6a8372e1a182139b9def4d89be5d87ca5a7
@@ -836,7 +836,7 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
   Protobuf: d7f7c8329edf5eb8af65547a8ba3e9c1cee927d5
-  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
+  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
   RCTRequired: c154ebcfbf41d6fef86c52674fc1aa08837ff538
   RCTTypeSafety: 3063e5a1e5b1dc2cbeda5c8f8926c0ad1a6b0871
   React: 0a1a36e8e81cfaac244ed88b97f23ab56e5434f0


### PR DESCRIPTION
This PR adds some improvements to the e2e test. Some of the code in the login flow were actually not working properly e.g. https://github.com/GaloyMoney/galoy-mobile/pull/1701/files#diff-8ffce1538d4d0c0cd9a295395d3e111073f9cf483a2b104d9ddf92bba152b07eL68
 
Also, somehow the displayCurrency of some of the test accounts was not USD by default which caused some the send flow tests to fail ([see here for browserstack video](https://app-automate.browserstack.com/sessions/072ac3a75edbcf547362b0a9597aa153b0aa528f/video?token=UlNFT1dybThSbVAya0UvNTMwaHVhTG9qbW93SVlGWDdzK3FKMzNsbEVTdkdaT1Z2bDkyekJFNXhQZm5NL1hhTzZuaHBrdzl3WENCTVE2ODVNbFVYdFE9PS0tSmIrNDJKOG4zbTd2QzQwenZ5Ymp3UT09--f5829c3f5a15b4d3909a5f36a11aeef0a637d917&source=rest_api&diff=30.073861999)). Maybe someone used the token locally, changed it to different currency??. Regardless, I have added a function to reset the display currency.