### PR TITLE
feat: switch themes

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -83,6 +83,7 @@ const getStories = () => {
     "./app/screens/settings-screen/display-currency-screen.stories.tsx": require("../app/screens/settings-screen/display-currency-screen.stories.tsx"),
     "./app/screens/settings-screen/language-screen.stories.tsx": require("../app/screens/settings-screen/language-screen.stories.tsx"),
     "./app/screens/settings-screen/settings-screen.stories.tsx": require("../app/screens/settings-screen/settings-screen.stories.tsx"),
+    "./app/screens/settings-screen/theme-screen.stories.tsx": require("../app/screens/settings-screen/theme-screen.stories.tsx"),
     "./app/screens/transaction-detail-screen/transaction-detail-screen.stories.tsx": require("../app/screens/transaction-detail-screen/transaction-detail-screen.stories.tsx"),
   };
 };

--- a/.storybook/storybook.tsx
+++ b/.storybook/storybook.tsx
@@ -14,7 +14,7 @@ import TypesafeI18n from "@app/i18n/i18n-react"
 import "./storybook.requires"
 import { detectDefaultLocale } from "../app/utils/locale-detector"
 import RNBootSplash from "react-native-bootsplash"
-import { ThemeSync } from "../app/utils/theme-sync"
+import { ThemeSyncGraphql } from "../app/utils/theme-sync"
 RNBootSplash.hide({ fade: true })
 
 const StorybookUI = getStorybookUI({
@@ -38,7 +38,6 @@ export const StorybookUIRoot: React.FC = () => (
   <I18nWrapper>
     <ThemeWrapper>
       <>
-        <ThemeSync />
         <NavigationContainer>
           <Stack.Navigator>
             <Stack.Screen

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -109,7 +109,7 @@ export const createCache = () =>
             read: (value) => value ?? false,
           },
           colorScheme: {
-            read: (value) => value ?? "light",
+            read: (value) => value ?? "system",
           },
         },
       },

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -24,7 +24,7 @@ export default gql`
   }
 
   query colorScheme {
-    colorScheme @client
+    colorScheme @client # "system" | "light" | "dark"
   }
 `
 

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -625,6 +625,7 @@ const en: BaseTranslation = {
     copyClipboardLnurl: "Lnurl address has been copied in the clipboard",
     defaultWallet: "Default Account",
     rateUs: "Rate us on {storeName: string}",
+    theme: "Theme",
   },
   AccountScreen: {
     accountLevel: "Account Level",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -639,6 +639,13 @@ const en: BaseTranslation = {
     title: "Default Account",
     info: "Your default account is the account that is selected by default when sending and receiving payments. You can change this setting for individual payments on the mobile app. However, payments received through the cash register or your Lightning address will always go to the default account.\n\nTo avoid Bitcoin's volatility, choose Stablesats. This allows you to maintain a stable amount of money while still being able to send and receive payments.\n\nYou can change this setting at any time, and it won't affect your current balance.",
   },
+  ThemeScreen: {
+    title: "Theme",
+    info: "Choose your preferred theme from the following options:",
+    system: "Use System setting",
+    light: "Use Light Mode",
+    dark: "Use Dark Mode",
+  },
   Languages: {
     "DEFAULT": "Default (OS)",
   },

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -642,7 +642,7 @@ const en: BaseTranslation = {
   },
   ThemeScreen: {
     title: "Theme",
-    info: "Choose your preferred theme from the following options:",
+    info: "We understand everyone has their unique preference. Please select one for your interface. You can also keep using the default System setting and we keep this app in line with the theme of your OS.",
     system: "Use System setting",
     light: "Use Light Mode",
     dark: "Use Dark Mode",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2152,7 +2152,7 @@ type RootTranslation = {
 		 */
 		title: string
 		/**
-		 * C​h​o​o​s​e​ ​y​o​u​r​ ​p​r​e​f​e​r​r​e​d​ ​t​h​e​m​e​ ​f​r​o​m​ ​t​h​e​ ​f​o​l​l​o​w​i​n​g​ ​o​p​t​i​o​n​s​:
+		 * W​e​ ​u​n​d​e​r​s​t​a​n​d​ ​e​v​e​r​y​o​n​e​ ​h​a​s​ ​t​h​e​i​r​ ​u​n​i​q​u​e​ ​p​r​e​f​e​r​e​n​c​e​.​ ​P​l​e​a​s​e​ ​s​e​l​e​c​t​ ​o​n​e​ ​f​o​r​ ​y​o​u​r​ ​i​n​t​e​r​f​a​c​e​.​ ​Y​o​u​ ​c​a​n​ ​a​l​s​o​ ​k​e​e​p​ ​u​s​i​n​g​ ​t​h​e​ ​d​e​f​a​u​l​t​ ​S​y​s​t​e​m​ ​s​e​t​t​i​n​g​ ​a​n​d​ ​w​e​ ​k​e​e​p​ ​t​h​i​s​ ​a​p​p​ ​i​n​ ​l​i​n​e​ ​w​i​t​h​ ​t​h​e​ ​t​h​e​m​e​ ​o​f​ ​y​o​u​r​ ​O​S​.
 		 */
 		info: string
 		/**
@@ -5076,7 +5076,7 @@ export type TranslationFunctions = {
 		 */
 		title: () => LocalizedString
 		/**
-		 * Choose your preferred theme from the following options:
+		 * We understand everyone has their unique preference. Please select one for your interface. You can also keep using the default System setting and we keep this app in line with the theme of your OS.
 		 */
 		info: () => LocalizedString
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2142,6 +2142,28 @@ type RootTranslation = {
 		 */
 		info: string
 	}
+	ThemeScreen: {
+		/**
+		 * T​h​e​m​e
+		 */
+		title: string
+		/**
+		 * C​h​o​o​s​e​ ​y​o​u​r​ ​p​r​e​f​e​r​r​e​d​ ​t​h​e​m​e​ ​f​r​o​m​ ​t​h​e​ ​f​o​l​l​o​w​i​n​g​ ​o​p​t​i​o​n​s​:
+		 */
+		info: string
+		/**
+		 * U​s​e​ ​S​y​s​t​e​m​ ​s​e​t​t​i​n​g
+		 */
+		system: string
+		/**
+		 * U​s​e​ ​L​i​g​h​t​ ​M​o​d​e
+		 */
+		light: string
+		/**
+		 * U​s​e​ ​D​a​r​k​ ​M​o​d​e
+		 */
+		dark: string
+	}
 	Languages: {
 		/**
 		 * D​e​f​a​u​l​t​ ​(​O​S​)
@@ -5039,6 +5061,28 @@ export type TranslationFunctions = {
 	You can change this setting at any time, and it won't affect your current balance.
 		 */
 		info: () => LocalizedString
+	}
+	ThemeScreen: {
+		/**
+		 * Theme
+		 */
+		title: () => LocalizedString
+		/**
+		 * Choose your preferred theme from the following options:
+		 */
+		info: () => LocalizedString
+		/**
+		 * Use System setting
+		 */
+		system: () => LocalizedString
+		/**
+		 * Use Light Mode
+		 */
+		light: () => LocalizedString
+		/**
+		 * Use Dark Mode
+		 */
+		dark: () => LocalizedString
 	}
 	Languages: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2095,6 +2095,10 @@ type RootTranslation = {
 		 * @param {string} storeName
 		 */
 		rateUs: RequiredParams<'storeName'>
+		/**
+		 * T​h​e​m​e
+		 */
+		theme: string
 	}
 	AccountScreen: {
 		/**
@@ -5016,6 +5020,10 @@ export type TranslationFunctions = {
 		 * Rate us on {storeName}
 		 */
 		rateUs: (arg: { storeName: string }) => LocalizedString
+		/**
+		 * Theme
+		 */
+		theme: () => LocalizedString
 	}
 	AccountScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -629,7 +629,7 @@
     },
     "ThemeScreen": {
         "title": "Theme",
-        "info": "Choose your preferred theme from the following options:",
+        "info": "We understand everyone has their unique preference. Please select one for your interface. You can also keep using the default System setting and we keep this app in line with the theme of your OS.",
         "system": "Use System setting",
         "light": "Use Light Mode",
         "dark": "Use Dark Mode"

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -626,6 +626,13 @@
         "title": "Default Account",
         "info": "Your default account is the account that is selected by default when sending and receiving payments. You can change this setting for individual payments on the mobile app. However, payments received through the cash register or your Lightning address will always go to the default account.\n\nTo avoid Bitcoin's volatility, choose Stablesats. This allows you to maintain a stable amount of money while still being able to send and receive payments.\n\nYou can change this setting at any time, and it won't affect your current balance."
     },
+    "ThemeScreen": {
+        "title": "Theme",
+        "info": "Choose your preferred theme from the following options:",
+        "system": "Use System setting",
+        "light": "Use Light Mode",
+        "dark": "Use Dark Mode"
+    },
     "Languages": {
         "DEFAULT": "Default (OS)"
     },

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -611,7 +611,8 @@
         "lnurlNoUsername": "To generate an lnurl address you must first set a username.  Do you want to set a username now?",
         "copyClipboardLnurl": "Lnurl address has been copied in the clipboard",
         "defaultWallet": "Default Account",
-        "rateUs": "Rate us on {storeName: string}"
+        "rateUs": "Rate us on {storeName: string}",
+        "theme": "Theme"
     },
     "AccountScreen": {
         "accountLevel": "Account Level",

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -56,6 +56,7 @@ import { PhoneValidationScreen } from "@app/screens/phone-auth-screen"
 import { DisplayCurrencyScreen } from "@app/screens/settings-screen/display-currency-screen"
 import { makeStyles, useTheme } from "@rneui/themed"
 import { DefaultWalletScreen } from "@app/screens/settings-screen/default-wallet"
+import { ThemeScreen } from "@app/screens/settings-screen/theme-screen"
 
 const useStyles = makeStyles(({ colors }) => ({
   bottomNavigatorStyle: {
@@ -234,6 +235,13 @@ export const RootStack = () => {
         component={DefaultWalletScreen}
         options={() => ({
           title: LL.DefaultWalletScreen.title(),
+        })}
+      />
+      <RootNavigator.Screen
+        name="theme"
+        component={ThemeScreen}
+        options={() => ({
+          title: LL.ThemeScreen.title(),
         })}
       />
       <RootNavigator.Screen

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -28,6 +28,7 @@ export type RootStackParamList = {
   settings: undefined
   addressScreen: undefined
   defaultWallet: undefined
+  theme: undefined
   sendBitcoinDestination: {
     payment?: string
     username?: string

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -261,12 +261,12 @@ export const SettingsScreen: React.FC = () => {
       styleDivider: true,
     },
     {
-      category: `${LL.SettingsScreen.darkMode()} - ${LL.common.beta()}`,
+      category: `${LL.SettingsScreen.theme()}`,
       icon: "contrast-outline",
       id: "contrast",
       action: () => navigation.navigate("theme"),
-      enabled: isAtLeastLevelZero,
-      greyed: !isAtLeastLevelZero,
+      enabled: true,
+      greyed: false,
       styleDivider: true,
     },
     {

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -10,9 +10,8 @@ import KeyStoreWrapper from "../../utils/storage/secureStorage"
 import ContactModal from "@app/components/contact-modal/contact-modal"
 import crashlytics from "@react-native-firebase/crashlytics"
 
-import { gql, useApolloClient } from "@apollo/client"
+import { gql } from "@apollo/client"
 import {
-  useColorSchemeQuery,
   useSettingsScreenQuery,
   useWalletCsvTransactionsLazyQuery,
 } from "@app/graphql/generated"
@@ -25,7 +24,6 @@ import { toastShow } from "@app/utils/toast"
 import Clipboard from "@react-native-clipboard/clipboard"
 import { useNavigation } from "@react-navigation/native"
 import { SettingsRow } from "./settings-row"
-import { updateColorScheme } from "@app/graphql/client-only-query"
 import { getReadableVersion } from "react-native-device-info"
 import { isIos } from "@app/utils/helper"
 import Rate from "react-native-rate"
@@ -65,11 +63,6 @@ gql`
 
 export const SettingsScreen: React.FC = () => {
   const navigation = useNavigation<StackNavigationProp<RootStackParamList, "settings">>()
-
-  const client = useApolloClient()
-
-  const colorSchemeData = useColorSchemeQuery()
-  const colorScheme = colorSchemeData?.data?.colorScheme ?? "light"
 
   const { appConfig } = useAppConfig()
   const { name: bankName } = appConfig.galoyInstance
@@ -165,18 +158,6 @@ export const SettingsScreen: React.FC = () => {
   const contactMessageSubject = LL.support.defaultEmailSubject({
     bankName,
   })
-
-  let newColorScheme: string
-  switch (colorScheme) {
-    case "light":
-      newColorScheme = "dark"
-      break
-    case "dark":
-      newColorScheme = "system"
-      break
-    default:
-      newColorScheme = "light"
-  }
 
   const settingsList: SettingRow[] = [
     {
@@ -283,8 +264,7 @@ export const SettingsScreen: React.FC = () => {
       category: `${LL.SettingsScreen.darkMode()} - ${LL.common.beta()}`,
       icon: "contrast-outline",
       id: "contrast",
-      action: () => updateColorScheme(client, newColorScheme),
-      subTitleText: `${colorScheme}; next - ${newColorScheme}`,
+      action: () => navigation.navigate("theme"),
       enabled: isAtLeastLevelZero,
       greyed: !isAtLeastLevelZero,
       styleDivider: true,

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -166,6 +166,18 @@ export const SettingsScreen: React.FC = () => {
     bankName,
   })
 
+  let newColorScheme: string
+  switch (colorScheme) {
+    case "light":
+      newColorScheme = "dark"
+      break
+    case "dark":
+      newColorScheme = "system"
+      break
+    default:
+      newColorScheme = "light"
+  }
+
   const settingsList: SettingRow[] = [
     {
       category: isAtLeastLevelOne
@@ -271,8 +283,8 @@ export const SettingsScreen: React.FC = () => {
       category: `${LL.SettingsScreen.darkMode()} - ${LL.common.beta()}`,
       icon: "contrast-outline",
       id: "contrast",
-      action: () => updateColorScheme(client, colorScheme === "light" ? "dark" : "light"),
-      subTitleText: colorScheme,
+      action: () => updateColorScheme(client, newColorScheme),
+      subTitleText: `${colorScheme}; next - ${newColorScheme}`,
       enabled: isAtLeastLevelZero,
       greyed: !isAtLeastLevelZero,
       styleDivider: true,

--- a/app/screens/settings-screen/theme-screen.stories.tsx
+++ b/app/screens/settings-screen/theme-screen.stories.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+import { StoryScreen } from "../../../.storybook/views"
+import { ThemeScreen } from "./theme-screen"
+import { Meta } from "@storybook/react"
+import { MockedProvider } from "@apollo/client/testing"
+import { createCache } from "../../graphql/cache"
+
+export default {
+  title: "Theme Screen",
+  component: ThemeScreen,
+  decorators: [(Story) => <StoryScreen>{Story()}</StoryScreen>],
+} as Meta<typeof ThemeScreen>
+
+export const Default = () => (
+  <MockedProvider cache={createCache()}>
+    <ThemeScreen />
+  </MockedProvider>
+)

--- a/app/screens/settings-screen/theme-screen.tsx
+++ b/app/screens/settings-screen/theme-screen.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { useI18nContext } from "@app/i18n/i18n-react"
 
 import { View } from "react-native"
-import { ListItem, Text, makeStyles, useTheme } from "@rneui/themed"
+import { ListItem, makeStyles, useTheme } from "@rneui/themed"
 import Icon from "react-native-vector-icons/Ionicons"
 
 import { Screen } from "../../components/screen"

--- a/app/screens/settings-screen/theme-screen.tsx
+++ b/app/screens/settings-screen/theme-screen.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import { useI18nContext } from "@app/i18n/i18n-react"
+
+import { View } from "react-native"
+import { ListItem, Text, makeStyles, useTheme } from "@rneui/themed"
+import Icon from "react-native-vector-icons/Ionicons"
+
+import { Screen } from "../../components/screen"
+
+import { useApolloClient } from "@apollo/client"
+import { useColorSchemeQuery } from "@app/graphql/generated"
+import { updateColorScheme } from "@app/graphql/client-only-query"
+
+const useStyles = makeStyles(() => ({
+  container: {
+    padding: 20,
+  },
+  info: {
+    marginBottom: 10,
+  },
+  viewSelectedIcon: { width: 18 },
+}))
+
+export const ThemeScreen: React.FC = () => {
+  const client = useApolloClient()
+  const colorSchemeData = useColorSchemeQuery()
+  const colorScheme = colorSchemeData?.data?.colorScheme ?? "system"
+
+  const { LL } = useI18nContext()
+  const {
+    theme: { colors },
+  } = useTheme()
+  const styles = useStyles()
+
+  const Themes = [
+    {
+      id: "system",
+      text: LL.ThemeScreen.system(),
+    },
+    {
+      id: "light",
+      text: LL.ThemeScreen.light(),
+    },
+    {
+      id: "dark",
+      text: LL.ThemeScreen.dark(),
+    },
+  ]
+
+  return (
+    <Screen style={styles.container} preset="scroll">
+      <Text style={styles.info}>{LL.ThemeScreen.info()}</Text>
+      {Themes.map(({ id, text }) => (
+        <ListItem key={id} bottomDivider onPress={() => updateColorScheme(client, id)}>
+          <View style={styles.viewSelectedIcon}>
+            {colorScheme === id && (
+              <Icon name="ios-checkmark-circle" size={18} color={colors.green} />
+            )}
+          </View>
+          <ListItem.Title>{text}</ListItem.Title>
+        </ListItem>
+      ))}
+    </Screen>
+  )
+}

--- a/app/screens/settings-screen/theme-screen.tsx
+++ b/app/screens/settings-screen/theme-screen.tsx
@@ -10,13 +10,14 @@ import { Screen } from "../../components/screen"
 import { useApolloClient } from "@apollo/client"
 import { useColorSchemeQuery } from "@app/graphql/generated"
 import { updateColorScheme } from "@app/graphql/client-only-query"
+import { GaloyInfo } from "@app/components/atomic/galoy-info"
 
 const useStyles = makeStyles(() => ({
   container: {
-    padding: 20,
+    padding: 10,
   },
   info: {
-    marginBottom: 10,
+    marginTop: 20,
   },
   viewSelectedIcon: { width: 18 },
 }))
@@ -49,7 +50,6 @@ export const ThemeScreen: React.FC = () => {
 
   return (
     <Screen style={styles.container} preset="scroll">
-      <Text style={styles.info}>{LL.ThemeScreen.info()}</Text>
       {Themes.map(({ id, text }) => (
         <ListItem key={id} bottomDivider onPress={() => updateColorScheme(client, id)}>
           <View style={styles.viewSelectedIcon}>
@@ -60,6 +60,9 @@ export const ThemeScreen: React.FC = () => {
           <ListItem.Title>{text}</ListItem.Title>
         </ListItem>
       ))}
+      <View style={styles.info}>
+        <GaloyInfo>{LL.ThemeScreen.info()}</GaloyInfo>
+      </View>
     </Screen>
   )
 }

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -1,38 +1,7 @@
 import { useColorSchemeQuery } from "@app/graphql/generated"
 import { useThemeMode, ThemeMode } from "@rneui/themed"
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import { Appearance } from "react-native"
-
-export const ThemeSync = () => {
-  const { mode, setMode } = useThemeMode()
-
-  React.useEffect(() => {
-    const isDarkMode = Appearance.getColorScheme() !== "light"
-    const intendedMode = isDarkMode ? "dark" : "light"
-
-    if (intendedMode !== mode) {
-      setMode(intendedMode)
-    }
-  }, [mode, setMode])
-
-  React.useEffect(() => {
-    const res = Appearance.addChangeListener(({ colorScheme }) => {
-      if (mode === colorScheme) {
-        return
-      }
-
-      if (colorScheme === null || colorScheme === undefined) {
-        setMode("dark")
-      }
-
-      setMode(colorScheme as ThemeMode) // TODO: not do casting?
-    })
-
-    return res.remove
-  }, [mode, setMode])
-
-  return null
-}
 
 export const ThemeSyncGraphql = () => {
   const { mode, setMode } = useThemeMode()

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -55,11 +55,11 @@ export const ThemeSyncGraphql = () => {
     }
 
     if (scheme === "system") {
-      const stopListener = Appearance.addChangeListener(({ colorScheme }) => {
+      const { remove: stopListener } = Appearance.addChangeListener(({ colorScheme }) => {
         if (!colorScheme) return
         if (colorScheme !== mode) setMode(colorScheme as ThemeMode)
       })
-      return () => stopListener.remove()
+      return () => stopListener()
     }
 
     return () => {}

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -43,12 +43,26 @@ export const ThemeSyncGraphql = () => {
     const scheme = data?.data?.colorScheme
 
     if (!scheme) {
-      return
+      return () => {}
     }
 
-    if (scheme !== mode) {
+    const systemScheme = Appearance.getColorScheme()
+
+    if (scheme !== mode && scheme !== "system") {
       setMode(scheme as ThemeMode)
+    } else if (scheme === "system" && systemScheme !== mode) {
+      setMode(systemScheme as ThemeMode)
     }
+
+    if (scheme === "system") {
+      const stopListener = Appearance.addChangeListener(({ colorScheme }) => {
+        if (!colorScheme) return
+        if (colorScheme !== mode) setMode(colorScheme as ThemeMode)
+      })
+      return () => stopListener.remove()
+    }
+
+    return () => {}
   }, [data, setMode, mode])
 
   return null

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -59,7 +59,7 @@ export const ThemeSyncGraphql = () => {
         if (!colorScheme) return
         if (colorScheme !== mode) setMode(colorScheme as ThemeMode)
       })
-      return () => stopListener()
+      return stopListener
     }
 
     return () => {}

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -12,7 +12,7 @@ export const ThemeSyncGraphql = () => {
     const scheme = data?.data?.colorScheme
 
     if (!scheme) {
-      return () => {}
+      return
     }
 
     const systemScheme = Appearance.getColorScheme()

--- a/app/utils/theme-sync.tsx
+++ b/app/utils/theme-sync.tsx
@@ -10,26 +10,25 @@ export const ThemeSyncGraphql = () => {
 
   useEffect(() => {
     const scheme = data?.data?.colorScheme
+    if (!scheme) return
 
-    if (!scheme) {
-      return
-    }
-
-    const systemScheme = Appearance.getColorScheme()
-
-    if (scheme !== mode && scheme !== "system") {
-      setMode(scheme as ThemeMode)
-    } else if (scheme === "system" && systemScheme !== mode) {
-      setMode(systemScheme as ThemeMode)
-    }
-
+    // Default scheme is system
     if (scheme === "system") {
+      const systemScheme = Appearance.getColorScheme()
+
+      // Set if System Scheme is different
+      if (systemScheme !== mode) setMode(systemScheme as ThemeMode)
+
+      // Listener for system scheme - in case OS theme is switched when the app is running
       const { remove: stopListener } = Appearance.addChangeListener(({ colorScheme }) => {
         if (!colorScheme) return
         if (colorScheme !== mode) setMode(colorScheme as ThemeMode)
       })
       return stopListener
     }
+
+    // Set if Set theme is different (and not system)
+    if (scheme !== mode) setMode(scheme as ThemeMode)
 
     return () => {}
   }, [data, setMode, mode])


### PR DESCRIPTION
- Theme can now be switched from settings.
- Added a new `System` theme which responds to dark/light mode as set at OS and changes at runtime too
- Removed Beta tag for Dark Mode

<table>
  <tr>
    <td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/b827556a-f545-498e-a7a0-357aa819566b" alt="Image 1" style="width: 100%;"/></td>
    <td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/5c5291a2-b05c-4571-80e4-07b88f4f471b" alt="Image 2" style="width: 100%;"/></td>
    <td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/b31bd07c-8354-4c41-b922-f2c23a1ef9f4" alt="Image 3" style="width: 100%;"/></td>  </tr>
</table>
