### PR TITLE
feat: add speed for batching

### DIFF
--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -754,12 +754,13 @@ query network {
   }
 }
 
-query onChainTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations) {
+query onChainTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainTxFee(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations
@@ -767,12 +768,13 @@ query onChainTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: Sat
   }
 }
 
-query onChainUsdTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: CentAmount!, $targetConfirmations: TargetConfirmations) {
+query onChainUsdTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: CentAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainUsdTxFee(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations
@@ -780,12 +782,13 @@ query onChainUsdTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: 
   }
 }
 
-query onChainUsdTxFeeAsBtcDenominated($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations) {
+query onChainUsdTxFeeAsBtcDenominated($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainUsdTxFeeAsBtcDenominated(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -40,6 +40,8 @@ export type Scalars = {
   /** An authentication code valid for a single use */
   OneTimeAuthCode: string;
   PaymentHash: string;
+  /** Unique request id for a payout */
+  PayoutRequestId: string;
   /** Phone number which includes country code */
   Phone: string;
   /** Non-fractional signed whole numeric value between -(2^53) + 1 and 2^53 - 1 */
@@ -856,6 +858,9 @@ export type OnChainAddressPayload = {
 export type OnChainPaymentSendAllInput = {
   readonly address: Scalars['OnChainAddress'];
   readonly memo?: InputMaybe<Scalars['Memo']>;
+  readonly requestId?: InputMaybe<Scalars['PayoutRequestId']>;
+  readonly speed?: InputMaybe<PayoutSpeed>;
+  /** @deprecated Ignored - will be replaced */
   readonly targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   readonly walletId: Scalars['WalletId'];
 };
@@ -864,6 +869,9 @@ export type OnChainPaymentSendInput = {
   readonly address: Scalars['OnChainAddress'];
   readonly amount: Scalars['SatAmount'];
   readonly memo?: InputMaybe<Scalars['Memo']>;
+  readonly requestId?: InputMaybe<Scalars['PayoutRequestId']>;
+  readonly speed?: InputMaybe<PayoutSpeed>;
+  /** @deprecated Ignored - will be replaced */
   readonly targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   readonly walletId: Scalars['WalletId'];
 };
@@ -871,6 +879,7 @@ export type OnChainPaymentSendInput = {
 export type OnChainTxFee = {
   readonly __typename: 'OnChainTxFee';
   readonly amount: Scalars['SatAmount'];
+  /** @deprecated Ignored - will be removed */
   readonly targetConfirmations: Scalars['TargetConfirmations'];
 };
 
@@ -889,6 +898,9 @@ export type OnChainUsdPaymentSendAsBtcDenominatedInput = {
   readonly address: Scalars['OnChainAddress'];
   readonly amount: Scalars['SatAmount'];
   readonly memo?: InputMaybe<Scalars['Memo']>;
+  readonly requestId?: InputMaybe<Scalars['PayoutRequestId']>;
+  readonly speed?: InputMaybe<PayoutSpeed>;
+  /** @deprecated Ignored - will be replaced */
   readonly targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   readonly walletId: Scalars['WalletId'];
 };
@@ -897,6 +909,9 @@ export type OnChainUsdPaymentSendInput = {
   readonly address: Scalars['OnChainAddress'];
   readonly amount: Scalars['CentAmount'];
   readonly memo?: InputMaybe<Scalars['Memo']>;
+  readonly requestId?: InputMaybe<Scalars['PayoutRequestId']>;
+  readonly speed?: InputMaybe<PayoutSpeed>;
+  /** @deprecated Ignored - will be replaced */
   readonly targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   readonly walletId: Scalars['WalletId'];
 };
@@ -904,6 +919,7 @@ export type OnChainUsdPaymentSendInput = {
 export type OnChainUsdTxFee = {
   readonly __typename: 'OnChainUsdTxFee';
   readonly amount: Scalars['CentAmount'];
+  /** @deprecated Ignored - will be removed */
   readonly targetConfirmations: Scalars['TargetConfirmations'];
 };
 
@@ -944,6 +960,11 @@ export const PaymentSendResult = {
 } as const;
 
 export type PaymentSendResult = typeof PaymentSendResult[keyof typeof PaymentSendResult];
+export const PayoutSpeed = {
+  Fast: 'FAST'
+} as const;
+
+export type PayoutSpeed = typeof PayoutSpeed[keyof typeof PayoutSpeed];
 export const PhoneCodeChannelType = {
   Sms: 'SMS',
   Whatsapp: 'WHATSAPP'
@@ -1085,6 +1106,7 @@ export type QueryLnInvoicePaymentStatusArgs = {
 export type QueryOnChainTxFeeArgs = {
   address: Scalars['OnChainAddress'];
   amount: Scalars['SatAmount'];
+  speed?: InputMaybe<PayoutSpeed>;
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   walletId: Scalars['WalletId'];
 };
@@ -1093,6 +1115,7 @@ export type QueryOnChainTxFeeArgs = {
 export type QueryOnChainUsdTxFeeArgs = {
   address: Scalars['OnChainAddress'];
   amount: Scalars['CentAmount'];
+  speed?: InputMaybe<PayoutSpeed>;
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   walletId: Scalars['WalletId'];
 };
@@ -1101,6 +1124,7 @@ export type QueryOnChainUsdTxFeeArgs = {
 export type QueryOnChainUsdTxFeeAsBtcDenominatedArgs = {
   address: Scalars['OnChainAddress'];
   amount: Scalars['SatAmount'];
+  speed?: InputMaybe<PayoutSpeed>;
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
   walletId: Scalars['WalletId'];
 };
@@ -1189,7 +1213,7 @@ export type SettlementViaLn = {
 
 export type SettlementViaOnChain = {
   readonly __typename: 'SettlementViaOnChain';
-  readonly transactionHash: Scalars['OnChainTxHash'];
+  readonly transactionHash?: Maybe<Scalars['OnChainTxHash']>;
   readonly vout?: Maybe<Scalars['Int']>;
 };
 
@@ -1565,9 +1589,9 @@ export type ColorSchemeQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type ColorSchemeQuery = { readonly __typename: 'Query', readonly colorScheme: string };
 
-export type TransactionFragment = { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } };
+export type TransactionFragment = { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null } };
 
-export type TransactionListFragment = { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } } }> | null };
+export type TransactionListFragment = { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null } } }> | null };
 
 export type NetworkQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1603,7 +1627,7 @@ export type TransactionListForContactQueryVariables = Exact<{
 }>;
 
 
-export type TransactionListForContactQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly contactByUsername: { readonly __typename: 'UserContact', readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } } }> | null } | null } } | null };
+export type TransactionListForContactQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly contactByUsername: { readonly __typename: 'UserContact', readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null } } }> | null } | null } } | null };
 
 export type UserContactUpdateAliasMutationVariables = Exact<{
   input: UserContactUpdateAliasInput;
@@ -1661,7 +1685,7 @@ export type UserLoginDeviceMutation = { readonly __typename: 'Mutation', readonl
 export type HomeAuthedQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type HomeAuthedQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly language: string, readonly username?: string | null, readonly phone?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly level: AccountLevel, readonly defaultWalletId: string, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } } }> | null } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> } } | null };
+export type HomeAuthedQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly language: string, readonly username?: string | null, readonly phone?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly level: AccountLevel, readonly defaultWalletId: string, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null } } }> | null } | null, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> } } | null };
 
 export type HomeUnauthedQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1964,7 +1988,7 @@ export type TransactionListForDefaultAccountQueryVariables = Exact<{
 }>;
 
 
-export type TransactionListForDefaultAccountQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash: string } } }> | null } | null } } | null };
+export type TransactionListForDefaultAccountQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly transactions?: { readonly __typename: 'TransactionConnection', readonly pageInfo: { readonly __typename: 'PageInfo', readonly hasNextPage: boolean, readonly hasPreviousPage: boolean, readonly startCursor?: string | null, readonly endCursor?: string | null }, readonly edges?: ReadonlyArray<{ readonly __typename: 'TransactionEdge', readonly cursor: string, readonly node: { readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly memo?: string | null, readonly createdAt: number, readonly settlementAmount: number, readonly settlementFee: number, readonly settlementDisplayFee: string, readonly settlementCurrency: WalletCurrency, readonly settlementDisplayAmount: string, readonly settlementDisplayCurrency: string, readonly settlementPrice: { readonly __typename: 'PriceOfOneSettlementMinorUnitInDisplayMinorUnit', readonly base: number, readonly offset: number, readonly currencyUnit: string, readonly formattedAmount: string }, readonly initiationVia: { readonly __typename: 'InitiationViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'InitiationViaLn', readonly paymentHash: string } | { readonly __typename: 'InitiationViaOnChain', readonly address: string }, readonly settlementVia: { readonly __typename: 'SettlementViaIntraLedger', readonly counterPartyWalletId?: string | null, readonly counterPartyUsername?: string | null } | { readonly __typename: 'SettlementViaLn', readonly paymentSecret?: string | null } | { readonly __typename: 'SettlementViaOnChain', readonly transactionHash?: string | null } } }> | null } | null } } | null };
 
 export type DeviceNotificationTokenCreateMutationVariables = Exact<{
   input: DeviceNotificationTokenCreateInput;

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1841,6 +1841,7 @@ export type OnChainTxFeeQueryVariables = Exact<{
   address: Scalars['OnChainAddress'];
   amount: Scalars['SatAmount'];
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
+  speed?: InputMaybe<PayoutSpeed>;
 }>;
 
 
@@ -1851,6 +1852,7 @@ export type OnChainUsdTxFeeQueryVariables = Exact<{
   address: Scalars['OnChainAddress'];
   amount: Scalars['CentAmount'];
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
+  speed?: InputMaybe<PayoutSpeed>;
 }>;
 
 
@@ -1861,6 +1863,7 @@ export type OnChainUsdTxFeeAsBtcDenominatedQueryVariables = Exact<{
   address: Scalars['OnChainAddress'];
   amount: Scalars['SatAmount'];
   targetConfirmations?: InputMaybe<Scalars['TargetConfirmations']>;
+  speed?: InputMaybe<PayoutSpeed>;
 }>;
 
 
@@ -4108,12 +4111,13 @@ export type LnNoAmountUsdInvoiceFeeProbeMutationHookResult = ReturnType<typeof u
 export type LnNoAmountUsdInvoiceFeeProbeMutationResult = Apollo.MutationResult<LnNoAmountUsdInvoiceFeeProbeMutation>;
 export type LnNoAmountUsdInvoiceFeeProbeMutationOptions = Apollo.BaseMutationOptions<LnNoAmountUsdInvoiceFeeProbeMutation, LnNoAmountUsdInvoiceFeeProbeMutationVariables>;
 export const OnChainTxFeeDocument = gql`
-    query onChainTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations) {
+    query onChainTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainTxFee(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations
@@ -4137,6 +4141,7 @@ export const OnChainTxFeeDocument = gql`
  *      address: // value for 'address'
  *      amount: // value for 'amount'
  *      targetConfirmations: // value for 'targetConfirmations'
+ *      speed: // value for 'speed'
  *   },
  * });
  */
@@ -4152,12 +4157,13 @@ export type OnChainTxFeeQueryHookResult = ReturnType<typeof useOnChainTxFeeQuery
 export type OnChainTxFeeLazyQueryHookResult = ReturnType<typeof useOnChainTxFeeLazyQuery>;
 export type OnChainTxFeeQueryResult = Apollo.QueryResult<OnChainTxFeeQuery, OnChainTxFeeQueryVariables>;
 export const OnChainUsdTxFeeDocument = gql`
-    query onChainUsdTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: CentAmount!, $targetConfirmations: TargetConfirmations) {
+    query onChainUsdTxFee($walletId: WalletId!, $address: OnChainAddress!, $amount: CentAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainUsdTxFee(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations
@@ -4181,6 +4187,7 @@ export const OnChainUsdTxFeeDocument = gql`
  *      address: // value for 'address'
  *      amount: // value for 'amount'
  *      targetConfirmations: // value for 'targetConfirmations'
+ *      speed: // value for 'speed'
  *   },
  * });
  */
@@ -4196,12 +4203,13 @@ export type OnChainUsdTxFeeQueryHookResult = ReturnType<typeof useOnChainUsdTxFe
 export type OnChainUsdTxFeeLazyQueryHookResult = ReturnType<typeof useOnChainUsdTxFeeLazyQuery>;
 export type OnChainUsdTxFeeQueryResult = Apollo.QueryResult<OnChainUsdTxFeeQuery, OnChainUsdTxFeeQueryVariables>;
 export const OnChainUsdTxFeeAsBtcDenominatedDocument = gql`
-    query onChainUsdTxFeeAsBtcDenominated($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations) {
+    query onChainUsdTxFeeAsBtcDenominated($walletId: WalletId!, $address: OnChainAddress!, $amount: SatAmount!, $targetConfirmations: TargetConfirmations, $speed: PayoutSpeed) {
   onChainUsdTxFeeAsBtcDenominated(
     walletId: $walletId
     address: $address
     amount: $amount
     targetConfirmations: $targetConfirmations
+    speed: $speed
   ) {
     amount
     targetConfirmations
@@ -4225,6 +4233,7 @@ export const OnChainUsdTxFeeAsBtcDenominatedDocument = gql`
  *      address: // value for 'address'
  *      amount: // value for 'amount'
  *      targetConfirmations: // value for 'targetConfirmations'
+ *      speed: // value for 'speed'
  *   },
  * });
  */

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -74,6 +74,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
           walletId: sendingWalletDescriptor.id,
           address,
           amount: settlementAmount.amount,
+          speed: "FAST",
         },
       })
 
@@ -128,6 +129,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
             walletId: sendingWalletDescriptor.id,
             address,
             amount: settlementAmount.amount,
+            speed: "FAST",
           },
         })
 
@@ -168,6 +170,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
             walletId: sendingWalletDescriptor.id,
             address,
             amount: settlementAmount.amount,
+            speed: "FAST",
           },
         })
 
@@ -304,6 +307,7 @@ export const createAmountOnchainPaymentDetails = <T extends WalletCurrency>(
           walletId: sendingWalletDescriptor.id,
           address,
           amount: settlementAmount.amount,
+          speed: "FAST",
         },
       })
 
@@ -352,6 +356,7 @@ export const createAmountOnchainPaymentDetails = <T extends WalletCurrency>(
           walletId: sendingWalletDescriptor.id,
           address,
           amount: unitOfAccountAmount.amount,
+          speed: "FAST",
         },
       })
 

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -58,6 +58,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
             address,
             amount: settlementAmount.amount,
             memo,
+            speed: "FAST",
           },
         },
       })
@@ -113,6 +114,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
               walletId: sendingWalletDescriptor.id,
               address,
               amount: settlementAmount.amount,
+              speed: "FAST",
             },
           },
         })
@@ -154,6 +156,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
               walletId: sendingWalletDescriptor.id,
               address,
               amount: settlementAmount.amount,
+              speed: "FAST",
             },
           },
         })
@@ -291,6 +294,7 @@ export const createAmountOnchainPaymentDetails = <T extends WalletCurrency>(
             address,
             amount: settlementAmount.amount,
             memo,
+            speed: "FAST",
           },
         },
       })

--- a/app/screens/send-bitcoin-screen/use-fee.ts
+++ b/app/screens/send-bitcoin-screen/use-fee.ts
@@ -70,12 +70,14 @@ gql`
     $address: OnChainAddress!
     $amount: SatAmount!
     $targetConfirmations: TargetConfirmations
+    $speed: PayoutSpeed
   ) {
     onChainTxFee(
       walletId: $walletId
       address: $address
       amount: $amount
       targetConfirmations: $targetConfirmations
+      speed: $speed
     ) {
       amount
       targetConfirmations
@@ -87,12 +89,14 @@ gql`
     $address: OnChainAddress!
     $amount: CentAmount!
     $targetConfirmations: TargetConfirmations
+    $speed: PayoutSpeed
   ) {
     onChainUsdTxFee(
       walletId: $walletId
       address: $address
       amount: $amount
       targetConfirmations: $targetConfirmations
+      speed: $speed
     ) {
       amount
       targetConfirmations
@@ -104,12 +108,14 @@ gql`
     $address: OnChainAddress!
     $amount: SatAmount!
     $targetConfirmations: TargetConfirmations
+    $speed: PayoutSpeed
   ) {
     onChainUsdTxFeeAsBtcDenominated(
       walletId: $walletId
       address: $address
       amount: $amount
       targetConfirmations: $targetConfirmations
+      speed: $speed
     ) {
       amount
       targetConfirmations

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -278,19 +278,23 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
           initiationVia.__typename === "InitiationViaLn" && (
             <Row entry="Hash" value={initiationVia.paymentHash} />
           )}
-        {settlementVia.__typename === "SettlementViaOnChain" && (
-          <TouchableWithoutFeedback
-            onPress={() => viewInExplorer(settlementVia.transactionHash)}
-          >
-            <View>
-              <Row
-                entry="Hash"
-                value={settlementVia.transactionHash}
-                __typename={settlementVia.__typename}
-              />
-            </View>
-          </TouchableWithoutFeedback>
-        )}
+        {settlementVia.__typename === "SettlementViaOnChain" &&
+          settlementVia.transactionHash !== null && (
+            <TouchableWithoutFeedback
+              onPress={() =>
+                settlementVia.transactionHash &&
+                viewInExplorer(settlementVia.transactionHash)
+              }
+            >
+              <View>
+                <Row
+                  entry="Hash"
+                  value={settlementVia.transactionHash}
+                  __typename={settlementVia.__typename}
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          )}
         {id && <Row entry="id" value={id} />}
       </View>
     </Screen>

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,5 +1,5 @@
 overwrite: true
-schema: "https://raw.githubusercontent.com/GaloyMoney/galoy/main/src/graphql/main/schema.graphql"
+schema: "https://raw.githubusercontent.com/GaloyMoney/galoy/add-bria-payouts/src/graphql/main/schema.graphql"
 documents:
   - "app/**/*.ts"
   - "app/**/*.tsx"
@@ -48,3 +48,4 @@ generates:
         DisplayCurrency: "string"
         SignedDisplayMajorAmount: "string"
         CountryCode: "string"
+        PayoutRequestId: "string"


### PR DESCRIPTION
Adds `PayoutSpeed` to fee and payment send mutation/queries.
The API is backwards compatible - these are optional fields.