### PR TITLE
ci: use local node 18 image for e2e tests, increase timeout for android and ios builds

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,24 +4,12 @@
 #@   return data.values.docker_registry + "/galoy-mobile-pipeline"
 #@ end
 
-#@ def nodejs_pipeline_image():
-#@   return data.values.docker_registry + "/nodejs-concourse"
-#@ end
-
 #@ def task_image_config():
 type: registry-image
 source:
   username: #@ data.values.docker_registry_user
   password: #@ data.values.docker_registry_password
   repository: #@ pipeline_image()
-#@ end
-
-#@ def nodejs_task_image_config():
-type: registry-image
-source:
-  username: #@ data.values.docker_registry_user
-  password: #@ data.values.docker_registry_password
-  repository: #@ nodejs_pipeline_image()
 #@ end
 
 #@ def cancel_circleci_build_on_abort():
@@ -208,7 +196,7 @@ jobs:
   - task: e2e-test
     config:
       platform: linux
-      image_resource: #@ nodejs_task_image_config()
+      image_resource: #@ task_image_config()
       inputs:
       - name: repo
       - name: bundled-deps
@@ -237,7 +225,7 @@ jobs:
   - task: e2e-test
     config:
       platform: linux
-      image_resource: #@ nodejs_task_image_config()
+      image_resource: #@ task_image_config()
       inputs:
       - name: repo
       - name: bundled-deps

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -152,7 +152,7 @@ jobs:
         path: pipeline-tasks/ci/tasks/build-on-circleci.sh
       params:
         PLATFORM: android
-        WAIT_FOR_BUILD_MINS: 20
+        WAIT_FOR_BUILD_MINS: 30
         BUILD_NUMBER_FILE: build-number-android/android
         GIT_REF_FILE: repo/.git/ref
         VERSION_FILE: repo/.git/ref
@@ -185,7 +185,7 @@ jobs:
         path: pipeline-tasks/ci/tasks/build-on-circleci.sh
       params:
         PLATFORM: ios
-        WAIT_FOR_BUILD_MINS: 30
+        WAIT_FOR_BUILD_MINS: 45
         BUILD_NUMBER_FILE: build-number-ios/ios
         GIT_REF_FILE: repo/.git/ref
         VERSION_FILE: repo/.git/ref
@@ -350,7 +350,7 @@ jobs:
         path: pipeline-tasks/ci/tasks/build-on-circleci.sh
       params:
         PLATFORM: android
-        WAIT_FOR_BUILD_MINS: 20
+        WAIT_FOR_BUILD_MINS: 30
         BUILD_NUMBER_FILE: build-number-android/android
         GIT_REF_FILE: built-dev-apk/url
         GIT_REF_PATTERN: dev/android/galoy-mobile-.+-v(.+)/apk
@@ -409,7 +409,7 @@ jobs:
         path: pipeline-tasks/ci/tasks/build-on-circleci.sh
       params:
         PLATFORM: ios
-        WAIT_FOR_BUILD_MINS: 30
+        WAIT_FOR_BUILD_MINS: 45
         BUILD_NUMBER_FILE: build-number-ios/ios
         GIT_REF_FILE: built-dev-ipa/url
         GIT_REF_PATTERN: dev/ios/galoy-mobile-.+-v(.+)/Bitcoin

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,12 +4,24 @@
 #@   return data.values.docker_registry + "/galoy-mobile-pipeline"
 #@ end
 
+#@ def release_pipeline_image():
+#@   return data.values.docker_registry + "/release-pipeline"
+#@ end
+
 #@ def task_image_config():
 type: registry-image
 source:
   username: #@ data.values.docker_registry_user
   password: #@ data.values.docker_registry_password
   repository: #@ pipeline_image()
+#@ end
+
+#@ def release_task_image_config():
+type: registry-image
+source:
+  username: #@ data.values.docker_registry_user
+  password: #@ data.values.docker_registry_password
+  repository: #@ release_pipeline_image()
 #@ end
 
 #@ def cancel_circleci_build_on_abort():


### PR DESCRIPTION
- also added a previously removed release pipeline task config to properly repipe

Already applied