### PR TITLE
fix(galoy-address-screen): make close 'X' button touchable in some modals

### DIFF
--- a/app/screens/galoy-address-screen/address-explainer-modal.tsx
+++ b/app/screens/galoy-address-screen/address-explainer-modal.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { View } from "react-native"
-import { TouchableOpacity } from "react-native-gesture-handler"
+import { View, TouchableOpacity } from "react-native"
 import Modal from "react-native-modal"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"

--- a/app/screens/galoy-address-screen/paycode-explainer-modal.tsx
+++ b/app/screens/galoy-address-screen/paycode-explainer-modal.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { View } from "react-native"
-import { TouchableOpacity } from "react-native-gesture-handler"
+import { View, TouchableOpacity } from "react-native"
 import Modal from "react-native-modal"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"

--- a/app/screens/galoy-address-screen/pos-explainer-modal.tsx
+++ b/app/screens/galoy-address-screen/pos-explainer-modal.tsx
@@ -1,6 +1,5 @@
 import React from "react"
-import { View } from "react-native"
-import { TouchableOpacity } from "react-native-gesture-handler"
+import { View, TouchableOpacity } from "react-native"
 import Modal from "react-native-modal"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"


### PR DESCRIPTION
addresses issue: #2888 

 swap react-native-gesture-handler TouchableOpacity component for react-native version