### PR TITLE
fix: deactivate setting an amount for onchain + stablesats

### DIFF
--- a/__tests__/payment-details/helpers.ts
+++ b/__tests__/payment-details/helpers.ts
@@ -49,11 +49,6 @@ type CreateFunctionWithSpy = <T extends (...args: any) => any>() => (
   params: CreateFunctionWithSpyParams<T>,
 ) => void
 
-export const expectCannotSetAmount = (paymentDetails: PaymentDetail<WalletCurrency>) => {
-  expect(paymentDetails.canSetAmount).toBeFalsy()
-  expect(paymentDetails.setAmount).toBeUndefined()
-}
-
 export const expectDestinationSpecifiedMemoCannotSetMemo = <T extends WalletCurrency>(
   paymentDetails: PaymentDetail<T>,
   destinationSpecifiedMemo: string,

--- a/__tests__/payment-request/payment-request-creation-data.spec.ts
+++ b/__tests__/payment-request/payment-request-creation-data.spec.ts
@@ -70,15 +70,29 @@ describe("create payment request creation data", () => {
     expect(prcd.receivingWalletDescriptor).toBe(btcWalletDescriptor)
   })
 
-  it("onchain set", () => {
+  it("onchain can set amount for btc", () => {
     const prcd = createPaymentRequestCreationData({
       ...defaultParams,
       type: Invoice.OnChain,
+      defaultWalletDescriptor: btcWalletDescriptor,
     })
 
+    expect(prcd.receivingWalletDescriptor).toBe(btcWalletDescriptor)
     expect(prcd.canSetAmount).toBe(true)
     expect(prcd.canSetMemo).toBe(true)
     expect(prcd.canSetReceivingWalletDescriptor).toBe(true)
-    expect(prcd.receivingWalletDescriptor).toBe(defaultParams.defaultWalletDescriptor)
+  })
+
+  it("onchain can't set amount for usd", () => {
+    const prcd = createPaymentRequestCreationData({
+      ...defaultParams,
+      type: Invoice.OnChain,
+      defaultWalletDescriptor: usdWalletDescriptor,
+    })
+
+    expect(prcd.receivingWalletDescriptor).toBe(usdWalletDescriptor)
+    expect(prcd.canSetAmount).toBe(false)
+    expect(prcd.canSetMemo).toBe(true)
+    expect(prcd.canSetReceivingWalletDescriptor).toBe(true)
   })
 })

--- a/app/screens/conversion-flow/conversion-details-screen.tsx
+++ b/app/screens/conversion-flow/conversion-details-screen.tsx
@@ -58,7 +58,7 @@ export const ConversionDetailsScreen = () => {
   })
 
   const { data } = useConversionScreenQuery({
-    fetchPolicy: "cache-first",
+    fetchPolicy: "cache-and-network",
     returnPartialData: true,
   })
 

--- a/app/screens/receive-bitcoin-screen/payment/payment-request-creation-data.ts
+++ b/app/screens/receive-bitcoin-screen/payment/payment-request-creation-data.ts
@@ -73,8 +73,17 @@ export const createPaymentRequestCreationData = <T extends WalletCurrency>(
   }
 
   // Paycode only to Bitcoin
-  if (type === "PayCode") {
+  // FIXME: this is no longer the case
+  if (type === Invoice.PayCode) {
     receivingWalletDescriptor = bitcoinWalletDescriptor as WalletDescriptor<T>
+  }
+
+  // We currently can't set amount for on-chain USD
+  if (
+    type === Invoice.OnChain &&
+    receivingWalletDescriptor.currency === WalletCurrency.Usd
+  ) {
+    permissions.canSetAmount = false
   }
 
   // Set settlement amount if unit of account amount is set

--- a/app/screens/receive-bitcoin-screen/use-receive-bitcoin.ts
+++ b/app/screens/receive-bitcoin-screen/use-receive-bitcoin.ts
@@ -148,7 +148,7 @@ export const useReceiveBitcoin = () => {
   const isAuthed = useIsAuthed()
 
   const { data } = usePaymentRequestQuery({
-    fetchPolicy: "cache-first",
+    fetchPolicy: "cache-and-network",
     skip: !isAuthed,
   })
 


### PR DESCRIPTION
this previously was showing a forever loading screen when trying to add an amount with stablesats + onchain

fix #2772