### PR TITLE
chore: Revert "chore: attempt to use new m1 ressources (#2257)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
   test_ios_in_pr:
     macos:
       xcode: 14.2.0
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.x86.medium.gen2
     working_directory: ~/galoy-mobile
     environment:
       FL_OUTPUT_DIR: output
@@ -219,7 +219,7 @@ jobs:
   build_ios:
     macos:
       xcode: 14.2.0
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.x86.medium.gen2
     environment:
       PUBLIC_VERSION: << pipeline.parameters.version >>
       BUILD_NUMBER: << pipeline.parameters.build_number >>
@@ -290,7 +290,7 @@ jobs:
   upload_to_app_store:
     macos:
       xcode: 14.2.0
-    resource_class: macos.m1.large.gen1
+    resource_class: macos.x86.medium.gen2
     environment:
       GCS_URL: << pipeline.parameters.gcs_url >>
     working_directory: ~/galoy-mobile


### PR DESCRIPTION
This reverts commit acd36aac50ba5ba603f036c4d0305e608d920288.