### PR TITLE
chore: avoid Could not install WWDR certificate issue in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,11 @@ jobs:
             - node_modules
             - ios/Pods
       - run:
+          name: Import Apple Certificates
+          command: |
+            tmpfile=$(mktemp /tmp/wwdr-cert.cer)
+            curl -f -o $tmpfile https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer && security import $tmpfile ~/Library/Keychains/login.keychain-db
+      - run:
           name: Browserstack Testing
           command: |
             set -o pipefail


### PR DESCRIPTION
this would avoid issues like this one: https://app.circleci.com/pipelines/github/GaloyMoney/galoy-mobile/8698/workflows/a6918e71-054b-4714-b0f8-7626921ae946/jobs/12789