### PR TITLE
refactor: use lnurl min to populate default send amount

### DIFF
--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -150,15 +150,15 @@ export const createLnurlPaymentDestination = (
     convertMoneyAmount,
     sendingWalletDescriptor,
   }: CreatePaymentDetailParams<T>) => {
+    const minAmount = resolvedLnurlPaymentDestination.lnurlParams.min || 0
+
     return createLnurlPaymentDetails({
       lnurl: resolvedLnurlPaymentDestination.lnurl,
       lnurlParams: resolvedLnurlPaymentDestination.lnurlParams,
       sendingWalletDescriptor,
       destinationSpecifiedMemo: resolvedLnurlPaymentDestination.lnurlParams.description,
       convertMoneyAmount,
-      unitOfAccountAmount: toBtcMoneyAmount(
-        resolvedLnurlPaymentDestination.lnurlParams.min,
-      ),
+      unitOfAccountAmount: toBtcMoneyAmount(minAmount),
     })
   }
   return {

--- a/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/lnurl.ts
@@ -8,7 +8,7 @@ import {
   fetchLnurlPaymentParams,
 } from "@galoymoney/client"
 
-import { ZeroBtcMoneyAmount } from "@app/types/amounts"
+import { toBtcMoneyAmount } from "@app/types/amounts"
 import { getParams } from "js-lnurl"
 import { LnUrlPayServiceResponse } from "lnurl-pay/dist/types/types"
 import { createLnurlPaymentDetails } from "../payment-details"
@@ -156,7 +156,9 @@ export const createLnurlPaymentDestination = (
       sendingWalletDescriptor,
       destinationSpecifiedMemo: resolvedLnurlPaymentDestination.lnurlParams.description,
       convertMoneyAmount,
-      unitOfAccountAmount: ZeroBtcMoneyAmount,
+      unitOfAccountAmount: toBtcMoneyAmount(
+        resolvedLnurlPaymentDestination.lnurlParams.min,
+      ),
     })
   }
   return {


### PR DESCRIPTION
## Description

When sending with lnurl-p, on the 1st request a response with `min` and `max` value is returned for the lnurl endpoint. This PR is to auto-populate the send amount field with the lnurl min instead of `0`.