### PR TITLE
Feat(send-bitcoin-destination-screen): UI improvements

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2254,6 +2254,7 @@ const en: BaseTranslation = {
       confirmButton: "I'm 100% sure",
     },
     clipboardError: "Error getting value from clipboard",
+    pastedClipboardSuccess: "Pasted from clipboard"
   },
   SendBitcoinScreen: {
     willBeSentToMempoolBy: "Transaction should be submitted to mempool",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6997,6 +6997,10 @@ type RootTranslation = {
 		 * E​r​r​o​r​ ​g​e​t​t​i​n​g​ ​v​a​l​u​e​ ​f​r​o​m​ ​c​l​i​p​b​o​a​r​d
 		 */
 		clipboardError: string
+		/**
+		 * P​a​s​t​e​d​ ​f​r​o​m​ ​c​l​i​p​b​o​a​r​d
+		 */
+		pastedClipboardSuccess: string
 	}
 	SendBitcoinScreen: {
 		/**
@@ -15771,6 +15775,10 @@ export type TranslationFunctions = {
 		 * Error getting value from clipboard
 		 */
 		clipboardError: () => LocalizedString
+		/**
+		 * Pasted from clipboard
+		 */
+		pastedClipboardSuccess: () => LocalizedString
 	}
 	SendBitcoinScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2184,7 +2184,8 @@
             "checkBox": "{lnAddress: string} is the right address.",
             "confirmButton": "I'm 100% sure"
         },
-        "clipboardError": "Error getting value from clipboard"
+        "clipboardError": "Error getting value from clipboard",
+        "pastedClipboardSuccess": "Pasted from clipboard"
     },
     "SendBitcoinScreen": {
         "willBeSentToMempoolBy": "Transaction should be submitted to mempool",

--- a/app/screens/send-bitcoin-screen/confirm-destination-modal.tsx
+++ b/app/screens/send-bitcoin-screen/confirm-destination-modal.tsx
@@ -40,7 +40,7 @@ export const ConfirmDestinationModal: React.FC<ConfirmDestinationModalProps> = (
   if (destinationState.destinationState !== DestinationState.RequiresUsernameConfirmation)
     return null
 
-  const lnAddress = destinationState.confirmationUsernameType.username + "@" + lnDomain
+  const lnAddress = destinationState?.confirmationUsernameType?.username + "@" + lnDomain
 
   const goBack = () => {
     dispatchDestinationStateAction({

--- a/app/screens/send-bitcoin-screen/destination-information.tsx
+++ b/app/screens/send-bitcoin-screen/destination-information.tsx
@@ -35,7 +35,7 @@ const destinationStateToInformation = (
   }
 
   if (sendBitcoinReducerState.destinationState === DestinationState.Invalid) {
-    switch (sendBitcoinReducerState.invalidDestination.invalidReason) {
+    switch (sendBitcoinReducerState?.invalidDestination?.invalidReason) {
       case InvalidDestinationReason.InvoiceExpired:
         return {
           error: translate.SendBitcoinDestinationScreen.expiredInvoice(),
@@ -53,7 +53,7 @@ const destinationStateToInformation = (
           error: translate.SendBitcoinDestinationScreen.usernameDoesNotExist({
             lnAddress: toLnAddress(
               (
-                sendBitcoinReducerState.invalidDestination
+                sendBitcoinReducerState?.invalidDestination
                   .invalidPaymentDestination as IntraledgerPaymentDestination
               ).handle,
             ),

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -136,7 +136,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
       const destination = await parseDestination({
         rawInput,
         myWalletIds: wallets.map((wallet) => wallet.id),
-        bitcoinNetwork: bitcoinNetwork,
+        bitcoinNetwork,
         lnurlDomains: LNURL_DOMAINS,
         accountDefaultWalletQuery,
       })
@@ -195,7 +195,14 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
         },
       })
     },
-    [navigation, accountDefaultWalletQuery],
+    [
+      navigation,
+      accountDefaultWalletQuery,
+      dispatchDestinationStateAction,
+      bitcoinNetwork,
+      wallets,
+      contacts,
+    ],
   )
 
   const handleChangeText = useCallback(

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -410,7 +410,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
             selectTextOnFocus
             autoCapitalize="none"
             autoCorrect={false}
-            selection={{ start: 0, end: destinationState.unparsedDestination.length }}
+            selection={{ start: 0, end: destinationState?.unparsedDestination?.length }}
           />
           <TouchableOpacity onPress={() => navigation.navigate("scanningQRCode")}>
             <View style={styles.iconContainer}>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -410,6 +410,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
             selectTextOnFocus
             autoCapitalize="none"
             autoCorrect={false}
+            selection={{ start: 0, end: destinationState.unparsedDestination.length }}
           />
           <TouchableOpacity onPress={() => navigation.navigate("scanningQRCode")}>
             <View style={styles.iconContainer}>

--- a/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
@@ -1,6 +1,6 @@
 import { Destination, InvalidDestination } from "./payment-destination/index.types"
 
-const DestinationState = {
+export const DestinationState = {
   Entering: "entering",
   Pasting: "pasting",
   Validating: "validating",
@@ -25,7 +25,7 @@ export type SendBitcoinDestinationState = {
   destination?: Destination
 }
 
-const SendBitcoinActions = {
+export const SendBitcoinActions = {
   SetUnparsedDestination: "set-unparsed-destination",
   SetUnparsedPastedDestination: "set-unparsed-pasted-destination",
   SetValidating: "set-validating",

--- a/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
@@ -44,7 +44,7 @@ export type SendBitcoinDestinationAction =
     }
   | {
       type: SendBitcoinActions.SetValidating
-      payload: {}
+      payload: Record<string, never>
     }
   | {
       type: SendBitcoinActions.SetValid
@@ -94,48 +94,49 @@ export const sendBitcoinDestinationReducer = (
         destinationState: DestinationState.Validating,
       }
     case SendBitcoinActions.SetValid:
-      return state.unparsedDestination !== action.payload?.unparsedDestination
-        ? state
-        : {
+      return state.unparsedDestination === action.payload?.unparsedDestination
+        ? {
             unparsedDestination: state.unparsedDestination,
             destinationState: DestinationState.Valid,
             destination: action.payload.validDestination,
           }
+        : state
     case SendBitcoinActions.SetInvalid:
       if (state.destinationState === DestinationState.Validating) {
-        return state.unparsedDestination !== action.payload?.unparsedDestination
-          ? state
-          : {
+        return state.unparsedDestination === action.payload?.unparsedDestination
+          ? {
               unparsedDestination: state.unparsedDestination,
               destinationState: DestinationState.Invalid,
               invalidDestination: action.payload.invalidDestination,
             }
+          : state
       }
       throw new Error("Invalid state transition")
     case SendBitcoinActions.SetRequiresUsernameConfirmation:
       if (state.destinationState === DestinationState.Validating) {
-        return state.unparsedDestination !== action.payload?.unparsedDestination
-          ? state
-          : {
+        return state.unparsedDestination === action.payload?.unparsedDestination
+          ? {
               unparsedDestination: state.unparsedDestination,
               destinationState: DestinationState.RequiresUsernameConfirmation,
               destination: action.payload.validDestination,
               confirmationUsernameType: action.payload.confirmationUsernameType,
             }
+          : state
       }
       throw new Error("Invalid state transition")
     case SendBitcoinActions.SetConfirmed:
       if (state.destinationState === DestinationState.RequiresUsernameConfirmation) {
-        return state.unparsedDestination !== action.payload?.unparsedDestination
-          ? state
-          : {
+        return state.unparsedDestination === action.payload?.unparsedDestination
+          ? {
               unparsedDestination: state.unparsedDestination,
               destinationState: DestinationState.Valid,
               destination: state.destination,
               confirmationUsernameType: state.confirmationUsernameType,
             }
+          : state
       }
       throw new Error("Invalid state transition")
-    default: return state;
+    default:
+      return state
   }
 }

--- a/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
@@ -1,13 +1,15 @@
 import { Destination, InvalidDestination } from "./payment-destination/index.types"
 
-export enum DestinationState {
-  Entering = "entering",
-  Pasting = "pasting",
-  Validating = "validating",
-  Valid = "valid",
-  RequiresUsernameConfirmation = "requires-destination-confirmation",
-  Invalid = "invalid",
-}
+const DestinationState = {
+  Entering: "entering",
+  Pasting: "pasting",
+  Validating: "validating",
+  Valid: "valid",
+  RequiresUsernameConfirmation: "requires-destination-confirmation",
+  Invalid: "invalid",
+} as const
+
+export type DestinationState = (typeof DestinationState)[keyof typeof DestinationState]
 
 export type ConfirmationDestinationType = {
   type: "new-username"
@@ -23,45 +25,48 @@ export type SendBitcoinDestinationState = {
   destination?: Destination
 }
 
-export enum SendBitcoinActions {
-  SetUnparsedDestination = "set-unparsed-destination",
-  SetUnparsedPastedDestination = "set-unparsed-pasted-destination",
-  SetValidating = "set-validating",
-  SetValid = "set-valid",
-  SetInvalid = "set-invalid",
-  SetRequiresUsernameConfirmation = "set-requires-destination-confirmation",
-  SetConfirmed = "set-confirmed",
-}
+const SendBitcoinActions = {
+  SetUnparsedDestination: "set-unparsed-destination",
+  SetUnparsedPastedDestination: "set-unparsed-pasted-destination",
+  SetValidating: "set-validating",
+  SetValid: "set-valid",
+  SetInvalid: "set-invalid",
+  SetRequiresUsernameConfirmation: "set-requires-destination-confirmation",
+  SetConfirmed: "set-confirmed",
+} as const
+
+export type SendBitcoinActions =
+  (typeof SendBitcoinActions)[keyof typeof SendBitcoinActions]
 
 export type SendBitcoinDestinationAction =
   | {
-      type: SendBitcoinActions.SetUnparsedDestination
+      type: typeof SendBitcoinActions.SetUnparsedDestination
       payload: { unparsedDestination: string }
     }
   | {
-      type: SendBitcoinActions.SetUnparsedPastedDestination
+      type: typeof SendBitcoinActions.SetUnparsedPastedDestination
       payload: { unparsedDestination: string }
     }
   | {
-      type: SendBitcoinActions.SetValidating
+      type: typeof SendBitcoinActions.SetValidating
       payload: Record<string, never>
     }
   | {
-      type: SendBitcoinActions.SetValid
+      type: typeof SendBitcoinActions.SetValid
       payload: {
         validDestination: Destination
         unparsedDestination: string
       }
     }
   | {
-      type: SendBitcoinActions.SetInvalid
+      type: typeof SendBitcoinActions.SetInvalid
       payload: {
         invalidDestination: InvalidDestination
         unparsedDestination: string
       }
     }
   | {
-      type: SendBitcoinActions.SetRequiresUsernameConfirmation
+      type: typeof SendBitcoinActions.SetRequiresUsernameConfirmation
       payload: {
         confirmationUsernameType: ConfirmationDestinationType
         unparsedDestination: string
@@ -69,7 +74,7 @@ export type SendBitcoinDestinationAction =
       }
     }
   | {
-      type: SendBitcoinActions.SetConfirmed
+      type: typeof SendBitcoinActions.SetConfirmed
       payload: { unparsedDestination: string }
     }
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-reducer.ts
@@ -111,7 +111,6 @@ export const sendBitcoinDestinationReducer = (
               invalidDestination: action.payload.invalidDestination,
             }
       }
-      console.log("Where we're we at? ", state.destinationState);
       throw new Error("Invalid state transition")
     case SendBitcoinActions.SetRequiresUsernameConfirmation:
       if (state.destinationState === DestinationState.Validating) {


### PR DESCRIPTION
Closing the old PR #2909 in order to separate it into 2 separate PRs that address different things.

This PR makes a few UI improvements to the send bitcoin destination screen:

- fix 1px jump from borderWidth on pasting
- Buttons didn't have opacity indication when being pressed
- Added a toast so users know what's happening when they press the paste button (I was confused when I was trying to press it and I didn't have anything in my clipboard. Initially thought it was broken)
- Pressing the paste button twice was messing up the validation process and removing it on 2nd press (it went into manual 'entering' mode)
- multiple seconds of lag after pressing paste button on android

@nicolasburtey This PR has been updated with all the code changes you requested on the previous PR