### PR TITLE
fix: prevent infinite 401 loop

### DIFF
--- a/app/graphql/network-error-context.ts
+++ b/app/graphql/network-error-context.ts
@@ -1,8 +1,16 @@
-import { ServerError } from "@apollo/client"
 import { createContext, useContext } from "react"
+import { NetworkError } from "@apollo/client/errors"
 
-const NetworkError = createContext<ServerError | undefined>(undefined)
+type NetworkErrorState = {
+  networkError: NetworkError | undefined
+  clearNetworkError: () => void
+}
 
-export const NetworkErrorContextProvider = NetworkError.Provider
+const NetworkErrorContext = createContext<NetworkErrorState>({
+  networkError: undefined,
+  clearNetworkError: () => {},
+})
 
-export const useNetworkError = () => useContext(NetworkError)
+export const NetworkErrorContextProvider = NetworkErrorContext.Provider
+
+export const useNetworkError = () => useContext(NetworkErrorContext)


### PR DESCRIPTION
- reverts 401 modal changes and instead gives special retry mechanism for 401 errors before logging the user out
- reorder retryLink so that it runs before the errorLink, in the past we set the error before we even retried, this should retry first and then if it still fails it will set the network error (it should help with the 502 errors we are seeing)