### PR TITLE
fix: prevent multiple sends

### DIFF
--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -104,7 +104,11 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
 
   const fee = useFee(getFee)
 
-  const { loading: sendPaymentLoading, sendPayment } = useSendPayment(sendPaymentMutation)
+  const {
+    loading: sendPaymentLoading,
+    sendPayment,
+    hasAttemptedSend,
+  } = useSendPayment(sendPaymentMutation)
 
   let feeDisplayText = ""
   if (fee.amount) {
@@ -135,7 +139,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           sendingWallet: sendingWalletDescriptor.currency,
         })
 
-        if (!errorsMessage && status === "SUCCESS") {
+        if (status === "SUCCESS" || status === "PENDING") {
           navigation.dispatch((state) => {
             const routes = [{ name: "Primary" }, { name: "sendBitcoinSuccess" }]
             return CommonActions.reset({
@@ -328,7 +332,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
             {...testProps(LL.SendBitcoinConfirmationScreen.title())}
             loading={sendPaymentLoading}
             title={LL.SendBitcoinConfirmationScreen.title()}
-            disabled={!handleSendPayment || !validAmount}
+            disabled={!handleSendPayment || !validAmount || hasAttemptedSend}
             onPress={handleSendPayment || undefined}
           />
         </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -353,7 +353,6 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
             }
             loading={destinationState.destinationState === "validating"}
             disabled={
-              destinationState.destinationState === "validating" ||
               destinationState.destinationState === "invalid" ||
               !destinationState.unparsedDestination ||
               !initiateGoToNextScreen


### PR DESCRIPTION
- only allow one attempt at sending a payment
- show a success message if payment status is `valid`