### PR TITLE
fix: post notification issue

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove"  />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.NFC" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 >
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" tools:node="remove" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tsc:check": "tsc -p .",
     "eslint:check": "eslint . --ext .js,.ts,.tsx",
     "eslint:fix": "eslint . --ext .js,.ts,.tsx --fix",
-    "check-code": "yarn tsc:check && yarn eslint:check && yarn check:translations && yarn check:codegen",
+    "check-code": "yarn tsc:check && yarn eslint:check && yarn check:translations && yarn check:codegen && yarn graphql-check",
     "check:translations": "yarn update-translations && if git diff --name-only | grep -q 'app/i18n/i18n-types.ts'; then echo 'Error: app/i18n/i18n-types.ts has changes, run `yarn update-translations` and re-recommit' >&2; exit 1; fi",
     "check:codegen": "yarn dev:codegen && if git diff --name-only | grep -q 'app/graphql/generated.ts'; then echo 'Error: app/graphql/generated.ts has changes, run `yarn dev:codegen` and re-recommit' >&2; exit 1; fi",
     "test": "LOGLEVEL=warn jest --runInBand",


### PR DESCRIPTION
I couldn't replicate the issue but reading on the docs, PermissionsAndroid are a list of specified dangerous permissions that prompts the user. The POST_NOTIFICATION key is not present in the manifest. This adds that.

I'm not 100% sure that it would fix the issue but I feel this is a step in the right direction.