### PR TITLE
ci: don't submit for review automatically

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -94,7 +94,7 @@ platform :ios do
       build_number: ENV["BUILD_NUMBER"],
 
       force: true, # dont verify the upload via an HTML file
-      submit_for_review: true,
+      submit_for_review: false,
       automatic_release: true,
       phased_release: true,
 


### PR DESCRIPTION
So that we can upload screenshots or change descriptions and stuff before finalizing and pushing for review,