### PR TITLE
fix: properly manage 401 response code

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -30,6 +30,7 @@ import { ErrorScreen } from "./screens/error-screen"
 import { PersistentStateProvider } from "./store/persistent-state"
 import { detectDefaultLocale } from "./utils/locale-detector"
 import { ThemeSyncGraphql } from "./utils/theme-sync"
+import { NetworkErrorComponent } from "./graphql/network-error-component"
 
 // FIXME should we only load the currently used local?
 // this would help to make the app load faster
@@ -54,6 +55,7 @@ export const App = () => (
                 <NotificationComponent />
                 <RootStack />
                 <GaloyToast />
+                <NetworkErrorComponent />
               </RootSiblingParent>
             </NavigationContainerWrapper>
           </ErrorBoundary>

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -31,11 +31,11 @@ import { loadString, saveString } from "../utils/storage"
 import { AnalyticsContainer } from "./analytics"
 import { useLanguageQuery, useRealtimePriceQuery } from "./generated"
 import { IsAuthedContextProvider, useIsAuthed } from "./is-authed-context"
+import { NetworkErrorContextProvider } from "./network-error-context"
 
 import { onError } from "@apollo/client/link/error"
 
 import { getLanguageFromString, getLocaleFromLanguage } from "@app/utils/locale-detector"
-import { NetworkErrorToast } from "./network-error-toast"
 import { MessagingContainer } from "./messaging"
 
 const noRetryOperations = [
@@ -111,7 +111,11 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
           max: 5,
           retryIf: (error, operation) => {
             console.debug(JSON.stringify(error), "retry on error")
-            return Boolean(error) && !noRetryOperations.includes(operation.operationName)
+            return (
+              Boolean(error) &&
+              !noRetryOperations.includes(operation.operationName) &&
+              error.statusCode !== 401
+            )
           },
         },
       })
@@ -245,12 +249,13 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
   return (
     <ApolloProvider client={apolloClient.client}>
       <IsAuthedContextProvider value={apolloClient.isAuthed}>
-        <MessagingContainer />
-        <NetworkErrorToast networkError={networkError} />
-        <LanguageSync />
-        <AnalyticsContainer />
-        <MyPriceUpdates />
-        {children}
+        <NetworkErrorContextProvider value={networkError}>
+          <MessagingContainer />
+          <LanguageSync />
+          <AnalyticsContainer />
+          <MyPriceUpdates />
+          {children}
+        </NetworkErrorContextProvider>
       </IsAuthedContextProvider>
     </ApolloProvider>
   )

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -229,6 +229,7 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
       client.onClearStore(persistor.purge)
 
       setApolloClient({ client, isAuthed: Boolean(token) })
+      setNetworkError(undefined)
 
       return () => client.cache.reset()
     })()

--- a/app/graphql/network-error-context.ts
+++ b/app/graphql/network-error-context.ts
@@ -1,0 +1,8 @@
+import { ServerError } from "@apollo/client"
+import { createContext, useContext } from "react"
+
+const NetworkError = createContext<ServerError | undefined>(undefined)
+
+export const NetworkErrorContextProvider = NetworkError.Provider
+
+export const useNetworkError = () => useContext(NetworkError)

--- a/app/screens/error-screen/error-screen.tsx
+++ b/app/screens/error-screen/error-screen.tsx
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
     margin: 20,
   },
   text: {
-    color: "$color",
+    color: palette.white,
     fontSize: 15,
     paddingHorizontal: 20,
     paddingTop: 24,


### PR DESCRIPTION
following improvement has been made:

On the UX side:
- convert Toast to Alert. if someone is logged out, it should be a persistent message they tap on to understand what is going on
- go back to the home screen once the user tap the Ok button.

on the network side:
- `logout` happen immediately, not after the user press Ok or when the Toast hide (limit the number of 401)
- if the error is 401, we don't retry it

it's still possible to get a couple of 401 because some requests are sent concurrently. but we're going from 20+ requests to the backend, to 1 to 3 based on my local tests. 

fix #1867