### PR TITLE
fix: spacing around wallet overview

### DIFF
--- a/app/components/wallet-overview/wallet-overview.tsx
+++ b/app/components/wallet-overview/wallet-overview.tsx
@@ -120,7 +120,7 @@ const WalletOverview: React.FC<Props> = ({
           <GaloyIcon name={isContentVisible ? "eye" : "eye-slash"} size={24} />
         </Pressable>
       </View>
-      <View style={styles.separator}></View>
+      <View style={[styles.separator, styles.titleSeparator]}></View>
       <View style={styles.displayTextView}>
         <View style={styles.currency}>
           <GaloyCurrencyBubble currency="BTC" />
@@ -202,11 +202,15 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "center",
     height: 45,
     marginVertical: 4,
+    marginTop: 5,
   },
   separator: {
     height: 1,
     backgroundColor: colors.grey4,
-    marginTop: 10,
+    marginVertical: 2,
+  },
+  titleSeparator: {
+    marginTop: 12,
   },
   currency: {
     display: "flex",
@@ -216,7 +220,6 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   hideableArea: {
     alignItems: "flex-end",
-    marginTop: 15,
   },
   loaderContainer: {
     flex: 1,


### PR DESCRIPTION
This PR is to fix spacing around the main home screen wallet overview component.

<table>
<tr>
<td></td>
<td>Earlier</td>
<td>Fix (this PR)</td>
</tr>
<tr>
<td>With Display Currency</td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/2d5823e5-8384-4e0b-9e7c-733f81610e40"/></td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/f51161a0-6833-4dc4-a9ad-5a8949e864b4" /></td>
</tr>
<tr>
<td>Without Display Currency</td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/31d28cb0-0075-430d-97a9-544022461807" /></td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/d59959ab-955c-414b-832a-c43b77b44925" /></td>
</tr>
</table>

This issue and it's fix is more vividly visible when I have highlighted the containers.

<table>
<tr>
<td></td>
<td>Earlier</td>
<td>Fix (this PR)</td>
</tr>
<tr>
<td>With Display Currency</td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/d5a5fc31-2da5-4eb6-9c57-0eb40ee2b342"/></td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/a705fcc3-3e54-4128-b860-ef6e1a23aefc" /></td>
</tr>
<tr>
<td>Without Display Currency</td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/d3f7c988-6de7-4d66-9e60-7c7d480f2e02" /></td>
<td><img src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/38c98555-537c-4249-9439-7704215bb8d8" /></td>
</tr>
</table>

