### PR TITLE
feat: Can copy destination on send bitcoin screen

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2213,6 +2213,7 @@ const en: BaseTranslation = {
     invoiceAlreadyPaid: "This invoice has already been paid",
     somethingWentWrong: "Something went wrong",
     paymentAlreadyAttempted: "Payment already attempted.\n\nIf you want to send this payment again, start from scratch.",
+    copiedDestination: "Copied destination to clipboard"
   },
   SendBitcoinDestinationScreen: {
     usernameNowAddress:
@@ -2287,6 +2288,7 @@ const en: BaseTranslation = {
       content: "Your fee is more than 50% bigger than the amount sent. Are you sure you want to proceed?\n\nTo reduce fees, ask the receiver to accept transaction via Lightning",
       confirmButton: "I'm 100% sure",
     },
+    copiedDestination: "Copied destination to clipboard"
   },
   SettingsScreen: {
     activated: "Activated",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6878,6 +6878,10 @@ type RootTranslation = {
 	​I​f​ ​y​o​u​ ​w​a​n​t​ ​t​o​ ​s​e​n​d​ ​t​h​i​s​ ​p​a​y​m​e​n​t​ ​a​g​a​i​n​,​ ​s​t​a​r​t​ ​f​r​o​m​ ​s​c​r​a​t​c​h​.
 		 */
 		paymentAlreadyAttempted: string
+		/**
+		 * C​o​p​i​e​d​ ​d​e​s​t​i​n​a​t​i​o​n​ ​t​o​ ​c​l​i​p​b​o​a​r​d
+		 */
+		copiedDestination: string
 	}
 	SendBitcoinDestinationScreen: {
 		/**
@@ -7113,6 +7117,10 @@ type RootTranslation = {
 			 */
 			confirmButton: string
 		}
+		/**
+		 * C​o​p​i​e​d​ ​d​e​s​t​i​n​a​t​i​o​n​ ​t​o​ ​c​l​i​p​b​o​a​r​d
+		 */
+		copiedDestination: string
 	}
 	SettingsScreen: {
 		/**
@@ -15669,6 +15677,10 @@ export type TranslationFunctions = {
 	If you want to send this payment again, start from scratch.
 		 */
 		paymentAlreadyAttempted: () => LocalizedString
+		/**
+		 * Copied destination to clipboard
+		 */
+		copiedDestination: () => LocalizedString
 	}
 	SendBitcoinDestinationScreen: {
 		/**
@@ -15887,6 +15899,10 @@ export type TranslationFunctions = {
 			 */
 			confirmButton: () => LocalizedString
 		}
+		/**
+		 * Copied destination to clipboard
+		 */
+		copiedDestination: () => LocalizedString
 	}
 	SettingsScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2156,7 +2156,8 @@
         "feeError": "Unable to calculate fee",
         "invoiceAlreadyPaid": "This invoice has already been paid",
         "somethingWentWrong": "Something went wrong",
-        "paymentAlreadyAttempted": "Payment already attempted.\n\nIf you want to send this payment again, start from scratch."
+        "paymentAlreadyAttempted": "Payment already attempted.\n\nIf you want to send this payment again, start from scratch.",
+        "copiedDestination": "Copied destination to clipboard"
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "{bankName: string} usernames are now {bankName: string} addresses.",
@@ -2214,7 +2215,8 @@
             "title": "High fee alert!",
             "content": "Your fee is more than 50% bigger than the amount sent. Are you sure you want to proceed?\n\nTo reduce fees, ask the receiver to accept transaction via Lightning",
             "confirmButton": "I'm 100% sure"
-        }
+        },
+        "copiedDestination": "Copied destination to clipboard"
     },
     "SettingsScreen": {
         "activated": "Activated",

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -23,9 +23,9 @@ import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
 import crashlytics from "@react-native-firebase/crashlytics"
 import { CommonActions, RouteProp, useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
-import { makeStyles, Text } from "@rneui/themed"
+import { makeStyles, Text, useTheme } from "@rneui/themed"
 import React, { useMemo, useState } from "react"
-import { ActivityIndicator, View } from "react-native"
+import { ActivityIndicator, TouchableOpacity, View } from "react-native"
 import ReactNativeHapticFeedback from "react-native-haptic-feedback"
 import { testProps } from "../../utils/testProps"
 import useFee from "./use-fee"
@@ -33,6 +33,8 @@ import { useSendPayment } from "./use-send-payment"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import Clipboard from "@react-native-clipboard/clipboard"
 
 gql`
   query sendBitcoinConfirmationScreen {
@@ -53,6 +55,9 @@ gql`
 type Props = { route: RouteProp<RootStackParamList, "sendBitcoinConfirmation"> }
 
 const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
+  const {
+    theme: { colors },
+  } = useTheme()
   const styles = useStyles()
 
   const navigation =
@@ -247,6 +252,13 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
               destination={destination}
               paymentType={paymentType}
             />
+            <TouchableOpacity
+              style={styles.iconContainer}
+              onPress={() => Clipboard.setString(paymentDetail.destination)}
+              hitSlop={30}
+            >
+              <GaloyIcon name={"copy-paste"} size={18} color={colors.primary} />
+            </TouchableOpacity>
           </View>
         </View>
         <View style={styles.fieldContainer}>
@@ -455,5 +467,10 @@ const useStyles = makeStyles(({ colors }) => ({
   screenStyle: {
     padding: 20,
     flexGrow: 1,
+  },
+  iconContainer: {
+    justifyContent: "center",
+    alignItems: "flex-start",
+    paddingLeft: 20,
   },
 }))

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -35,6 +35,7 @@ import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import Clipboard from "@react-native-clipboard/clipboard"
+import { toastShow } from "@app/utils/toast"
 
 gql`
   query sendBitcoinConfirmationScreen {
@@ -239,6 +240,15 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     }
   }
 
+  const copyToClipboard = () => {
+    Clipboard.setString(destination)
+    toastShow({
+      type: "success",
+      message: LL.SendBitcoinConfirmationScreen.copiedDestination(),
+      LL,
+    })
+  }
+
   const errorMessage = paymentError || invalidAmountErrorMessage
 
   const displayAmount = convertMoneyAmount(settlementAmount, DisplayCurrency)
@@ -254,7 +264,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
             />
             <TouchableOpacity
               style={styles.iconContainer}
-              onPress={() => Clipboard.setString(paymentDetail.destination)}
+              onPress={copyToClipboard}
               hitSlop={30}
             >
               <GaloyIcon name={"copy-paste"} size={18} color={colors.primary} />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -45,6 +45,7 @@ import { PaymentDestinationDisplay } from "@app/components/payment-destination-d
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { ConfirmFeesModal } from "./confirm-fees-modal"
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import { toastShow } from "@app/utils/toast"
 
 gql`
   query sendBitcoinDetailsScreen {
@@ -249,6 +250,15 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
     setIsModalVisible(!isModalVisible)
   }
 
+  const copyToClipboard = () => {
+    Clipboard.setString(paymentDetail.destination)
+    toastShow({
+      type: "success",
+      message: LL.SendBitcoinScreen.copiedDestination(),
+      LL,
+    })
+  }
+
   const chooseWallet = (wallet: Pick<Wallet, "id" | "walletCurrency">) => {
     let updatedPaymentDetail = paymentDetail.setSendingWalletDescriptor({
       id: wallet.id,
@@ -443,7 +453,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
             </View>
             <TouchableOpacity
               style={styles.iconContainer}
-              onPress={() => Clipboard.setString(paymentDetail.destination)}
+              onPress={copyToClipboard}
               hitSlop={30}
             >
               <GaloyIcon name={"copy-paste"} size={18} color={colors.primary} />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -12,6 +12,7 @@ import {
   WalletCurrency,
 } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
+import Clipboard from "@react-native-clipboard/clipboard"
 import { useLevel } from "@app/graphql/level-context"
 import { usePriceConversion } from "@app/hooks"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
@@ -29,7 +30,7 @@ import crashlytics from "@react-native-firebase/crashlytics"
 import { NavigationProp, RouteProp, useNavigation } from "@react-navigation/native"
 import { makeStyles, Text, useTheme } from "@rneui/themed"
 import React, { useEffect, useState } from "react"
-import { TouchableWithoutFeedback, View } from "react-native"
+import { TouchableOpacity, TouchableWithoutFeedback, View } from "react-native"
 import ReactNativeModal from "react-native-modal"
 import Icon from "react-native-vector-icons/Ionicons"
 import { testProps } from "../../utils/testProps"
@@ -43,6 +44,7 @@ import { NoteInput } from "@app/components/note-input"
 import { PaymentDestinationDisplay } from "@app/components/payment-destination-display"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
 import { ConfirmFeesModal } from "./confirm-fees-modal"
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 
 gql`
   query sendBitcoinDetailsScreen {
@@ -432,11 +434,19 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
       <View style={styles.sendBitcoinAmountContainer}>
         <View style={styles.fieldContainer}>
           <Text style={styles.fieldTitleText}>{LL.SendBitcoinScreen.destination()}</Text>
-          <View style={styles.disabledFieldBackground}>
-            <PaymentDestinationDisplay
-              destination={paymentDetail.destination}
-              paymentType={paymentDetail.paymentType}
-            />
+          <View style={styles.destinationFieldContainer}>
+            <View style={styles.disabledFieldBackground}>
+              <PaymentDestinationDisplay
+                destination={paymentDetail.destination}
+                paymentType={paymentDetail.paymentType}
+              />
+            </View>
+            <TouchableOpacity
+              style={styles.iconContainer}
+              onPress={() => Clipboard.setString(paymentDetail.destination)}
+            >
+              <GaloyIcon name={"copy-paste"} size={18} color={colors.primary} />
+            </TouchableOpacity>
           </View>
         </View>
         <View style={styles.fieldContainer}>
@@ -565,7 +575,7 @@ const useStyles = makeStyles(({ colors }) => ({
     padding: 14,
     minHeight: 60,
   },
-  disabledFieldBackground: {
+  destinationFieldContainer: {
     flexDirection: "row",
     borderStyle: "solid",
     overflow: "hidden",
@@ -574,7 +584,12 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "center",
     padding: 14,
     minHeight: 60,
+  },
+  disabledFieldBackground: {
+    flex: 1,
     opacity: 0.5,
+    flexDirection: "row",
+    alignItems: "center",
   },
   walletContainer: {
     flexDirection: "row",
@@ -671,6 +686,11 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "center",
     marginBottom: 8,
     height: 18,
+  },
+  iconContainer: {
+    justifyContent: "center",
+    alignItems: "flex-start",
+    paddingLeft: 20,
   },
 }))
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -444,6 +444,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
             <TouchableOpacity
               style={styles.iconContainer}
               onPress={() => Clipboard.setString(paymentDetail.destination)}
+              hitSlop={30}
             >
               <GaloyIcon name={"copy-paste"} size={18} color={colors.primary} />
             </TouchableOpacity>


### PR DESCRIPTION
Made as a substitute solution for issue #2298 

Allows for the the user to copy to clipboard on the send bitcoin screen. This is done here because it's really only a desired behaviour when the user has gotten to this screen from scanning a QR.