### PR TITLE
feat: send all onchain

### DIFF
--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -132,6 +132,7 @@ export const createSendPaymentMocks = (): SendPaymentMutationParams => {
     lnNoAmountUsdInvoicePaymentSend: jest.fn(),
     onChainPaymentSend: jest.fn(),
     onChainUsdPaymentSend: jest.fn(),
+    onChainPaymentSendAll: jest.fn(),
     onChainUsdPaymentSendAsBtcDenominated: jest.fn(),
     intraLedgerPaymentSend: jest.fn(),
     intraLedgerUsdPaymentSend: jest.fn(),

--- a/__tests__/payment-details/no-amount-onchain.spec.ts
+++ b/__tests__/payment-details/no-amount-onchain.spec.ts
@@ -22,6 +22,7 @@ const defaultParams: PaymentDetails.CreateNoAmountOnchainPaymentDetailsParams<Wa
     convertMoneyAmount: convertMoneyAmountMock,
     sendingWalletDescriptor: btcSendingWalletDescriptor,
     unitOfAccountAmount: testAmount,
+    sendAll: false,
   }
 
 const spy = jest.spyOn(PaymentDetails, "createNoAmountOnchainPaymentDetails")

--- a/__tests__/payment-details/no-amount-onchain.spec.ts
+++ b/__tests__/payment-details/no-amount-onchain.spec.ts
@@ -22,7 +22,7 @@ const defaultParams: PaymentDetails.CreateNoAmountOnchainPaymentDetailsParams<Wa
     convertMoneyAmount: convertMoneyAmountMock,
     sendingWalletDescriptor: btcSendingWalletDescriptor,
     unitOfAccountAmount: testAmount,
-    sendAll: false,
+    isSendingMax: false,
   }
 
 const spy = jest.spyOn(PaymentDetails, "createNoAmountOnchainPaymentDetails")

--- a/app/components/amount-input/amount-input.tsx
+++ b/app/components/amount-input/amount-input.tsx
@@ -21,7 +21,7 @@ export type AmountInputProps = {
   maxAmount?: MoneyAmount<WalletOrDisplayCurrency>
   minAmount?: MoneyAmount<WalletOrDisplayCurrency>
   canSetAmount?: boolean
-  sendAll?: boolean
+  isSendingMax?: boolean
 }
 
 export const AmountInput: React.FC<AmountInputProps> = ({
@@ -32,7 +32,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   minAmount,
   convertMoneyAmount,
   canSetAmount = true,
-  sendAll = false,
+  isSendingMax = false,
 }) => {
   const [isSettingAmount, setIsSettingAmount] = React.useState(false)
   const { formatMoneyAmount, getSecondaryAmountIfCurrencyIsDifferent } =
@@ -94,7 +94,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
       })
   }
 
-  if (sendAll && formattedPrimaryAmount)
+  if (isSendingMax && formattedPrimaryAmount)
     formattedPrimaryAmount = `~ ${formattedPrimaryAmount} (${LL.SendBitcoinScreen.max()})`
 
   const onPressInputButton = () => {

--- a/app/components/amount-input/amount-input.tsx
+++ b/app/components/amount-input/amount-input.tsx
@@ -95,7 +95,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   }
 
   if (sendAll && formattedPrimaryAmount)
-    formattedPrimaryAmount = `~ ${formattedPrimaryAmount} (Max)`
+    formattedPrimaryAmount = `~ ${formattedPrimaryAmount} (${LL.SendBitcoinScreen.max()})`
 
   const onPressInputButton = () => {
     setIsSettingAmount(true)

--- a/app/components/amount-input/amount-input.tsx
+++ b/app/components/amount-input/amount-input.tsx
@@ -21,6 +21,7 @@ export type AmountInputProps = {
   maxAmount?: MoneyAmount<WalletOrDisplayCurrency>
   minAmount?: MoneyAmount<WalletOrDisplayCurrency>
   canSetAmount?: boolean
+  sendAll?: boolean
 }
 
 export const AmountInput: React.FC<AmountInputProps> = ({
@@ -31,6 +32,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   minAmount,
   convertMoneyAmount,
   canSetAmount = true,
+  sendAll = false,
 }) => {
   const [isSettingAmount, setIsSettingAmount] = React.useState(false)
   const { formatMoneyAmount, getSecondaryAmountIfCurrencyIsDifferent } =
@@ -91,6 +93,9 @@ export const AmountInput: React.FC<AmountInputProps> = ({
           secondaryAmount.currency === WalletCurrency.Usd,
       })
   }
+
+  if (sendAll && formattedPrimaryAmount)
+    formattedPrimaryAmount = `~ ${formattedPrimaryAmount} (Max)`
 
   const onPressInputButton = () => {
     setIsSettingAmount(true)

--- a/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
+++ b/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
@@ -101,7 +101,7 @@ const useStyles = makeStyles((_, props: GaloyTertiaryButtonProps) => ({
 
   pressableStyle: {
     paddingHorizontal: props.clear ? 0 : 16,
-    paddingVertical: props.clear ? 2 : 4,
+    paddingVertical: props.clear ? 0 : 4,
     borderRadius: 50,
   },
 }))

--- a/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
+++ b/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
@@ -59,18 +59,9 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
     return [dynamicStyle, containerStyle, styles.pressableStyle]
   }
 
-  let textColor
-
-  switch (true) {
-    case outline:
-      textColor = colors.black
-      break
-    case clear:
-      textColor = colors.primary
-      break
-    default:
-      textColor = colors.white
-  }
+  let textColor = colors.white
+  if (outline) textColor = colors.black
+  if (clear) textColor = colors.primary
 
   return (
     <Pressable {...remainingProps} style={pressableStyle} disabled={disabled}>

--- a/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
+++ b/app/components/atomic/galoy-tertiary-button/galoy-tertiary-button.tsx
@@ -4,17 +4,19 @@ import { Pressable, PressableProps, StyleProp, View, ViewStyle } from "react-nat
 
 export type GaloyTertiaryButtonProps = {
   outline?: boolean
+  clear?: boolean
   containerStyle?: StyleProp<ViewStyle>
   title: string
   icon?: JSX.Element
 } & PressableProps
 
 export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
-  const { outline, containerStyle, disabled, icon, ...remainingProps } = props
+  const { outline, clear, containerStyle, disabled, icon, ...remainingProps } = props
   const styles = useStyles(props)
   const {
     theme: { colors },
   } = useTheme()
+
   const pressableStyle = ({ pressed }: { pressed: boolean }): StyleProp<ViewStyle> => {
     let dynamicStyle
     switch (true) {
@@ -25,9 +27,14 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
           borderWidth: 1.5,
         }
         break
-      case pressed && !outline:
+      case pressed && !outline && !clear:
         dynamicStyle = {
           backgroundColor: colors.primary,
+        }
+        break
+      case pressed && clear:
+        dynamicStyle = {
+          opacity: 0.7,
         }
         break
       case outline:
@@ -38,28 +45,37 @@ export const GaloyTertiaryButton = (props: GaloyTertiaryButtonProps) => {
           borderWidth: 1.5,
         }
         break
+      case clear:
+        dynamicStyle = {
+          backgroundColor: colors.transparent,
+        }
+        break
       default:
         dynamicStyle = {
           backgroundColor: colors.primary3,
         }
     }
 
-    const sizingStyle = {
-      paddingHorizontal: 16,
-      paddingVertical: 4,
-      borderRadius: 50,
-    }
+    return [dynamicStyle, containerStyle, styles.pressableStyle]
+  }
 
-    return [sizingStyle, dynamicStyle, containerStyle]
+  let textColor
+
+  switch (true) {
+    case outline:
+      textColor = colors.black
+      break
+    case clear:
+      textColor = colors.primary
+      break
+    default:
+      textColor = colors.white
   }
 
   return (
     <Pressable {...remainingProps} style={pressableStyle} disabled={disabled}>
       <View style={styles.container}>
-        <Text
-          color={outline ? colors.black : colors.white}
-          style={styles.buttonTitleStyle}
-        >
+        <Text color={textColor} style={styles.buttonTitleStyle}>
           {props.title}
         </Text>
         {icon ? icon : null}
@@ -79,7 +95,13 @@ const useStyles = makeStyles((_, props: GaloyTertiaryButtonProps) => ({
     lineHeight: 20,
     textAlign: "center",
     fontSize: 14,
-    fontWeight: "600",
+    fontWeight: props.clear ? "bold" : "600",
     opacity: props.disabled ? 0.7 : 1,
+  },
+
+  pressableStyle: {
+    paddingHorizontal: props.clear ? 0 : 16,
+    paddingVertical: props.clear ? 2 : 4,
+    borderRadius: 50,
   },
 }))

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -333,6 +333,17 @@ mutation onChainPaymentSend($input: OnChainPaymentSendInput!) {
   }
 }
 
+mutation onChainPaymentSendAll($input: OnChainPaymentSendAllInput!) {
+  onChainPaymentSendAll(input: $input) {
+    errors {
+      message
+      __typename
+    }
+    status
+    __typename
+  }
+}
+
 mutation onChainUsdPaymentSend($input: OnChainUsdPaymentSendInput!) {
   onChainUsdPaymentSend(input: $input) {
     errors {

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -1886,6 +1886,13 @@ export type OnChainPaymentSendMutationVariables = Exact<{
 
 export type OnChainPaymentSendMutation = { readonly __typename: 'Mutation', readonly onChainPaymentSend: { readonly __typename: 'PaymentSendPayload', readonly status?: PaymentSendResult | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }> } };
 
+export type OnChainPaymentSendAllMutationVariables = Exact<{
+  input: OnChainPaymentSendAllInput;
+}>;
+
+
+export type OnChainPaymentSendAllMutation = { readonly __typename: 'Mutation', readonly onChainPaymentSendAll: { readonly __typename: 'PaymentSendPayload', readonly status?: PaymentSendResult | null, readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }> } };
+
 export type OnChainUsdPaymentSendMutationVariables = Exact<{
   input: OnChainUsdPaymentSendInput;
 }>;
@@ -4403,6 +4410,42 @@ export function useOnChainPaymentSendMutation(baseOptions?: Apollo.MutationHookO
 export type OnChainPaymentSendMutationHookResult = ReturnType<typeof useOnChainPaymentSendMutation>;
 export type OnChainPaymentSendMutationResult = Apollo.MutationResult<OnChainPaymentSendMutation>;
 export type OnChainPaymentSendMutationOptions = Apollo.BaseMutationOptions<OnChainPaymentSendMutation, OnChainPaymentSendMutationVariables>;
+export const OnChainPaymentSendAllDocument = gql`
+    mutation onChainPaymentSendAll($input: OnChainPaymentSendAllInput!) {
+  onChainPaymentSendAll(input: $input) {
+    errors {
+      message
+    }
+    status
+  }
+}
+    `;
+export type OnChainPaymentSendAllMutationFn = Apollo.MutationFunction<OnChainPaymentSendAllMutation, OnChainPaymentSendAllMutationVariables>;
+
+/**
+ * __useOnChainPaymentSendAllMutation__
+ *
+ * To run a mutation, you first call `useOnChainPaymentSendAllMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useOnChainPaymentSendAllMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [onChainPaymentSendAllMutation, { data, loading, error }] = useOnChainPaymentSendAllMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useOnChainPaymentSendAllMutation(baseOptions?: Apollo.MutationHookOptions<OnChainPaymentSendAllMutation, OnChainPaymentSendAllMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<OnChainPaymentSendAllMutation, OnChainPaymentSendAllMutationVariables>(OnChainPaymentSendAllDocument, options);
+      }
+export type OnChainPaymentSendAllMutationHookResult = ReturnType<typeof useOnChainPaymentSendAllMutation>;
+export type OnChainPaymentSendAllMutationResult = Apollo.MutationResult<OnChainPaymentSendAllMutation>;
+export type OnChainPaymentSendAllMutationOptions = Apollo.BaseMutationOptions<OnChainPaymentSendAllMutation, OnChainPaymentSendAllMutationVariables>;
 export const OnChainUsdPaymentSendDocument = gql`
     mutation onChainUsdPaymentSend($input: OnChainUsdPaymentSendInput!) {
   onChainUsdPaymentSend(input: $input) {

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -600,12 +600,12 @@ const en: BaseTranslation = {
     feeCalculationUnsuccessful: "Calculation unsuccessful ⚠️",
     input: "Username, invoice, or address",
     invalidUsername: "Invalid username",
-    noAmount:
-      "This invoice doesn't have an amount, so you need to manually specify how much money you want to send",
-    notConfirmed:
-      "Payment has been sent\nbut is not confirmed yet\n\nYou can check the status\nof the payment in Transactions",
+    noAmount: "This invoice doesn't have an amount, so you need to manually specify how much money you want to send",
+    notConfirmed: "Payment has been sent\nbut is not confirmed yet\n\nYou can check the status\nof the payment in Transactions",
     note: "Note or label",
     success: "Payment has been sent successfully",
+    max: "Max",
+    maxAmount: "Max Amount",
     title: "Send Bitcoin",
     failedToFetchLnurlInvoice: "Failed to fetch lnurl invoice",
     lnurlInvoiceIncorrectAmount: "The lnurl server responded with an invoice with an incorrect amount.",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2032,6 +2032,14 @@ type RootTranslation = {
 		 */
 		success: string
 		/**
+		 * M​a​x
+		 */
+		max: string
+		/**
+		 * M​a​x​ ​A​m​o​u​n​t
+		 */
+		maxAmount: string
+		/**
 		 * S​e​n​d​ ​B​i​t​c​o​i​n
 		 */
 		title: string
@@ -5072,6 +5080,14 @@ export type TranslationFunctions = {
 		 * Payment has been sent successfully
 		 */
 		success: () => LocalizedString
+		/**
+		 * Max
+		 */
+		max: () => LocalizedString
+		/**
+		 * Max Amount
+		 */
+		maxAmount: () => LocalizedString
 		/**
 		 * Send Bitcoin
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -595,6 +595,8 @@
         "notConfirmed": "Payment has been sent\nbut is not confirmed yet\n\nYou can check the status\nof the payment in Transactions",
         "note": "Note or label",
         "success": "Payment has been sent successfully",
+        "max": "Max",
+        "maxAmount": "Max Amount",
         "title": "Send Bitcoin",
         "failedToFetchLnurlInvoice": "Failed to fetch lnurl invoice",
         "lnurlInvoiceIncorrectAmount": "The lnurl server responded with an invoice with an incorrect amount.",

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -59,7 +59,9 @@ export type GetFeeParams = {
   >["0"]
 }
 
-export type GetFee<T extends WalletCurrency> = (getFeeFns: GetFeeParams) => Promise<{
+export type GetFee<T extends WalletCurrency> = (
+  getFeeFns: GetFeeParams,
+) => Promise<{
   amount?: WalletAmount<T> | null | undefined
   errors?: readonly GraphQlApplicationError[]
 }>
@@ -107,7 +109,7 @@ type BasePaymentDetail<T extends WalletCurrency> = {
   setConvertMoneyAmount: (convertMoneyAmount: ConvertMoneyAmount) => PaymentDetail<T>
   setSendingWalletDescriptor: SetSendingWalletDescriptor<T>
   sendAll?: boolean
-  setSendAll?: () => PaymentDetail<T>
+  setSendAll?: (sendAll: boolean) => PaymentDetail<T>
   setMemo?: SetMemo<T>
   canSetMemo: boolean
   setAmount?: SetAmount<T>
@@ -187,15 +189,14 @@ export const AmountInvalidReason = {
   NoAmount: "NoAmount",
 } as const
 
-export type AmountInvalidReason =
-  (typeof AmountInvalidReason)[keyof typeof AmountInvalidReason]
+export type AmountInvalidReason = typeof AmountInvalidReason[keyof typeof AmountInvalidReason]
 
 export const LimitType = {
   Withdrawal: "withdrawal",
   Intraledger: "Intraledger",
 } as const
 
-export type LimitType = (typeof LimitType)[keyof typeof LimitType]
+export type LimitType = typeof LimitType[keyof typeof LimitType]
 
 export type AmountStatus =
   | {

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -87,6 +87,7 @@ export type SendPaymentMutation = (
 
 export type SetAmount<T extends WalletCurrency> = (
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>,
+  all?: boolean,
 ) => PaymentDetail<T>
 
 export type SetMemo<T extends WalletCurrency> = (memo: string) => PaymentDetail<T>
@@ -109,7 +110,6 @@ type BasePaymentDetail<T extends WalletCurrency> = {
   setConvertMoneyAmount: (convertMoneyAmount: ConvertMoneyAmount) => PaymentDetail<T>
   setSendingWalletDescriptor: SetSendingWalletDescriptor<T>
   sendAll?: boolean
-  setSendAll?: (sendAll: boolean) => PaymentDetail<T>
   setMemo?: SetMemo<T>
   canSetMemo: boolean
   setAmount?: SetAmount<T>

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -59,9 +59,7 @@ export type GetFeeParams = {
   >["0"]
 }
 
-export type GetFee<T extends WalletCurrency> = (
-  getFeeFns: GetFeeParams,
-) => Promise<{
+export type GetFee<T extends WalletCurrency> = (getFeeFns: GetFeeParams) => Promise<{
   amount?: WalletAmount<T> | null | undefined
   errors?: readonly GraphQlApplicationError[]
 }>
@@ -189,14 +187,15 @@ export const AmountInvalidReason = {
   NoAmount: "NoAmount",
 } as const
 
-export type AmountInvalidReason = typeof AmountInvalidReason[keyof typeof AmountInvalidReason]
+export type AmountInvalidReason =
+  (typeof AmountInvalidReason)[keyof typeof AmountInvalidReason]
 
 export const LimitType = {
   Withdrawal: "withdrawal",
   Intraledger: "Intraledger",
 } as const
 
-export type LimitType = typeof LimitType[keyof typeof LimitType]
+export type LimitType = (typeof LimitType)[keyof typeof LimitType]
 
 export type AmountStatus =
   | {

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -106,6 +106,8 @@ type BasePaymentDetail<T extends WalletCurrency> = {
   convertMoneyAmount: ConvertMoneyAmount
   setConvertMoneyAmount: (convertMoneyAmount: ConvertMoneyAmount) => PaymentDetail<T>
   setSendingWalletDescriptor: SetSendingWalletDescriptor<T>
+  sendAll?: boolean
+  setSendAll?: () => PaymentDetail<T>
   setMemo?: SetMemo<T>
   canSetMemo: boolean
   setAmount?: SetAmount<T>

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -6,6 +6,7 @@ import {
   LnNoAmountInvoicePaymentSendMutationHookResult,
   LnNoAmountUsdInvoicePaymentSendMutationHookResult,
   OnChainPaymentSendMutationHookResult,
+  OnChainPaymentSendAllMutationHookResult,
   OnChainUsdPaymentSendAsBtcDenominatedMutationHookResult,
   OnChainUsdPaymentSendMutationHookResult,
   PaymentSendResult,
@@ -68,6 +69,7 @@ export type SendPaymentMutationParams = {
   lnNoAmountInvoicePaymentSend: LnNoAmountInvoicePaymentSendMutationHookResult["0"]
   lnNoAmountUsdInvoicePaymentSend: LnNoAmountUsdInvoicePaymentSendMutationHookResult["0"]
   onChainPaymentSend: OnChainPaymentSendMutationHookResult["0"]
+  onChainPaymentSendAll: OnChainPaymentSendAllMutationHookResult["0"]
   onChainUsdPaymentSend: OnChainUsdPaymentSendMutationHookResult["0"]
   onChainUsdPaymentSendAsBtcDenominated: OnChainUsdPaymentSendAsBtcDenominatedMutationHookResult["0"]
   intraLedgerPaymentSend: IntraLedgerPaymentSendMutationHookResult["0"]

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -85,7 +85,7 @@ export type SendPaymentMutation = (
 
 export type SetAmount<T extends WalletCurrency> = (
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>,
-  all?: boolean,
+  sendMax?: boolean,
 ) => PaymentDetail<T>
 
 export type SetMemo<T extends WalletCurrency> = (memo: string) => PaymentDetail<T>
@@ -107,7 +107,8 @@ type BasePaymentDetail<T extends WalletCurrency> = {
   convertMoneyAmount: ConvertMoneyAmount
   setConvertMoneyAmount: (convertMoneyAmount: ConvertMoneyAmount) => PaymentDetail<T>
   setSendingWalletDescriptor: SetSendingWalletDescriptor<T>
-  sendAll?: boolean
+  canSendMax?: boolean
+  isSendingMax?: boolean
   setMemo?: SetMemo<T>
   canSetMemo: boolean
   setAmount?: SetAmount<T>

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -408,10 +408,10 @@ export const createLnurlPaymentDetails = <T extends WalletCurrency>(
     settlementAmount = amountLightningPaymentDetails.settlementAmount
     if (amountLightningPaymentDetails.canSendPayment) {
       sendPaymentAndGetFee = {
-        canGetFee: true,
         canSendPayment: true,
-        getFee: amountLightningPaymentDetails.getFee,
         sendPaymentMutation: amountLightningPaymentDetails.sendPaymentMutation,
+        canGetFee: true,
+        getFee: amountLightningPaymentDetails.getFee,
       }
     }
   } else {

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -227,16 +227,13 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     }
   }
 
-  const setSendAll = (sendAll: boolean) => {
+  const setAmount: SetAmount<T> | undefined = (
+    newUnitOfAccountAmount,
+    sendAll = false,
+  ) => {
     return createNoAmountOnchainPaymentDetails({
       ...params,
       sendAll,
-    })
-  }
-
-  const setAmount: SetAmount<T> | undefined = (newUnitOfAccountAmount) => {
-    return createNoAmountOnchainPaymentDetails({
-      ...params,
       unitOfAccountAmount: newUnitOfAccountAmount,
     })
   }
@@ -284,7 +281,6 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     canSetAmount: true,
     ...sendPaymentAndGetFee,
     sendAll: Boolean(sendAll),
-    setSendAll,
   } as const
 }
 

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -20,7 +20,7 @@ import {
 
 export type CreateNoAmountOnchainPaymentDetailsParams<T extends WalletCurrency> = {
   address: string
-  sendAll?: boolean
+  isSendingMax?: boolean
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
 } & BaseCreatePaymentDetailsParams<T>
 
@@ -33,7 +33,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     destinationSpecifiedMemo,
     unitOfAccountAmount,
     senderSpecifiedMemo,
-    sendAll,
+    isSendingMax,
     address,
   } = params
 
@@ -48,7 +48,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     canGetFee: false,
   }
 
-  if (sendAll) {
+  if (isSendingMax) {
     const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
       const { data } = await paymentMutations.onChainPaymentSendAll({
         variables: {
@@ -229,11 +229,11 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
 
   const setAmount: SetAmount<T> | undefined = (
     newUnitOfAccountAmount,
-    sendAll = false,
+    sendMax = false,
   ) => {
     return createNoAmountOnchainPaymentDetails({
       ...params,
-      sendAll,
+      isSendingMax: sendMax,
       unitOfAccountAmount: newUnitOfAccountAmount,
     })
   }
@@ -280,7 +280,8 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     setAmount,
     canSetAmount: true,
     ...sendPaymentAndGetFee,
-    sendAll: Boolean(sendAll),
+    canSendMax: true,
+    isSendingMax,
   } as const
 }
 

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -227,10 +227,10 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     }
   }
 
-  const setSendAll = () => {
+  const setSendAll = (sendAll: boolean) => {
     return createNoAmountOnchainPaymentDetails({
       ...params,
-      sendAll: true,
+      sendAll,
     })
   }
 

--- a/app/screens/send-bitcoin-screen/payment-details/onchain.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/onchain.ts
@@ -20,6 +20,7 @@ import {
 
 export type CreateNoAmountOnchainPaymentDetailsParams<T extends WalletCurrency> = {
   address: string
+  sendAll?: boolean
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
 } & BaseCreatePaymentDetailsParams<T>
 
@@ -32,6 +33,7 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     destinationSpecifiedMemo,
     unitOfAccountAmount,
     senderSpecifiedMemo,
+    sendAll,
     address,
   } = params
 
@@ -46,7 +48,38 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     canGetFee: false,
   }
 
-  if (
+  if (sendAll) {
+    const sendPaymentMutation: SendPaymentMutation = async (paymentMutations) => {
+      const { data } = await paymentMutations.onChainPaymentSendAll({
+        variables: {
+          input: {
+            walletId: sendingWalletDescriptor.id,
+            address,
+            memo,
+          },
+        },
+      })
+
+      return {
+        status: data?.onChainPaymentSendAll.status,
+        errors: data?.onChainPaymentSendAll.errors,
+      }
+    }
+
+    // fee will be calculated dynamically by backend
+    const getFee: GetFee<T> = async () => {
+      return {
+        amount: null,
+      }
+    }
+
+    sendPaymentAndGetFee = {
+      canSendPayment: true,
+      canGetFee: true,
+      sendPaymentMutation,
+      getFee,
+    }
+  } else if (
     settlementAmount.amount &&
     sendingWalletDescriptor.currency === WalletCurrency.Btc
   ) {
@@ -194,6 +227,13 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     }
   }
 
+  const setSendAll = () => {
+    return createNoAmountOnchainPaymentDetails({
+      ...params,
+      sendAll: true,
+    })
+  }
+
   const setAmount: SetAmount<T> | undefined = (newUnitOfAccountAmount) => {
     return createNoAmountOnchainPaymentDetails({
       ...params,
@@ -243,6 +283,8 @@ export const createNoAmountOnchainPaymentDetails = <T extends WalletCurrency>(
     setAmount,
     canSetAmount: true,
     ...sendPaymentAndGetFee,
+    sendAll: Boolean(sendAll),
+    setSendAll,
   } as const
 }
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -240,7 +240,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           <AmountInput
             unitOfAccountAmount={unitOfAccountAmount}
             canSetAmount={false}
-            sendAll={paymentDetail.sendAll}
+            isSendingMax={paymentDetail.isSendingMax}
             convertMoneyAmount={convertMoneyAmount}
             walletCurrency={sendingWalletDescriptor.currency}
           />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -240,6 +240,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           <AmountInput
             unitOfAccountAmount={unitOfAccountAmount}
             canSetAmount={false}
+            sendAll={paymentDetail.sendAll}
             convertMoneyAmount={convertMoneyAmount}
             walletCurrency={sendingWalletDescriptor.currency}
           />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -484,7 +484,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
         <View style={styles.fieldContainer}>
           <View style={styles.amountRightMaxField}>
             <Text style={styles.amountText}>{LL.SendBitcoinScreen.amount()}</Text>
-            {paymentDetail.paymentType === "onchain" && !paymentDetail.sendAll && (
+            {paymentDetail.canSendMax && !paymentDetail.isSendingMax && (
               <GaloyTertiaryButton
                 clear
                 title={LL.SendBitcoinScreen.maxAmount()}
@@ -499,7 +499,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
               convertMoneyAmount={paymentDetail.convertMoneyAmount}
               walletCurrency={sendingWalletDescriptor.currency}
               canSetAmount={paymentDetail.canSetAmount}
-              sendAll={paymentDetail.sendAll}
+              isSendingMax={paymentDetail.isSendingMax}
               maxAmount={lnurlParams?.max ? toBtcMoneyAmount(lnurlParams.max) : undefined}
               minAmount={lnurlParams?.min ? toBtcMoneyAmount(lnurlParams.min) : undefined}
             />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -400,13 +400,13 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
 
     if (paymentDetail.sendingWalletDescriptor.currency === WalletCurrency.Btc) {
       moneyAmount = {
-        amount: data?.me?.defaultAccount?.btcWallet?.balance!,
+        amount: data?.me?.defaultAccount?.btcWallet?.balance ?? 0,
         currency: WalletCurrency.Btc,
         currencyCode: "BTC",
       }
     } else {
       moneyAmount = {
-        amount: data?.me?.defaultAccount?.usdWallet?.balance!,
+        amount: data?.me?.defaultAccount?.usdWallet?.balance ?? 0,
         currency: WalletCurrency.Usd,
         currencyCode: "USD",
       }
@@ -484,7 +484,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
         <View style={styles.fieldContainer}>
           <View style={styles.amountRightMaxField}>
             <Text style={styles.amountText}>{LL.SendBitcoinScreen.amount()}</Text>
-            {paymentDetail.paymentType == "onchain" && !paymentDetail.sendAll && (
+            {paymentDetail.paymentType === "onchain" && !paymentDetail.sendAll && (
               <GaloyTertiaryButton clear title="Max Amount" onPress={sendAll} />
             )}
           </View>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -36,6 +36,7 @@ import { isValidAmount } from "./payment-details"
 import { PaymentDetail } from "./payment-details/index.types"
 import { SendBitcoinDetailsExtraInfo } from "./send-bitcoin-details-extra-info"
 import { requestInvoice, utils } from "lnurl-pay"
+import { GaloyTertiaryButton } from "@app/components/atomic/galoy-tertiary-button"
 
 gql`
   query sendBitcoinDetailsScreen {
@@ -457,7 +458,10 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
           {ChooseWalletModal}
         </View>
         <View style={styles.fieldContainer}>
-          <Text style={styles.fieldTitleText}>{LL.SendBitcoinScreen.amount()}</Text>
+          <View style={styles.amountRightMaxField}>
+            <Text style={styles.amountText}>{LL.SendBitcoinScreen.amount()}</Text>
+            <GaloyTertiaryButton clear title="Max Amount" />
+          </View>
           <View style={styles.currencyInputContainer}>
             <AmountInput
               unitOfAccountAmount={paymentDetail.unitOfAccountAmount}
@@ -629,5 +633,14 @@ const useStyles = makeStyles(({ colors }) => ({
   screenStyle: {
     padding: 20,
     flexGrow: 1,
+  },
+  amountText: {
+    fontWeight: "bold",
+  },
+  amountRightMaxField: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 8,
   },
 }))

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -395,6 +395,30 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
     )
   }
 
+  const sendAll = () => {
+    let moneyAmount: MoneyAmount<WalletCurrency>
+
+    if (paymentDetail.sendingWalletDescriptor.currency === WalletCurrency.Btc) {
+      moneyAmount = {
+        amount: data?.me?.defaultAccount?.btcWallet?.balance!,
+        currency: WalletCurrency.Btc,
+        currencyCode: "BTC",
+      }
+    } else {
+      moneyAmount = {
+        amount: data?.me?.defaultAccount?.usdWallet?.balance!,
+        currency: WalletCurrency.Usd,
+        currencyCode: "USD",
+      }
+    }
+
+    setPaymentDetail((paymentDetail) =>
+      paymentDetail?.setAmount
+        ? paymentDetail.setAmount(moneyAmount, true)
+        : paymentDetail,
+    )
+  }
+
   return (
     <Screen
       preset="scroll"
@@ -460,7 +484,9 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
         <View style={styles.fieldContainer}>
           <View style={styles.amountRightMaxField}>
             <Text style={styles.amountText}>{LL.SendBitcoinScreen.amount()}</Text>
-            <GaloyTertiaryButton clear title="Max Amount" />
+            {paymentDetail.paymentType == "onchain" && !paymentDetail.sendAll && (
+              <GaloyTertiaryButton clear title="Max Amount" onPress={sendAll} />
+            )}
           </View>
           <View style={styles.currencyInputContainer}>
             <AmountInput
@@ -469,6 +495,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
               convertMoneyAmount={paymentDetail.convertMoneyAmount}
               walletCurrency={sendingWalletDescriptor.currency}
               canSetAmount={paymentDetail.canSetAmount}
+              sendAll={paymentDetail.sendAll}
               maxAmount={lnurlParams?.max ? toBtcMoneyAmount(lnurlParams.max) : undefined}
               minAmount={lnurlParams?.min ? toBtcMoneyAmount(lnurlParams.min) : undefined}
             />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -485,7 +485,11 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
           <View style={styles.amountRightMaxField}>
             <Text style={styles.amountText}>{LL.SendBitcoinScreen.amount()}</Text>
             {paymentDetail.paymentType === "onchain" && !paymentDetail.sendAll && (
-              <GaloyTertiaryButton clear title="Max Amount" onPress={sendAll} />
+              <GaloyTertiaryButton
+                clear
+                title={LL.SendBitcoinScreen.maxAmount()}
+                onPress={sendAll}
+              />
             )}
           </View>
           <View style={styles.currencyInputContainer}>

--- a/app/screens/send-bitcoin-screen/use-send-payment.ts
+++ b/app/screens/send-bitcoin-screen/use-send-payment.ts
@@ -7,6 +7,7 @@ import {
   useLnNoAmountInvoicePaymentSendMutation,
   useLnNoAmountUsdInvoicePaymentSendMutation,
   useOnChainPaymentSendMutation,
+  useOnChainPaymentSendAllMutation,
   useOnChainUsdPaymentSendAsBtcDenominatedMutation,
   useOnChainUsdPaymentSendMutation,
 } from "@app/graphql/generated"
@@ -81,6 +82,15 @@ gql`
     }
   }
 
+  mutation onChainPaymentSendAll($input: OnChainPaymentSendAllInput!) {
+    onChainPaymentSendAll(input: $input) {
+      errors {
+        message
+      }
+      status
+    }
+  }
+
   mutation onChainUsdPaymentSend($input: OnChainUsdPaymentSendInput!) {
     onChainUsdPaymentSend(input: $input) {
       errors {
@@ -125,6 +135,9 @@ export const useSendPayment = (
   const [onChainPaymentSend, { loading: onChainPaymentSendLoading }] =
     useOnChainPaymentSendMutation({ refetchQueries: [HomeAuthedDocument] })
 
+  const [onChainPaymentSendAll, { loading: onChainPaymentSendAllLoading }] =
+    useOnChainPaymentSendAllMutation({ refetchQueries: [HomeAuthedDocument] })
+
   const [onChainUsdPaymentSend, { loading: onChainUsdPaymentSendLoading }] =
     useOnChainUsdPaymentSendMutation({ refetchQueries: [HomeAuthedDocument] })
 
@@ -142,6 +155,7 @@ export const useSendPayment = (
     lnNoAmountInvoicePaymentSendLoading ||
     lnNoAmountUsdInvoicePaymentSendLoading ||
     onChainPaymentSendLoading ||
+    onChainPaymentSendAllLoading ||
     onChainUsdPaymentSendLoading ||
     onChainUsdPaymentSendAsBtcDenominatedLoading
 
@@ -156,6 +170,7 @@ export const useSendPayment = (
           lnNoAmountInvoicePaymentSend,
           lnNoAmountUsdInvoicePaymentSend,
           onChainPaymentSend,
+          onChainPaymentSendAll,
           onChainUsdPaymentSend,
           onChainUsdPaymentSendAsBtcDenominated,
         })
@@ -174,6 +189,7 @@ export const useSendPayment = (
     lnNoAmountInvoicePaymentSend,
     lnNoAmountUsdInvoicePaymentSend,
     onChainPaymentSend,
+    onChainPaymentSendAll,
     onChainUsdPaymentSend,
     onChainUsdPaymentSendAsBtcDenominated,
   ])


### PR DESCRIPTION
This PR adds the feature of sending all of an user's bitcoin/stablesats usd onchain. It uses the `onChainPaymentSendAll` mutation supported by the backend. It's a flow only available in "onchain" payment.

- [x] Use onChainPaymentSendAll
- [x] Hook Send All with Payment Details
- [x] Max Amount Button
- [x] ~Get Fee with user's balance~ (Can't do because backend always says "Payment of xxx exceeds balance yyy")
- [x] Add Language conversions for texts
- [x] Fix Tests

## How it looks

<table>
  <tr>
  <td>Selected USD Wallet</td>
  <td>Tapped "Max Amount" button</td>
  <td>Details Screen</td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/c97580e6-6705-4690-a001-f87d5eec7e95" alt="image 1">
    </td>
    <td>
      <img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/2b71985f-b210-4337-87a3-5ff49c8769aa" alt="image 2">
    </td>
    <td>
      <img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/1769f66f-7634-4f55-a1a5-8a638b8cf1a7" alt="image 3">
    </td>
  </tr>
</table>

---
Supersedes https://github.com/GaloyMoney/galoy-mobile/pull/1670

PS: It uses @UncleSamtoshi's payment detail logic layer for the send all handling so a review from him would be awesome.