### PR TITLE
fix: Fix contact options

### DIFF
--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -14,9 +14,10 @@ export const SupportChannels = {
   Telegram: "telegram",
   WhatsApp: "whatsapp",
   StatusPage: "statusPage",
+  Mattermost: "mattermost",
 } as const
 
-type SupportChannelsToHide = (typeof SupportChannels)[keyof typeof SupportChannels]
+export type SupportChannelsToHide = (typeof SupportChannels)[keyof typeof SupportChannels]
 
 type Props = {
   isVisible: boolean
@@ -53,6 +54,8 @@ const ContactModal: React.FC<Props> = ({
   // TODO: extract in Instance
   const openTelegramAction = () => Linking.openURL(`https://t.me/blinkbtc`)
 
+  const openMattermostAction = () => Linking.openURL(`https://chat.galoy.io`)
+
   const contactOptionList = [
     {
       name: LL.support.statusPage(),
@@ -71,6 +74,15 @@ const ContactModal: React.FC<Props> = ({
         toggleModal()
       },
       hidden: supportChannelsToHide?.includes(SupportChannels.Telegram),
+    },
+    {
+      name: LL.support.mattermost(),
+      icon: <Icon name={"chatbubbles-outline"} type="ionicon" color={colors.black} />,
+      action: () => {
+        openMattermostAction()
+        toggleModal()
+      },
+      hidden: supportChannelsToHide?.includes(SupportChannels.Mattermost),
     },
     {
       name: LL.support.whatsapp(),

--- a/app/components/contact-support-button/contact-support-button.tsx
+++ b/app/components/contact-support-button/contact-support-button.tsx
@@ -1,7 +1,7 @@
 import { useI18nContext } from "@app/i18n/i18n-react"
 import React, { useState } from "react"
 import { GaloyTertiaryButton } from "../atomic/galoy-tertiary-button"
-import ContactModal from "../contact-modal/contact-modal"
+import ContactModal, { SupportChannels } from "../contact-modal/contact-modal"
 import { StyleProp, ViewStyle } from "react-native"
 import { getReadableVersion } from "react-native-device-info"
 import { isIos } from "@app/utils/helper"
@@ -34,6 +34,8 @@ export const ContactSupportButton = ({
         messageSubject={messageSubject}
         isVisible={showContactSupport}
         toggleModal={() => setShowContactSupport(!showContactSupport)}
+        // Assuming the support button is always used for 1:1 support I'm excluding community channels
+        supportChannelsToHide={[SupportChannels.Mattermost, SupportChannels.Telegram]}
       />
       <GaloyTertiaryButton
         containerStyle={containerStyle}

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -872,10 +872,12 @@ const en: BaseTranslation = {
   },
   support: {
     contactUs: "Need help? Contact us.",
+    joinTheCommunity: "Join the community",
     whatsapp: "WhatsApp",
     email: "Email",
     statusPage: "Status Page",
-    telegram: "Telegram (community)",
+    telegram: "Telegram",
+    mattermost: "Mattermost",
     defaultEmailSubject: "{bankName: string} - Support",
     defaultSupportMessage: "Hey there! I need some help with {bankName: string}, I'm using the version {version: string} on {os: string}.",
     emailCopied: "email {email: string} copied to clipboard",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -2959,6 +2959,10 @@ type RootTranslation = {
 		 */
 		contactUs: string
 		/**
+		 * J​o​i​n​ ​t​h​e​ ​c​o​m​m​u​n​i​t​y
+		 */
+		joinTheCommunity: string
+		/**
 		 * W​h​a​t​s​A​p​p
 		 */
 		whatsapp: string
@@ -2971,9 +2975,13 @@ type RootTranslation = {
 		 */
 		statusPage: string
 		/**
-		 * T​e​l​e​g​r​a​m​ ​(​c​o​m​m​u​n​i​t​y​)
+		 * T​e​l​e​g​r​a​m
 		 */
 		telegram: string
+		/**
+		 * M​a​t​t​e​r​m​o​s​t
+		 */
+		mattermost: string
 		/**
 		 * {​b​a​n​k​N​a​m​e​}​ ​-​ ​S​u​p​p​o​r​t
 		 * @param {string} bankName
@@ -5987,6 +5995,10 @@ export type TranslationFunctions = {
 		 */
 		contactUs: () => LocalizedString
 		/**
+		 * Join the community
+		 */
+		joinTheCommunity: () => LocalizedString
+		/**
 		 * WhatsApp
 		 */
 		whatsapp: () => LocalizedString
@@ -5999,9 +6011,13 @@ export type TranslationFunctions = {
 		 */
 		statusPage: () => LocalizedString
 		/**
-		 * Telegram (community)
+		 * Telegram
 		 */
 		telegram: () => LocalizedString
+		/**
+		 * Mattermost
+		 */
+		mattermost: () => LocalizedString
 		/**
 		 * {bankName} - Support
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -853,10 +853,12 @@
     },
     "support": {
         "contactUs": "Need help? Contact us.",
+        "joinTheCommunity": "Join the community",
         "whatsapp": "WhatsApp",
         "email": "Email",
         "statusPage": "Status Page",
-        "telegram": "Telegram (community)",
+        "telegram": "Telegram",
+        "mattermost": "Mattermost",
         "defaultEmailSubject": "{bankName: string} - Support",
         "defaultSupportMessage": "Hey there! I need some help with {bankName: string}, I'm using the version {version: string} on {os: string}.",
         "emailCopied": "email {email: string} copied to clipboard",

--- a/app/screens/settings-screen/settings-screen.tsx
+++ b/app/screens/settings-screen/settings-screen.tsx
@@ -7,7 +7,10 @@ import { VersionComponent } from "../../components/version"
 import type { RootStackParamList } from "../../navigation/stack-param-lists"
 import KeyStoreWrapper from "../../utils/storage/secureStorage"
 
-import ContactModal from "@app/components/contact-modal/contact-modal"
+import ContactModal, {
+  SupportChannels,
+  SupportChannelsToHide,
+} from "@app/components/contact-modal/contact-modal"
 import crashlytics from "@react-native-firebase/crashlytics"
 
 import { gql } from "@apollo/client"
@@ -78,6 +81,10 @@ export const SettingsScreen: React.FC = () => {
   const { isAtLeastLevelZero, isAtLeastLevelOne, currentLevel } = useLevel()
   const { LL } = useI18nContext()
 
+  const [hiddenContactMethods, setHiddenContactMethods] = React.useState<
+    SupportChannelsToHide[]
+  >([SupportChannels.Telegram, SupportChannels.Mattermost])
+
   const { data } = useSettingsScreenQuery({
     fetchPolicy: "cache-first",
     returnPartialData: true,
@@ -143,6 +150,7 @@ export const SettingsScreen: React.FC = () => {
   }
 
   const [isContactModalVisible, setIsContactModalVisible] = React.useState(false)
+
   const toggleIsContactModalVisible = () => {
     setIsContactModalVisible(!isContactModalVisible)
   }
@@ -285,7 +293,27 @@ export const SettingsScreen: React.FC = () => {
       category: LL.support.contactUs(),
       icon: "help-circle",
       id: "contact-us",
-      action: toggleIsContactModalVisible,
+      action: () => {
+        setHiddenContactMethods([SupportChannels.Telegram, SupportChannels.Mattermost])
+        toggleIsContactModalVisible()
+      },
+      enabled: true,
+      greyed: false,
+      styleDivider: true,
+    },
+    {
+      category: LL.support.joinTheCommunity(),
+      icon: "people",
+      id: "join-the-community",
+      action: () => {
+        setHiddenContactMethods([
+          SupportChannels.Email,
+          SupportChannels.StatusPage,
+          SupportChannels.WhatsApp,
+        ])
+
+        toggleIsContactModalVisible()
+      },
       enabled: true,
       greyed: false,
       styleDivider: true,
@@ -313,6 +341,7 @@ export const SettingsScreen: React.FC = () => {
         toggleModal={toggleIsContactModalVisible}
         messageBody={contactMessageBody}
         messageSubject={contactMessageSubject}
+        supportChannelsToHide={hiddenContactMethods}
       />
       <ModalNfc isActive={isNFCActive} setIsActive={setIsNFCActive} />
     </Screen>


### PR DESCRIPTION
Fixes issue #2384 by removing telegram from the available support options when user taps "Need help".  Instead I've added a "Join the community" option on the main settings menu which also includes a link to mattermost.  I've utilised the existing `supportChannelsToHide` prop on the ContactModal to show/hide either 1:1 support options or community options.  I also changed the ContactModal which is available through the ContactSupportButton which is currently only used on the PhoneInput.  

Example screenshots below:
### 1:1 Support options
<img width="390" alt="image" src="https://github.com/GaloyMoney/galoy-mobile/assets/3502409/f63c74bb-d893-4962-aff3-a816329e23b9">

### Community options
<img width="390" alt="image" src="https://github.com/GaloyMoney/galoy-mobile/assets/3502409/470ac837-484c-4dd3-aea4-3ab4460a4254">
