### PR TITLE
ci: fetch tags in prerelease

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -259,6 +259,8 @@ jobs:
       trigger: true
     - get: repo
       passed: ["e2e-test-android", "e2e-test-ios"]
+      params:
+        fetch_tags: true
     - get: built-dev-ipa
       passed: [ e2e-test-ios ]
     - get: built-dev-apk


### PR DESCRIPTION
Applied, attempt to fix:
```
fatal: ambiguous argument '2.2.52': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```