### PR TITLE
fix(earns-map-screen): Quickfix to ensure NaaN is not used in width value of ProgressBar

### DIFF
--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -62,13 +62,13 @@ const ProgressBar = ({ progress }: ProgressProps) => {
   } = useTheme()
 
   const styles = useStyles()
-  const balanceWidth = Number(`${progress * 100}%`)
+  const balanceWidth = Number(`${progress * 100}`)
 
   return (
     <View style={styles.progressContainer}>
       {/* pass props to style object to remove inline style */}
       {/* eslint-disable-next-line react-native/no-inline-styles */}
-      <View style={{ width: balanceWidth, height: 3, backgroundColor: colors._white }} />
+      <View style={{ width: `${balanceWidth}%`, height: 3, backgroundColor: colors._white }} />
     </View>
   )
 }

--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -68,7 +68,9 @@ const ProgressBar = ({ progress }: ProgressProps) => {
     <View style={styles.progressContainer}>
       {/* pass props to style object to remove inline style */}
       {/* eslint-disable-next-line react-native/no-inline-styles */}
-      <View style={{ width: `${balanceWidth}%`, height: 3, backgroundColor: colors._white }} />
+      <View
+        style={{ width: `${balanceWidth}%`, height: 3, backgroundColor: colors._white }}
+      />
     </View>
   )
 }


### PR DESCRIPTION
Was no one else experiencing this crash? Adding a '%' sign to the input of a Number() call will always result in Naan. Had to move the '%' outside of that equation. 