### PR TITLE
chore: prevent button flickering on app start

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -48,8 +48,8 @@ export const App = () => (
   <PersistentStateProvider>
     <TypesafeI18n locale={detectDefaultLocale()}>
       <ThemeProvider theme={theme}>
-        <FeatureFlagContextProvider>
-          <GaloyClient>
+        <GaloyClient>
+          <FeatureFlagContextProvider>
             <ErrorBoundary FallbackComponent={ErrorScreen}>
               <NavigationContainerWrapper>
                 <RootSiblingParent>
@@ -62,8 +62,8 @@ export const App = () => (
               </NavigationContainerWrapper>
             </ErrorBoundary>
             <ThemeSyncGraphql />
-          </GaloyClient>
-        </FeatureFlagContextProvider>
+          </FeatureFlagContextProvider>
+        </GaloyClient>
       </ThemeProvider>
     </TypesafeI18n>
   </PersistentStateProvider>

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -1,6 +1,7 @@
 import React, { useState, createContext, useContext, useEffect } from "react"
 import remoteConfigInstance from "@react-native-firebase/remote-config"
 import { useAppConfig } from "@app/hooks"
+import { useLevel } from "@app/graphql/level-context"
 
 const DeviceAccountEnabledKey = "deviceAccountEnabled"
 
@@ -31,6 +32,9 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
   const [remoteConfig, setRemoteConfig] = useState<RemoteConfig>(defaultRemoteConfig)
 
+  const { currentLevel } = useLevel()
+  const [removeConfigReady, setRemoteConfigReady] = useState(false)
+
   const {
     appConfig: { galoyInstance },
   } = useAppConfig()
@@ -45,6 +49,8 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
         setRemoteConfig({ deviceAccountEnabled })
       } catch (err) {
         console.error("Error fetching remote config: ", err)
+      } finally {
+        setRemoteConfigReady(true)
       }
     })()
   }, [])
@@ -52,6 +58,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
   const featureFlags = {
     deviceAccountEnabled:
       remoteConfig.deviceAccountEnabled || galoyInstance.id === "Local",
+  }
+
+  if (!removeConfigReady && currentLevel === "NonAuth") {
+    return null
   }
 
   return (


### PR DESCRIPTION
currently the secondary button label change after 1 sec

this PR would preserve the "blink" loading screen from RNBootSplash until the call to the the remote config server has resolved