### PR TITLE
ci: have prod builds as prerelease assets

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -334,7 +334,6 @@ jobs:
       - name: built-dev-apk
       outputs:
       - name: repo
-      - name: artifacts
       run:
         path: pipeline-tasks/ci/tasks/choose-commit-prerelease.sh
       params:
@@ -347,7 +346,6 @@ jobs:
       - name: repo
       - name: pipeline-tasks
       - name: testflight-version
-      - name: artifacts
       outputs:
       - name: testflight-version
       - name: artifacts
@@ -360,8 +358,6 @@ jobs:
         tag: artifacts/gh-release-tag
         body: artifacts/gh-release-notes.md
         commitish: artifacts/commit-id
-        globs:
-          - artifacts/files/*
     - put: testflight-version
       params:
         file: testflight-version/version

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -336,8 +336,6 @@ jobs:
       - name: repo
       run:
         path: pipeline-tasks/ci/tasks/choose-commit-prerelease.sh
-      params:
-        ARTIFACTS_BUCKET_SA_JSON_KEY: #@ data.values.build_artifacts_bucket_creds
   - task: prep-release
     config:
       platform: linux
@@ -479,6 +477,34 @@ jobs:
     params:
       repository: build-number-ios
       rebase: true
+
+- name: upload-gh-prerelease-asset
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed: ["prod-build-android", "prod-build-ios"]
+    - get: pipeline-tasks
+    - get: built-prod-apk
+      trigger: true
+    - get: built-prod-ipa
+      trigger: true
+    - get: testflight-version
+  - task: upload
+    config:
+      platform: linux
+      image_resource: #@ release_task_image_config()
+      inputs:
+      - name: repo
+      - name: pipeline-tasks
+      - name: built-prod-apk
+      - name: built-prod-ipa
+      - name: testflight-version
+      run:
+        path: pipeline-tasks/ci/tasks/upload-gh-prerelease-asset.sh
+      params:
+        GH_TOKEN: #@ data.values.github_api_token
+        ARTIFACTS_BUCKET_SA_JSON_KEY: #@ data.values.build_artifacts_bucket_creds
 
 - name: upload-to-play-store
   serial: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -78,6 +78,7 @@ groups:
   - upload-to-play-store
   - upload-to-app-store
   - upload-to-huawei-store
+  - upload-gh-prerelease-asset
   - bump-testflight-to-beta-pr
   - migrate-existing-beta-prs
   - promote-testflight-to-beta-app-store
@@ -109,6 +110,7 @@ groups:
   - upload-to-play-store
   - upload-to-app-store
   - upload-to-huawei-store
+  - upload-gh-prerelease-asset
   - bump-testflight-to-beta-pr
 - name: beta
   jobs:

--- a/ci/tasks/choose-commit-prerelease.sh
+++ b/ci/tasks/choose-commit-prerelease.sh
@@ -24,17 +24,4 @@ echo "Using Commit: $CHOSEN_COMMITID"
 
 popd
 
-mkdir -p artifacts/files
-activate_gcloud_service_account
-
-pushd repo
-export URL=$(cat ../built-dev-apk/url)
-download_build_apk
-mv android/app/build/outputs/apk/release/*.apk ../artifacts/files
-
-export URL=$(cat ../built-dev-ipa/url)
-download_build_ipa
-mv ios/*.ipa ../artifacts/files
-popd
-
 echo $IPA_COMMIT > artifacts/commit-id

--- a/ci/tasks/upload-gh-prerelease-asset.sh
+++ b/ci/tasks/upload-gh-prerelease-asset.sh
@@ -20,6 +20,8 @@ mv android/app/build/outputs/apk/release/*.apk ../artifacts/files
 export URL=$(cat ../built-prod-ipa/url)
 download_build_ipa
 mv ios/*.ipa ../artifacts/files
+
+gh release upload $(cat ../testflight-version/version) ../artifacts/files/*
+
 popd
 
-gh release upload $(cat ./testflight-version/version) ./artifacts/files/*

--- a/ci/tasks/upload-gh-prerelease-asset.sh
+++ b/ci/tasks/upload-gh-prerelease-asset.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eu
+
+. pipeline-tasks/ci/tasks/helpers.sh
+
+if [[ $(cat ./built-prod-apk/version) != $(cat ./built-prod-ipa/version) ]]; then
+  echo "Version mismatch, one of the upload tasks must be running!"
+  exit 1
+fi
+
+mkdir -p artifacts/files
+activate_gcloud_service_account
+
+pushd repo
+export URL=$(cat ../built-prod-apk/url)
+download_build_apk
+mv android/app/build/outputs/apk/release/*.apk ../artifacts/files
+
+export URL=$(cat ../built-prod-ipa/url)
+download_build_ipa
+mv ios/*.ipa ../artifacts/files
+popd
+
+gh release upload $(cat ./testflight-version/version) ./artifacts/files/*


### PR DESCRIPTION
Because dev builds were getting uploaded with commit ids as build numbers. This is more appropriate.
Already applied.
Works: https://ci.galoy.io/teams/dev/pipelines/galoy-mobile/jobs/upload-gh-prerelease-asset/builds/2