### PR TITLE
fix: QR code too small to be scan on my old LG

### DIFF
--- a/app/screens/receive-bitcoin-screen/qr-view.tsx
+++ b/app/screens/receive-bitcoin-screen/qr-view.tsx
@@ -133,21 +133,14 @@ export const QRView: React.FC<Props> = ({
       return null
     }
 
-    const getQrSize = () => {
-      if (Platform.OS === "android") {
-        if (scale > 3) {
-          return 195
-        }
-      }
-      return size
-    }
+    const qrSize = Platform.OS === "android" && scale > 3 ? 240 : size
 
     if (displayingQR && getFullUri) {
       const uri = getFullUri({ uppercase: true })
       return (
         <View style={[styles.container, style]} {...testProps("QR-Code")}>
           <QRCode
-            size={getQrSize()}
+            size={qrSize}
             value={uri}
             logoBackgroundColor="white"
             ecl={type && configByType[type].ecl}


### PR DESCRIPTION
value was changed from 260 to 195 in the receive screen refactoring

why was it changed? some issues with some particular devices?

https://github.com/GaloyMoney/galoy-mobile/blame/main/app/screens/receive-bitcoin-screen/qr-view.tsx#L139C19-L139C19