### PR TITLE
feat: hide decimals for inflated currencies

### DIFF
--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -17,7 +17,5 @@ it("SendScreen Confirmation", async () => {
   await act(async () => {})
 
   const { children } = await findByLabelText("Successful Fee")
-  expect(children).toEqual(["₦0.00 ($0.00)"])
-
-  // console.log(JSON.stringify(toJSON(), null, 2))
+  expect(children).toEqual(["₦0 ($0.00)"])
 })

--- a/app/components/money-amount-input/index.tsx
+++ b/app/components/money-amount-input/index.tsx
@@ -24,6 +24,7 @@ export const MoneyAmountInput = ({
     amountInMajorUnitOrSatsToMoneyAmount,
     fractionDigits,
     fiatSymbol,
+    displayCurrencyShouldDisplayDecimals,
   } = useDisplayCurrency()
 
   let prefix: string | undefined
@@ -43,7 +44,7 @@ export const MoneyAmountInput = ({
     case DisplayCurrency:
       prefix = fiatSymbol
       suffix = ""
-      precision = fractionDigits
+      precision = displayCurrencyShouldDisplayDecimals ? fractionDigits : 0
       break
   }
 


### PR DESCRIPTION
- if a currency's dollar has less value than a usd cent, do not display decimals