### PR TITLE
feat: send bitcoin screen dark mode support

### DIFF
--- a/app/components/floor-tooltip/floor-tooltip.tsx
+++ b/app/components/floor-tooltip/floor-tooltip.tsx
@@ -9,7 +9,7 @@ import { useAppConfig } from "@app/hooks"
 import { LocalizedString } from "typesafe-i18n"
 import { makeStyles } from "@rneui/themed"
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles((theme, type) => ({
   modalStyle: {
     margin: 0,
     flexDirection: "column",
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
     marginBottom: 20,
   },
   icon: {
-    color: theme.colors.grey1,
+    color: type == "info" ? theme.colors.grey1 : theme.colors.error5,
   },
 }))
 
@@ -66,7 +66,7 @@ export const FloorTooltip: React.FC<FloorTooltipProps> = ({
   } = useAppConfig()
   const [isVisible, setIsVisible] = React.useState(false)
   const toggleModal = () => setIsVisible(!isVisible)
-  const styles = useStyles()
+  const styles = useStyles(type)
 
   let iconParams: { name: string; type: string }
   let defaultTitle: LocalizedString

--- a/app/components/floor-tooltip/floor-tooltip.tsx
+++ b/app/components/floor-tooltip/floor-tooltip.tsx
@@ -9,7 +9,7 @@ import { useAppConfig } from "@app/hooks"
 import { LocalizedString } from "typesafe-i18n"
 import { makeStyles } from "@rneui/themed"
 
-const useStyles = makeStyles((theme, type) => ({
+const useStyles = makeStyles((theme) => ({
   modalStyle: {
     margin: 0,
     flexDirection: "column",
@@ -40,8 +40,11 @@ const useStyles = makeStyles((theme, type) => ({
     fontSize: 20,
     marginBottom: 20,
   },
-  icon: {
-    color: type === "info" ? theme.colors.grey1 : theme.colors.error5,
+  iconInfo: {
+    color: theme.colors.grey1,
+  },
+  iconAdvice: {
+    color: theme.colors.error5,
   },
 }))
 
@@ -66,7 +69,7 @@ export const FloorTooltip: React.FC<FloorTooltipProps> = ({
   } = useAppConfig()
   const [isVisible, setIsVisible] = React.useState(false)
   const toggleModal = () => setIsVisible(!isVisible)
-  const styles = useStyles(type)
+  const styles = useStyles()
 
   let iconParams: { name: string; type: string }
   let defaultTitle: LocalizedString
@@ -90,7 +93,12 @@ export const FloorTooltip: React.FC<FloorTooltipProps> = ({
 
   return (
     <View>
-      <Icon style={styles.icon} size={size} {...iconParams} onPress={toggleModal} />
+      <Icon
+        style={type === "info" ? styles.iconInfo : styles.iconAdvice}
+        size={size}
+        {...iconParams}
+        onPress={toggleModal}
+      />
       <Modal
         isVisible={isVisible}
         onBackdropPress={toggleModal}

--- a/app/components/floor-tooltip/floor-tooltip.tsx
+++ b/app/components/floor-tooltip/floor-tooltip.tsx
@@ -1,14 +1,15 @@
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { palette } from "@app/theme"
 import * as React from "react"
-import { Text, View, TouchableOpacity, ScrollView, StyleSheet } from "react-native"
+import { Text, View, TouchableOpacity, ScrollView } from "react-native"
 import Icon from "react-native-vector-icons/Ionicons"
 
 import Modal from "react-native-modal"
 import { useAppConfig } from "@app/hooks"
 import { LocalizedString } from "typesafe-i18n"
+import { makeStyles } from "@rneui/themed"
 
-const styles = StyleSheet.create({
+const useStyles = makeStyles((theme) => ({
   modalStyle: {
     margin: 0,
     flexDirection: "column",
@@ -39,7 +40,10 @@ const styles = StyleSheet.create({
     fontSize: 20,
     marginBottom: 20,
   },
-})
+  icon: {
+    color: theme.colors.grey1,
+  },
+}))
 
 type FloorTooltipProps = {
   size?: number
@@ -62,6 +66,7 @@ export const FloorTooltip: React.FC<FloorTooltipProps> = ({
   } = useAppConfig()
   const [isVisible, setIsVisible] = React.useState(false)
   const toggleModal = () => setIsVisible(!isVisible)
+  const styles = useStyles()
 
   let iconParams: { name: string; type: string }
   let defaultTitle: LocalizedString
@@ -85,7 +90,7 @@ export const FloorTooltip: React.FC<FloorTooltipProps> = ({
 
   return (
     <View>
-      <Icon size={size} {...iconParams} onPress={toggleModal} />
+      <Icon style={styles.icon} size={size} {...iconParams} onPress={toggleModal} />
       <Modal
         isVisible={isVisible}
         onBackdropPress={toggleModal}

--- a/app/components/floor-tooltip/floor-tooltip.tsx
+++ b/app/components/floor-tooltip/floor-tooltip.tsx
@@ -41,7 +41,7 @@ const useStyles = makeStyles((theme, type) => ({
     marginBottom: 20,
   },
   icon: {
-    color: type == "info" ? theme.colors.grey1 : theme.colors.error5,
+    color: type === "info" ? theme.colors.grey1 : theme.colors.error5,
   },
 }))
 

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -620,7 +620,6 @@ export type Mutation = {
   readonly quizCompleted: QuizCompletedPayload;
   /** @deprecated will be moved to AccountContact */
   readonly userContactUpdateAlias: UserContactUpdateAliasPayload;
-  readonly userDeviceAccountCreate: SuccessPayload;
   readonly userLogin: AuthTokenPayload;
   readonly userLoginDevice: JwtPayload;
   readonly userLoginUpgrade: AuthTokenPayload;

--- a/app/screens/send-bitcoin-screen/destination-information.tsx
+++ b/app/screens/send-bitcoin-screen/destination-information.tsx
@@ -135,7 +135,7 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: 2,
   },
   errorText: {
-    color: palette.red,
+    color: theme.colors.error5,
   },
   warningText: {
     color: palette.orange,

--- a/app/screens/send-bitcoin-screen/destination-information.tsx
+++ b/app/screens/send-bitcoin-screen/destination-information.tsx
@@ -1,7 +1,6 @@
 import { FloorTooltip } from "@app/components/floor-tooltip/floor-tooltip"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { TranslationFunctions } from "@app/i18n/i18n-types"
-import { palette } from "@app/theme"
 import { useAppConfig } from "@app/hooks"
 import React from "react"
 import { Text, View } from "react-native"
@@ -138,7 +137,7 @@ const useStyles = makeStyles((theme) => ({
     color: theme.colors.error5,
   },
   warningText: {
-    color: palette.orange,
+    color: theme.colors.warning,
   },
   textContainer: {
     flex: 1,

--- a/app/screens/send-bitcoin-screen/destination-information.tsx
+++ b/app/screens/send-bitcoin-screen/destination-information.tsx
@@ -4,10 +4,11 @@ import { TranslationFunctions } from "@app/i18n/i18n-types"
 import { palette } from "@app/theme"
 import { useAppConfig } from "@app/hooks"
 import React from "react"
-import { StyleSheet, Text, View } from "react-native"
+import { Text, View } from "react-native"
 import { DestinationState, SendBitcoinDestinationState } from "./send-bitcoin-reducer"
 import { IntraledgerPaymentDestination } from "@galoymoney/client/dist/parsing-v2"
 import { InvalidDestinationReason } from "./payment-destination/index.types"
+import { makeStyles } from "@rneui/themed"
 
 const createToLnAddress = (lnDomain: string) => {
   return (handle: string) => {
@@ -123,13 +124,16 @@ const destinationStateToInformation = (
   return {}
 }
 
-const styles = StyleSheet.create({
+const useStyles = makeStyles((theme) => ({
   informationContainer: {
     flexDirection: "row",
     alignItems: "center",
     flexWrap: "wrap",
   },
-  informationText: {},
+  informationText: {
+    color: theme.colors.grey1,
+    paddingLeft: 2,
+  },
   errorText: {
     color: palette.red,
   },
@@ -139,7 +143,7 @@ const styles = StyleSheet.create({
   textContainer: {
     flex: 1,
   },
-})
+}))
 
 export const DestinationInformation = ({
   destinationState,
@@ -148,6 +152,7 @@ export const DestinationInformation = ({
 }) => {
   const { LL } = useI18nContext()
   const { appConfig } = useAppConfig()
+  const styles = useStyles()
   const { lnAddressHostname, name } = appConfig.galoyInstance
   const bankDetails = { lnDomain: lnAddressHostname, bankName: name }
   const information = destinationStateToInformation(destinationState, LL, bankDetails)

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -66,7 +66,7 @@ const usestyles = makeStyles((theme) => ({
     flexDirection: "row",
     borderStyle: "solid",
     overflow: "hidden",
-    backgroundColor: palette.white,
+    backgroundColor: theme.mode == "light" ? theme.colors.white : theme.colors.grey10,
     borderRadius: 10,
     justifyContent: "center",
     alignItems: "center",
@@ -93,6 +93,10 @@ const usestyles = makeStyles((theme) => ({
   input: {
     flex: 1,
     paddingHorizontal: 12,
+    color: theme.colors.black,
+  },
+  placeholder: {
+    color: theme.colors.grey2,
   },
   button: {
     height: 50,
@@ -369,6 +373,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
             {...testProps(LL.SendBitcoinScreen.input())}
             style={styles.input}
             placeholder={LL.SendBitcoinScreen.input()}
+            placeholderTextColor={styles.placeholder.color}
             onChangeText={handleChangeText}
             value={destinationState.unparsedDestination}
             onSubmitEditing={() =>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -75,7 +75,7 @@ const usestyles = makeStyles((theme) => ({
   },
   enteringInputContainer: {},
   errorInputContainer: {
-    borderColor: palette.red,
+    borderColor: theme.colors.error,
     borderWidth: 1,
   },
   validInputContainer: {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -66,7 +66,7 @@ const usestyles = makeStyles((theme) => ({
     flexDirection: "row",
     borderStyle: "solid",
     overflow: "hidden",
-    backgroundColor: theme.mode == "light" ? theme.colors.white : theme.colors.grey10,
+    backgroundColor: theme.colors.whiteOrDarkGrey,
     borderRadius: 10,
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
Adds dark mode support to send bitcoin screen.

How Dark Mode looks:
![image](https://github.com/GaloyMoney/galoy-mobile/assets/40622610/83f96aee-27b2-4055-9ab2-a9441749e2b3)

How Dark Mode handles error:
![image](https://github.com/GaloyMoney/galoy-mobile/assets/40622610/78fd0ac1-7422-4600-9b33-d51f8fe00fbc)