### PR TITLE
fix: percentage symbol must be outside of 'Number()' call

### DIFF
--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -62,13 +62,15 @@ const ProgressBar = ({ progress }: ProgressProps) => {
   } = useTheme()
 
   const styles = useStyles()
-  const balanceWidth = Number(`${progress * 100}%`)
+  const balanceWidth = Number(`${progress * 100}`)
 
   return (
     <View style={styles.progressContainer}>
       {/* pass props to style object to remove inline style */}
       {/* eslint-disable-next-line react-native/no-inline-styles */}
-      <View style={{ width: balanceWidth, height: 3, backgroundColor: colors._white }} />
+      <View
+        style={{ width: `${balanceWidth}%`, height: 3, backgroundColor: colors._white }}
+      />
     </View>
   )
 }

--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -67,10 +67,11 @@ const ProgressBar = ({ progress }: ProgressProps) => {
   return (
     <View style={styles.progressContainer}>
       {/* pass props to style object to remove inline style */}
-      {/* eslint-disable-next-line react-native/no-inline-styles */}
+      {/* eslint-disable react-native/no-inline-styles */}
       <View
         style={{ width: `${balanceWidth}%`, height: 3, backgroundColor: colors._white }}
       />
+      {/* eslint-enable react-native/no-inline-styles */}
     </View>
   )
 }


### PR DESCRIPTION
Was anyone else experiencing this crash? Number() call was always returning NaaN cause it had invalid data for the arg.

