### PR TITLE
feat: handle onchain transaction hash null for pending unbroadcast state

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -679,6 +679,7 @@ const en: BaseTranslation = {
     spent: "You spent",
     receivingAccount: "Receiving Account",
     sendingAccount: "Sending Account",
+    txNotBroadcast: "Your transaction is currently pending and will be broadcasted to the Bitcoin network in a moment."
   },
   TransactionLimitsScreen: {
     receive: "Receive",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2274,6 +2274,10 @@ type RootTranslation = {
 		 * S​e​n​d​i​n​g​ ​A​c​c​o​u​n​t
 		 */
 		sendingAccount: string
+		/**
+		 * Y​o​u​r​ ​t​r​a​n​s​a​c​t​i​o​n​ ​i​s​ ​c​u​r​r​e​n​t​l​y​ ​p​e​n​d​i​n​g​ ​a​n​d​ ​w​i​l​l​ ​b​e​ ​b​r​o​a​d​c​a​s​t​e​d​ ​t​o​ ​t​h​e​ ​B​i​t​c​o​i​n​ ​n​e​t​w​o​r​k​ ​i​n​ ​a​ ​m​o​m​e​n​t​.
+		 */
+		txNotBroadcast: string
 	}
 	TransactionLimitsScreen: {
 		/**
@@ -5307,6 +5311,10 @@ export type TranslationFunctions = {
 		 * Sending Account
 		 */
 		sendingAccount: () => LocalizedString
+		/**
+		 * Your transaction is currently pending and will be broadcasted to the Bitcoin network in a moment.
+		 */
+		txNotBroadcast: () => LocalizedString
 	}
 	TransactionLimitsScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -664,7 +664,8 @@
         "received": "You received",
         "spent": "You spent",
         "receivingAccount": "Receiving Account",
-        "sendingAccount": "Sending Account"
+        "sendingAccount": "Sending Account",
+        "txNotBroadcast": "Your transaction is currently pending and will be broadcasted to the Bitcoin network in a moment."
     },
     "TransactionLimitsScreen": {
         "receive": "Receive",

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -27,56 +27,7 @@ import { useAppConfig } from "@app/hooks"
 import { makeStyles, Text, useTheme } from "@rneui/themed"
 import { toWalletAmount } from "@app/types/amounts"
 import { isIos } from "@app/utils/helper"
-
-const useStyles = makeStyles(({ colors }) => ({
-  closeIconContainer: {
-    flexDirection: "row",
-    justifyContent: "flex-end",
-    paddingRight: 10,
-  },
-
-  amountText: {
-    fontSize: 18,
-    marginVertical: 6,
-  },
-
-  amountDetailsContainer: {
-    paddingTop: isIos ? 36 : 0,
-  },
-
-  amountView: {
-    alignItems: "center",
-    justifyContent: "center",
-    transform: [{ translateY: -12 }],
-  },
-
-  description: {
-    marginBottom: 6,
-  },
-
-  entry: {
-    marginBottom: 6,
-  },
-
-  transactionDetailView: {
-    marginHorizontal: 24,
-    marginVertical: 12,
-  },
-  valueContainer: {
-    flexDirection: "row",
-    height: 50,
-    backgroundColor: colors.grey5,
-    alignItems: "center",
-    borderRadius: 8,
-  },
-  value: {
-    marginLeft: 10,
-    alignItems: "center",
-    justifyContent: "center",
-    fontSize: 14,
-    fontWeight: "bold",
-  },
-}))
+import { GaloyInfo } from "@app/components/atomic/galoy-info"
 
 const Row = ({
   entry,
@@ -256,6 +207,12 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
       </View>
 
       <View style={styles.transactionDetailView}>
+        {settlementVia.__typename === "SettlementViaOnChain" &&
+          settlementVia.transactionHash === null && (
+            <View style={styles.txNotBroadcast}>
+              <GaloyInfo>{LL.TransactionDetailScreen.txNotBroadcast()}</GaloyInfo>
+            </View>
+          )}
         <Row
           entry={
             isReceive
@@ -297,3 +254,56 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
     </Screen>
   )
 }
+
+const useStyles = makeStyles(({ colors }) => ({
+  closeIconContainer: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    paddingRight: 10,
+  },
+
+  amountText: {
+    fontSize: 18,
+    marginVertical: 6,
+  },
+
+  amountDetailsContainer: {
+    paddingTop: isIos ? 36 : 0,
+  },
+
+  amountView: {
+    alignItems: "center",
+    justifyContent: "center",
+    transform: [{ translateY: -12 }],
+  },
+
+  description: {
+    marginBottom: 6,
+  },
+
+  entry: {
+    marginBottom: 6,
+  },
+
+  transactionDetailView: {
+    marginHorizontal: 24,
+    marginVertical: 12,
+  },
+  valueContainer: {
+    flexDirection: "row",
+    height: 50,
+    backgroundColor: colors.grey5,
+    alignItems: "center",
+    borderRadius: 8,
+  },
+  value: {
+    marginLeft: 10,
+    alignItems: "center",
+    justifyContent: "center",
+    fontSize: 14,
+    fontWeight: "bold",
+  },
+  txNotBroadcast: {
+    marginBottom: 16,
+  },
+}))

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -278,21 +278,20 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
           initiationVia.__typename === "InitiationViaLn" && (
             <Row entry="Hash" value={initiationVia.paymentHash} />
           )}
-        {settlementVia.__typename === "SettlementViaOnChain" && (
-          // FIXME settlementVia.transactionHash is a dummy value following the use of Bria
-          <TouchableWithoutFeedback
-            onPress={() => viewInExplorer(settlementVia.transactionHash || "")}
-          >
-            <View>
-              <Row
-                entry="Hash"
-                // FIXME settlementVia.transactionHash is a dummy value following the use of Bria
-                value={settlementVia.transactionHash || ""}
-                __typename={settlementVia.__typename}
-              />
-            </View>
-          </TouchableWithoutFeedback>
-        )}
+        {settlementVia.__typename === "SettlementViaOnChain" &&
+          settlementVia.transactionHash !== null && (
+            <TouchableWithoutFeedback
+              onPress={() => viewInExplorer(settlementVia.transactionHash || "")}
+            >
+              <View>
+                <Row
+                  entry="Hash"
+                  value={settlementVia.transactionHash || ""}
+                  __typename={settlementVia.__typename}
+                />
+              </View>
+            </TouchableWithoutFeedback>
+          )}
         {id && <Row entry="id" value={id} />}
       </View>
     </Screen>

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -154,6 +154,13 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
     }),
   })
 
+  const onChainTxBroadcasted =
+    settlementVia.__typename === "SettlementViaOnChain" &&
+    settlementVia.transactionHash !== null
+  const onChainTxNotBroadcasted =
+    settlementVia.__typename === "SettlementViaOnChain" &&
+    settlementVia.transactionHash === null
+
   // only show a secondary amount if it is in a different currency than the primary amount
   const formattedSecondaryFeeAmount =
     tx.settlementDisplayCurrency === tx.settlementCurrency
@@ -207,12 +214,11 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
       </View>
 
       <View style={styles.transactionDetailView}>
-        {settlementVia.__typename === "SettlementViaOnChain" &&
-          settlementVia.transactionHash === null && (
-            <View style={styles.txNotBroadcast}>
-              <GaloyInfo>{LL.TransactionDetailScreen.txNotBroadcast()}</GaloyInfo>
-            </View>
-          )}
+        {onChainTxNotBroadcasted && (
+          <View style={styles.txNotBroadcast}>
+            <GaloyInfo>{LL.TransactionDetailScreen.txNotBroadcast()}</GaloyInfo>
+          </View>
+        )}
         <Row
           entry={
             isReceive
@@ -235,20 +241,19 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
           initiationVia.__typename === "InitiationViaLn" && (
             <Row entry="Hash" value={initiationVia.paymentHash} />
           )}
-        {settlementVia.__typename === "SettlementViaOnChain" &&
-          settlementVia.transactionHash !== null && (
-            <TouchableWithoutFeedback
-              onPress={() => viewInExplorer(settlementVia.transactionHash || "")}
-            >
-              <View>
-                <Row
-                  entry="Hash"
-                  value={settlementVia.transactionHash || ""}
-                  __typename={settlementVia.__typename}
-                />
-              </View>
-            </TouchableWithoutFeedback>
-          )}
+        {onChainTxBroadcasted && (
+          <TouchableWithoutFeedback
+            onPress={() => viewInExplorer(settlementVia.transactionHash || "")}
+          >
+            <View>
+              <Row
+                entry="Hash"
+                value={settlementVia.transactionHash || ""}
+                __typename={settlementVia.__typename}
+              />
+            </View>
+          </TouchableWithoutFeedback>
+        )}
         {id && <Row entry="id" value={id} />}
       </View>
     </Screen>


### PR DESCRIPTION
This is how the screen will look when an Onchain Transaction returns `null` transactionHash

<img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/4f55f12d-55bf-4d40-b6b4-7b4eb0f43df5" width="300" />

