### PR TITLE
fix: state issue when scanning QR code and going back

### DIFF
--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -168,7 +168,7 @@ export const ScanningQRCodeScreen: React.FC<ScanningQRCodeScreenProps> = ({
 
         if (destination.valid) {
           if (destination.destinationDirection === DestinationDirection.Send) {
-            return navigation.navigate("sendBitcoinDetails", {
+            return navigation.replace("sendBitcoinDetails", {
               paymentDestination: destination,
             })
           }


### PR DESCRIPTION
issue: if one were to scan a QR code, but this is not the correct QR code (ie: amount has not been set, and the merchant show another QR code where the amount is set), the user would have to go back. 

there is some state when this happens, scanning the new QR code doesn't work anymore, it's becoming a no-op.

I think this is the best way to address this bug.