### PR TITLE
feat(amount-input-screen): allow for pasting values in amount input s…

### DIFF
--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -59,7 +59,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
               showSoftInputOnFocus={false}
               onChangeText={(e) => {
                 // remove commas for ease of calculation later on
-                let val = e.replaceAll(",", "")
+                const val = e.replaceAll(",", "")
                 // todo adjust for currencies that use commas instead of decimals
 
                 // test for string input that can be either numerical or float

--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -6,7 +6,7 @@ import { GaloyIconButton } from "../atomic/galoy-icon-button"
 import { GaloyPrimaryButton } from "../atomic/galoy-primary-button"
 import { GaloyErrorBox } from "../atomic/galoy-error-box"
 import { CurrencyKeyboard } from "../currency-keyboard"
-import { Key, Keys } from "./number-pad-reducer"
+import { Key } from "./number-pad-reducer"
 
 export type AmountInputScreenUIProps = {
   primaryCurrencySymbol?: string
@@ -18,7 +18,7 @@ export type AmountInputScreenUIProps = {
   errorMessage?: string
   setAmountDisabled?: boolean
   onKeyPress: (key: Key) => void
-  onPaste: (key: Keys) => void
+  onPaste: (keys: number) => void
   onToggleCurrency?: () => void
   onClearAmount: () => void
   onSetAmountPress?: () => void
@@ -67,7 +67,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
                 // test for string input that can be either numerical or float
                 if (/^\d*\.?\d*$/.test(val)) {
                   const num = Number(val)
-                  onPaste(`${num}`)
+                  onPaste(num)
                 }
               }}
               containerStyle={styles.primaryNumberContainer}

--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -6,7 +6,7 @@ import { GaloyIconButton } from "../atomic/galoy-icon-button"
 import { GaloyPrimaryButton } from "../atomic/galoy-primary-button"
 import { GaloyErrorBox } from "../atomic/galoy-error-box"
 import { CurrencyKeyboard } from "../currency-keyboard"
-import { Key } from "./number-pad-reducer"
+import { Key, Keys } from "./number-pad-reducer"
 
 export type AmountInputScreenUIProps = {
   primaryCurrencySymbol?: string
@@ -18,6 +18,7 @@ export type AmountInputScreenUIProps = {
   errorMessage?: string
   setAmountDisabled?: boolean
   onKeyPress: (key: Key) => void
+  onPaste: (key: Keys) => void
   onToggleCurrency?: () => void
   onClearAmount: () => void
   onSetAmountPress?: () => void
@@ -33,6 +34,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
   secondaryCurrencyCode,
   errorMessage,
   onKeyPress,
+  onPaste,
   onToggleCurrency,
   onSetAmountPress,
   setAmountDisabled,
@@ -60,11 +62,12 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
               onChangeText={(e) => {
                 // remove commas for ease of calculation later on
                 const val = e.replaceAll(",", "")
-                // todo adjust for currencies that use commas instead of decimals
+                // TODO adjust for currencies that use commas instead of decimals
 
                 // test for string input that can be either numerical or float
                 if (/^\d*\.?\d*$/.test(val)) {
-                  onKeyPress(val as Key)
+                  const num = Number(val)
+                  onPaste(`${num}`)
                 }
               }}
               containerStyle={styles.primaryNumberContainer}

--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -65,7 +65,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
                 // TODO adjust for currencies that use commas instead of decimals
 
                 // test for string input that can be either numerical or float
-                if (/^\d*\.?\d*$/.test(val)) {
+                if (/^\d*\.?\d*$/.test(val.trim())) {
                   const num = Number(val)
                   onPaste(num)
                 }

--- a/app/components/amount-input-screen/amount-input-screen-ui.tsx
+++ b/app/components/amount-input-screen/amount-input-screen-ui.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { makeStyles, Text } from "@rneui/themed"
+import { Input, makeStyles, Text, useTheme } from "@rneui/themed"
 import { View } from "react-native"
 import { GaloyIconButton } from "../atomic/galoy-icon-button"
 import { GaloyPrimaryButton } from "../atomic/galoy-primary-button"
@@ -40,6 +40,7 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
 }) => {
   const { LL } = useI18nContext()
   const styles = useStyles()
+  const { theme } = useTheme()
 
   return (
     <View style={styles.amountInputScreenContainer}>
@@ -53,13 +54,26 @@ export const AmountInputScreenUI: React.FC<AmountInputScreenUIProps> = ({
             {primaryCurrencySymbol && (
               <Text style={styles.primaryCurrencySymbol}>{primaryCurrencySymbol}</Text>
             )}
-            {primaryCurrencyFormattedAmount ? (
-              <Text style={styles.primaryNumberText}>
-                {primaryCurrencyFormattedAmount}
-              </Text>
-            ) : (
-              <Text style={styles.faintPrimaryNumberText}>0</Text>
-            )}
+            <Input
+              value={primaryCurrencyFormattedAmount}
+              showSoftInputOnFocus={false}
+              onChangeText={(e) => {
+                // remove commas for ease of calculation later on
+                let val = e.replaceAll(",", "")
+                // todo adjust for currencies that use commas instead of decimals
+
+                // test for string input that can be either numerical or float
+                if (/^\d*\.?\d*$/.test(val)) {
+                  onKeyPress(val as Key)
+                }
+              }}
+              containerStyle={styles.primaryNumberContainer}
+              inputStyle={styles.primaryNumberText}
+              placeholder="0"
+              placeholderTextColor={theme.colors.grey3}
+              inputContainerStyle={styles.primaryNumberInputContainer}
+              renderErrorMessage={false}
+            />
             <Text style={styles.primaryCurrencyCodeText}>{primaryCurrencyCode}</Text>
           </View>
           {Boolean(secondaryCurrencyFormattedAmount) && (
@@ -116,6 +130,9 @@ const useStyles = makeStyles(({ colors }) => ({
   amountContainer: {
     marginBottom: 16,
   },
+  primaryNumberContainer: {
+    flex: 1,
+  },
   primaryAmountContainer: {
     flexDirection: "row",
     alignItems: "center",
@@ -131,12 +148,8 @@ const useStyles = makeStyles(({ colors }) => ({
     flex: 1,
     fontWeight: "bold",
   },
-  faintPrimaryNumberText: {
-    fontSize: 28,
-    lineHeight: 32,
-    flex: 1,
-    fontWeight: "bold",
-    color: colors.grey3,
+  primaryNumberInputContainer: {
+    borderBottomWidth: 0,
   },
   primaryCurrencyCodeText: {
     fontSize: 28,

--- a/app/components/amount-input-screen/amount-input-screen.tsx
+++ b/app/components/amount-input-screen/amount-input-screen.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useReducer } from "react"
 import { AmountInputScreenUI } from "./amount-input-screen-ui"
 import {
   Key,
+  Keys,
   NumberPadNumber,
   numberPadReducer,
   NumberPadReducerActionType,
@@ -170,6 +171,15 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     })
   }
 
+  const onPaste = (keys: Keys) => {
+    dispatchNumberPadAction({
+      action: NumberPadReducerActionType.HandlePaste,
+      payload: {
+        keys,
+      },
+    })
+  }
+
   const onClear = () => {
     dispatchNumberPadAction({
       action: NumberPadReducerActionType.ClearAmount,
@@ -253,6 +263,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
       secondaryCurrencySymbol={secondaryCurrencyInfo?.symbol}
       errorMessage={errorMessage}
       onKeyPress={onKeyPress}
+      onPaste={onPaste}
       onClearAmount={onClear}
       onToggleCurrency={onToggleCurrency}
       setAmountDisabled={Boolean(errorMessage)}

--- a/app/components/amount-input-screen/amount-input-screen.tsx
+++ b/app/components/amount-input-screen/amount-input-screen.tsx
@@ -14,7 +14,6 @@ import { useCallback, useEffect, useReducer } from "react"
 import { AmountInputScreenUI } from "./amount-input-screen-ui"
 import {
   Key,
-  Keys,
   NumberPadNumber,
   numberPadReducer,
   NumberPadReducerActionType,
@@ -171,7 +170,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     })
   }
 
-  const onPaste = (keys: Keys) => {
+  const onPaste = (keys: number) => {
     dispatchNumberPadAction({
       action: NumberPadReducerActionType.HandlePaste,
       payload: {

--- a/app/components/amount-input-screen/number-pad-reducer.ts
+++ b/app/components/amount-input-screen/number-pad-reducer.ts
@@ -16,6 +16,7 @@ export const NumberPadReducerActionType = {
   SetAmount: "SetAmount",
   HandleKeyPress: "HandleKeyPress",
   ClearAmount: "ClearAmount",
+  HandlePaste: "HandlePaste",
 } as const
 
 export type NumberPadReducerAction =
@@ -36,6 +37,12 @@ export type NumberPadReducerAction =
   | {
       action: typeof NumberPadReducerActionType.ClearAmount
     }
+  | {
+      action: typeof NumberPadReducerActionType.HandlePaste
+      payload: {
+        keys: Keys
+      }
+    }
 
 export const Key = {
   Backspace: "⌫",
@@ -54,6 +61,8 @@ export const Key = {
 
 export type Key = (typeof Key)[keyof typeof Key]
 
+export type Keys = `${number | ""}${"." | ""}${number | ""}`
+
 export type NumberPadReducerActionType =
   (typeof NumberPadReducerActionType)[keyof typeof NumberPadReducerActionType]
 
@@ -69,6 +78,20 @@ export const numberPadReducer = (
   switch (action.action) {
     case NumberPadReducerActionType.SetAmount:
       return action.payload
+    case NumberPadReducerActionType.HandlePaste:
+      const num: number = Number(action.payload.keys)
+      const formatted: string =
+        num % 1 === 0 ? num.toString() : num.toFixed(numberOfDecimalsAllowed)
+      const splitByDecimal = formatted.split(".")
+
+      return {
+        ...state,
+        numberPadNumber: {
+          majorAmount: splitByDecimal[0],
+          hasDecimal: splitByDecimal.length > 1,
+          minorAmount: splitByDecimal[1] ?? "",
+        },
+      }
     case NumberPadReducerActionType.HandleKeyPress:
       if (action.payload.key === Key.Backspace) {
         if (minorAmount.length > 0) {
@@ -115,26 +138,6 @@ export const numberPadReducer = (
           }
         }
         return state
-      }
-
-      // pasted
-      if (action.payload.key.length > 1) {
-        // here the whole numberPadNumber will be formatted and replaced
-        // unlike the several sections below which append to the value(s)
-        const num = Number(action.payload.key)
-        // format to float if number has decimal - otherwise integer
-        const formatted: string =
-          num % 1 === 0 ? num.toString() : num.toFixed(numberOfDecimalsAllowed)
-        const splitByDecimal = formatted.split(".")
-
-        return {
-          ...state,
-          numberPadNumber: {
-            majorAmount: splitByDecimal[0],
-            hasDecimal: splitByDecimal.length > 1,
-            minorAmount: splitByDecimal[1] ?? "",
-          },
-        }
       }
 
       if (hasDecimal && minorAmount.length < numberOfDecimalsAllowed) {

--- a/app/components/amount-input-screen/number-pad-reducer.ts
+++ b/app/components/amount-input-screen/number-pad-reducer.ts
@@ -117,6 +117,26 @@ export const numberPadReducer = (
         return state
       }
 
+      // pasted
+      if (action.payload.key.length > 1) {
+        // here the whole numberPadNumber will be formatted and replaced
+        // unlike the several sections below which append to the value(s)
+        const num = Number(action.payload.key)
+        // format to float if number has decimal - otherwise integer
+        let formatted: string =
+          num % 1 != 0 ? num.toFixed(numberOfDecimalsAllowed) : num.toString()
+        const splitByDecimal = formatted.split(".")
+
+        return {
+          ...state,
+          numberPadNumber: {
+            majorAmount: splitByDecimal[0],
+            hasDecimal: splitByDecimal.length > 1,
+            minorAmount: splitByDecimal[1] ?? "",
+          },
+        }
+      }
+
       if (hasDecimal && minorAmount.length < numberOfDecimalsAllowed) {
         return {
           ...state,

--- a/app/components/amount-input-screen/number-pad-reducer.ts
+++ b/app/components/amount-input-screen/number-pad-reducer.ts
@@ -78,8 +78,8 @@ export const numberPadReducer = (
   switch (action.action) {
     case NumberPadReducerActionType.SetAmount:
       return action.payload
-    case NumberPadReducerActionType.HandlePaste:
-      const num: number = Number(action.payload.keys)
+    case NumberPadReducerActionType.HandlePaste: {
+      const num = Number(action.payload.keys)
       const formatted: string =
         num % 1 === 0 ? num.toString() : num.toFixed(numberOfDecimalsAllowed)
       const splitByDecimal = formatted.split(".")
@@ -92,6 +92,7 @@ export const numberPadReducer = (
           minorAmount: splitByDecimal[1] ?? "",
         },
       }
+    }
     case NumberPadReducerActionType.HandleKeyPress:
       if (action.payload.key === Key.Backspace) {
         if (minorAmount.length > 0) {

--- a/app/components/amount-input-screen/number-pad-reducer.ts
+++ b/app/components/amount-input-screen/number-pad-reducer.ts
@@ -123,8 +123,8 @@ export const numberPadReducer = (
         // unlike the several sections below which append to the value(s)
         const num = Number(action.payload.key)
         // format to float if number has decimal - otherwise integer
-        let formatted: string =
-          num % 1 != 0 ? num.toFixed(numberOfDecimalsAllowed) : num.toString()
+        const formatted: string =
+          num % 1 === 0 ? num.toString() : num.toFixed(numberOfDecimalsAllowed)
         const splitByDecimal = formatted.split(".")
 
         return {

--- a/app/components/amount-input-screen/number-pad-reducer.ts
+++ b/app/components/amount-input-screen/number-pad-reducer.ts
@@ -40,7 +40,7 @@ export type NumberPadReducerAction =
   | {
       action: typeof NumberPadReducerActionType.HandlePaste
       payload: {
-        keys: Keys
+        keys: number
       }
     }
 
@@ -61,8 +61,6 @@ export const Key = {
 
 export type Key = (typeof Key)[keyof typeof Key]
 
-export type Keys = `${number | ""}${"." | ""}${number | ""}`
-
 export type NumberPadReducerActionType =
   (typeof NumberPadReducerActionType)[keyof typeof NumberPadReducerActionType]
 
@@ -79,7 +77,7 @@ export const numberPadReducer = (
     case NumberPadReducerActionType.SetAmount:
       return action.payload
     case NumberPadReducerActionType.HandlePaste: {
-      const num = Number(action.payload.keys)
+      const num = action.payload.keys
       const formatted: string =
         num % 1 === 0 ? num.toString() : num.toFixed(numberOfDecimalsAllowed)
       const splitByDecimal = formatted.split(".")


### PR DESCRIPTION
Addresses issue #2497 

I've added the ability to paste into the amount screen. 
This accounts for: 
- validating that it's only numerical and/or decimals
- not opening the keyboard
- maintaining that there can varying amounts of integers after the decimal (depending on the currency)
- maintains auto-formatting with commas for ease of viewing 
- combining the stateful input of pastes with numpad inputs

PS While working on this I noticed a large problem. There are dozens of currencies that use commas instead of decimals to differentiate between the 'dollar' and 'cent' (or whatever they call them) values. The library we're using for countries accounts for this but our numpad and input does not. This means anyone trying to input partial values is blocked. If you'd like to see for yourself, try Albanian money. I've opened an issue for this #2853