### PR TITLE
fix: changed notification bar color on mode change

### DIFF
--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -11,7 +11,6 @@ import { ScreenProps } from "./screen.props"
 import { isNonScrolling, offsets, presets } from "./screen.presets"
 import { isIos } from "../../utils/helper"
 import { makeStyles, useTheme } from "@rneui/themed"
-import { light } from "@app/rne-theme/colors"
 
 const useStyles = makeStyles(({ colors }) => ({
   background: {

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -41,7 +41,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={props.backgroundColor}
+        backgroundColor={mode === "light" ? "#FFFFFF" : "#000000"}
       />
       <Wrapper style={[preset.inner, style]}>{props.children}</Wrapper>
     </KeyboardAvoidingView>
@@ -71,7 +71,7 @@ function ScreenWithScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={props.backgroundColor}
+        backgroundColor={mode === "light" ? "#FFFFFF" : "#000000"}
       />
       <Wrapper style={[preset.outer, backgroundStyle]}>
         <ScrollView

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -11,6 +11,7 @@ import { ScreenProps } from "./screen.props"
 import { isNonScrolling, offsets, presets } from "./screen.presets"
 import { isIos } from "../../utils/helper"
 import { makeStyles, useTheme } from "@rneui/themed"
+import { light } from "@app/rne-theme/colors"
 
 const useStyles = makeStyles(({ colors }) => ({
   background: {
@@ -41,7 +42,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={mode === "light" ? "#FFFFFF" : "#000000"}
+        backgroundColor={mode === "light" ? light._white : light._black}
       />
       <Wrapper style={[preset.inner, style]}>{props.children}</Wrapper>
     </KeyboardAvoidingView>

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -10,18 +10,11 @@ import {
 import { ScreenProps } from "./screen.props"
 import { isNonScrolling, offsets, presets } from "./screen.presets"
 import { isIos } from "../../utils/helper"
-import { makeStyles, useTheme } from "@rneui/themed"
-
-const useStyles = makeStyles(({ colors }) => ({
-  background: {
-    color: colors.white,
-  },
-}))
+import { useTheme } from "@rneui/themed"
 
 function ScreenWithoutScrolling(props: ScreenProps) {
-  const styles = useStyles()
   const {
-    theme: { mode },
+    theme: { mode, colors },
   } = useTheme()
 
   const statusBarContent = mode === "light" ? "dark-content" : "light-content"
@@ -30,7 +23,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
   const style = props.style || {}
   const backgroundStyle = props.backgroundColor
     ? { backgroundColor: props.backgroundColor }
-    : { backgroundColor: styles.background.color }
+    : { backgroundColor: colors.white }
   const Wrapper = props.unsafe ? View : SafeAreaView
 
   return (
@@ -41,7 +34,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={styles.background.color}
+        backgroundColor={colors.white}
       />
       <Wrapper style={[preset.inner, style]}>{props.children}</Wrapper>
     </KeyboardAvoidingView>
@@ -49,9 +42,8 @@ function ScreenWithoutScrolling(props: ScreenProps) {
 }
 
 function ScreenWithScrolling(props: ScreenProps) {
-  const styles = useStyles()
   const {
-    theme: { mode },
+    theme: { mode, colors },
   } = useTheme()
 
   const statusBarContent = mode === "light" ? "dark-content" : "light-content"
@@ -60,7 +52,7 @@ function ScreenWithScrolling(props: ScreenProps) {
   const style = props.style || {}
   const backgroundStyle = props.backgroundColor
     ? { backgroundColor: props.backgroundColor }
-    : { backgroundColor: styles.background.color }
+    : { backgroundColor: colors.white }
   const Wrapper = props.unsafe ? View : SafeAreaView
 
   return (
@@ -71,7 +63,7 @@ function ScreenWithScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={styles.background.color}
+        backgroundColor={colors.white}
       />
       <Wrapper style={[preset.outer, backgroundStyle]}>
         <ScrollView

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -42,7 +42,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={mode === "light" ? light._white : light._black}
+        backgroundColor={styles.background.color}
       />
       <Wrapper style={[preset.inner, style]}>{props.children}</Wrapper>
     </KeyboardAvoidingView>
@@ -72,7 +72,7 @@ function ScreenWithScrolling(props: ScreenProps) {
     >
       <StatusBar
         barStyle={props.statusBar || statusBarContent}
-        backgroundColor={mode === "light" ? "#FFFFFF" : "#000000"}
+        backgroundColor={styles.background.color}
       />
       <Wrapper style={[preset.outer, backgroundStyle]}>
         <ScrollView


### PR DESCRIPTION
Fix issue #2208

**Preview**
![image](https://github.com/GaloyMoney/galoy-mobile/assets/74586135/9ec251a4-ec21-4386-adab-7871f6f19e94)
![image](https://github.com/GaloyMoney/galoy-mobile/assets/74586135/889e0ead-5f2f-4e3a-8abb-e696b2939a6e)

I haven't changed the earn screen to blue or green
if we want to match it with the background, then the earn screen also scrolls, and when we scroll the background color changes, should I change the notification bar color on scroll?