### PR TITLE
Refactor(phone-auth-screen): issue #2812 Updated headers on phone authentication screens to more accurately reflect the type of authentication (creating account versus logging in)

### DIFF
--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -43,6 +43,7 @@ import { AllContactsScreen } from "@app/screens/people-screen/contacts/all-conta
 import { PeopleTabIcon } from "@app/screens/people-screen/tab-icon"
 import {
   PhoneLoginInitiateScreen,
+  PhoneLoginInitiateType,
   PhoneLoginValidationScreen,
 } from "@app/screens/phone-auth-screen"
 import { PhoneRegistrationInitiateScreen } from "@app/screens/phone-auth-screen/phone-registration-input"
@@ -288,9 +289,7 @@ export const RootStack = () => {
       <RootNavigator.Screen
         name="phoneFlow"
         component={PhoneLoginNavigator}
-        options={{
-          title: LL.PhoneLoginInitiateScreen.title(),
-        }}
+        options={{ headerShown: false }}
       />
       <RootNavigator.Screen
         name="phoneRegistrationInitiate"
@@ -469,21 +468,31 @@ const StackPhoneValidation = createStackNavigator<PhoneValidationStackParamList>
 
 export const PhoneLoginNavigator = () => {
   const { LL } = useI18nContext()
+
+  function getTitle(type: PhoneLoginInitiateType) {
+    return type === PhoneLoginInitiateType.CreateAccount
+      ? LL.PhoneLoginInitiateScreen.title()
+      : LL.common.phoneNumber()
+  }
+
   return (
     <StackPhoneValidation.Navigator>
       <StackPhoneValidation.Screen
         name="phoneLoginInitiate"
-        options={{
-          headerShown: false,
-          title: LL.common.phoneNumber(),
+        options={(props) => {
+          return {
+            title: getTitle(props.route.params.type),
+          }
         }}
         component={PhoneLoginInitiateScreen}
       />
       <StackPhoneValidation.Screen
         name="phoneLoginValidate"
         component={PhoneLoginValidationScreen}
-        options={{
-          headerShown: false,
+        options={(props) => {
+          return {
+            title: getTitle(props.route.params.type),
+          }
         }}
       />
     </StackPhoneValidation.Navigator>

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -479,21 +479,17 @@ export const PhoneLoginNavigator = () => {
     <StackPhoneValidation.Navigator>
       <StackPhoneValidation.Screen
         name="phoneLoginInitiate"
-        options={(props) => {
-          return {
-            title: getTitle(props.route.params.type),
-          }
-        }}
+        options={(props) => ({
+          title: getTitle(props.route.params.type),
+        })}
         component={PhoneLoginInitiateScreen}
       />
       <StackPhoneValidation.Screen
         name="phoneLoginValidate"
         component={PhoneLoginValidationScreen}
-        options={(props) => {
-          return {
-            title: getTitle(props.route.params.type),
-          }
-        }}
+        options={(props) => ({
+          title: getTitle(props.route.params.type),
+        })}
       />
     </StackPhoneValidation.Navigator>
   )

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -104,9 +104,13 @@ export type PeopleStackParamList = {
 export type PhoneValidationStackParamList = {
   Primary: undefined
   phoneLoginInitiate: {
-    type?: PhoneLoginInitiateType
+    type: PhoneLoginInitiateType
   }
-  phoneLoginValidate: { phone: string; channel: PhoneCodeChannelType }
+  phoneLoginValidate: {
+    phone: string
+    channel: PhoneCodeChannelType
+    type: PhoneLoginInitiateType
+  }
   authentication: {
     screenPurpose: AuthenticationScreenPurpose
   }

--- a/app/screens/earns-screen/earns-section.tsx
+++ b/app/screens/earns-screen/earns-section.tsx
@@ -22,6 +22,7 @@ import {
   getQuizQuestionsContent,
 } from "./earns-utils"
 import { makeStyles, useTheme } from "@rneui/themed"
+import { PhoneLoginInitiateType } from "../phone-auth-screen"
 
 const { width: screenWidth } = Dimensions.get("window")
 
@@ -218,7 +219,7 @@ export const EarnSection = ({ route }: Props) => {
           onPress: () =>
             navigation.navigate("phoneFlow", {
               screen: "phoneLoginInitiate",
-              params: {},
+              params: { type: PhoneLoginInitiateType.CreateAccount },
             }),
         },
       ])

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -148,10 +148,10 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
 
   const { LL } = useI18nContext()
 
-  const screenType = route.params.type;
+  const screenType = route.params.type
 
   const isDisabledCountryAndCreateAccount =
-    screenType=== PhoneLoginInitiateType.CreateAccount &&
+    screenType === PhoneLoginInitiateType.CreateAccount &&
     phoneInputInfo?.countryCode &&
     DisableCountriesForAccountCreation.includes(phoneInputInfo.countryCode)
 

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -148,8 +148,10 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
 
   const { LL } = useI18nContext()
 
+  const screenType = route.params.type;
+
   const isDisabledCountryAndCreateAccount =
-    route.params.type === PhoneLoginInitiateType.CreateAccount &&
+    screenType=== PhoneLoginInitiateType.CreateAccount &&
     phoneInputInfo?.countryCode &&
     DisableCountriesForAccountCreation.includes(phoneInputInfo.countryCode)
 
@@ -157,6 +159,7 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
     if (status === RequestPhoneCodeStatus.SuccessRequestingCode) {
       setStatus(RequestPhoneCodeStatus.InputtingPhoneNumber)
       navigation.navigate("phoneLoginValidate", {
+        type: screenType,
         phone: validatedPhoneNumber || "",
         channel: phoneCodeChannel,
       })

--- a/app/screens/phone-auth-screen/phone-login-input.tsx
+++ b/app/screens/phone-auth-screen/phone-login-input.tsx
@@ -164,7 +164,7 @@ export const PhoneLoginInitiateScreen: React.FC<PhoneLoginInitiateScreenProps> =
         channel: phoneCodeChannel,
       })
     }
-  }, [status, phoneCodeChannel, validatedPhoneNumber, navigation, setStatus])
+  }, [status, phoneCodeChannel, validatedPhoneNumber, navigation, setStatus, screenType])
 
   if (status === RequestPhoneCodeStatus.LoadingCountryCode || loadingSupportedCountries) {
     return (

--- a/app/screens/phone-auth-screen/phone-login-validation.stories.tsx
+++ b/app/screens/phone-auth-screen/phone-login-validation.stories.tsx
@@ -11,7 +11,7 @@ const route = {
   key: "PhoneLoginValidationScreen",
   name: "phoneLoginValidate",
   params: {
-    type: "CreateAccount", 
+    type: "CreateAccount",
     phone: "+50365055543",
     channel: "SMS",
   },

--- a/app/screens/phone-auth-screen/phone-login-validation.stories.tsx
+++ b/app/screens/phone-auth-screen/phone-login-validation.stories.tsx
@@ -11,6 +11,7 @@ const route = {
   key: "PhoneLoginValidationScreen",
   name: "phoneLoginValidate",
   params: {
+    type: "CreateAccount", 
     phone: "+50365055543",
     channel: "SMS",
   },


### PR DESCRIPTION
There was some unused code (unused as in it was being overridden) that looked like it was trying to make the header during login to say 'Phone number' as the header. So I followed suit and used that.

For ease of reading the PR, take note of changing the optional property 'type' (in PhoneValidationStackParamList.phoneLoginValidate) to required. There was only 1 instance of this property not being used and that was in 'earns-section.tsx'. It used to pass in undefined and then default to PhoneLoginInitiateType.CreateAccount. Now it's stated there explicitly. 