### PR TITLE
fix: crash from cache

### DIFF
--- a/app/components/invite-modal/invite-modal.tsx
+++ b/app/components/invite-modal/invite-modal.tsx
@@ -38,6 +38,7 @@ type Props = {
 gql`
   query invite {
     me {
+      id
       username
     }
   }

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -694,6 +694,7 @@ mutation userTotpRegistrationValidate($input: UserTotpRegistrationValidateInput!
       __typename
     }
     me {
+      id
       totpEnabled
       phone
       email {
@@ -739,6 +740,7 @@ mutation userUpdateUsername($input: UserUpdateUsernameInput!) {
 
 query Circles {
   me {
+    id
     username
     defaultAccount {
       id
@@ -1070,6 +1072,7 @@ query introducingCirclesModalShown {
 
 query invite {
   me {
+    id
     username
     __typename
   }
@@ -1456,6 +1459,7 @@ query supportedCountries {
 
 query totpRegistrationScreen {
   me {
+    id
     username
     __typename
   }

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -393,9 +393,11 @@ export type ConsumerAccount = Account & {
   readonly defaultWallet: PublicWallet;
   readonly defaultWalletId: Scalars['WalletId']['output'];
   readonly displayCurrency: Scalars['DisplayCurrency']['output'];
+  readonly firstName?: Maybe<Scalars['String']['output']>;
   readonly id: Scalars['ID']['output'];
   /** A list of all invoices associated with walletIds optionally passed. */
   readonly invoices?: Maybe<InvoiceConnection>;
+  readonly lastName?: Maybe<Scalars['String']['output']>;
   readonly level: AccountLevel;
   readonly limits: AccountLimits;
   readonly notificationSettings: NotificationSettings;
@@ -2143,7 +2145,7 @@ export type BalanceHeaderQuery = { readonly __typename: 'Query', readonly me?: {
 export type InviteQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type InviteQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null } | null };
+export type InviteQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null } | null };
 
 export type BtcPriceListQueryVariables = Exact<{
   range: PriceGraphRange;
@@ -2336,7 +2338,7 @@ export type BusinessMapMarkersQuery = { readonly __typename: 'Query', readonly b
 export type CirclesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type CirclesQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly welcomeProfile?: { readonly __typename: 'WelcomeProfile', readonly allTimePoints: number, readonly allTimeRank: number, readonly innerCircleAllTimeCount: number, readonly innerCircleThisMonthCount: number, readonly outerCircleAllTimeCount: number, readonly outerCircleThisMonthCount: number, readonly thisMonthPoints: number, readonly thisMonthRank: number } | null } } | null };
+export type CirclesQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly welcomeProfile?: { readonly __typename: 'WelcomeProfile', readonly allTimePoints: number, readonly allTimeRank: number, readonly innerCircleAllTimeCount: number, readonly innerCircleThisMonthCount: number, readonly outerCircleAllTimeCount: number, readonly outerCircleThisMonthCount: number, readonly thisMonthPoints: number, readonly thisMonthRank: number } | null } } | null };
 
 export type ContactsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2725,7 +2727,7 @@ export type AccountLimitsQuery = { readonly __typename: 'Query', readonly me?: {
 export type TotpRegistrationScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type TotpRegistrationScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly username?: string | null } | null };
+export type TotpRegistrationScreenQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null } | null };
 
 export type UserTotpRegistrationInitiateMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -2737,7 +2739,7 @@ export type UserTotpRegistrationValidateMutationVariables = Exact<{
 }>;
 
 
-export type UserTotpRegistrationValidateMutation = { readonly __typename: 'Mutation', readonly userTotpRegistrationValidate: { readonly __typename: 'UserTotpRegistrationValidatePayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly me?: { readonly __typename: 'User', readonly totpEnabled: boolean, readonly phone?: string | null, readonly email?: { readonly __typename: 'Email', readonly address?: string | null, readonly verified?: boolean | null } | null } | null } };
+export type UserTotpRegistrationValidateMutation = { readonly __typename: 'Mutation', readonly userTotpRegistrationValidate: { readonly __typename: 'UserTotpRegistrationValidatePayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly me?: { readonly __typename: 'User', readonly id: string, readonly totpEnabled: boolean, readonly phone?: string | null, readonly email?: { readonly __typename: 'Email', readonly address?: string | null, readonly verified?: boolean | null } | null } | null } };
 
 export type TransactionListForDefaultAccountQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -2906,6 +2908,7 @@ export type BalanceHeaderQueryResult = Apollo.QueryResult<BalanceHeaderQuery, Ba
 export const InviteDocument = gql`
     query invite {
   me {
+    id
     username
   }
 }
@@ -4235,6 +4238,7 @@ export type BusinessMapMarkersQueryResult = Apollo.QueryResult<BusinessMapMarker
 export const CirclesDocument = gql`
     query Circles {
   me {
+    id
     username
     defaultAccount {
       id
@@ -6707,6 +6711,7 @@ export type AccountLimitsQueryResult = Apollo.QueryResult<AccountLimitsQuery, Ac
 export const TotpRegistrationScreenDocument = gql`
     query totpRegistrationScreen {
   me {
+    id
     username
   }
 }
@@ -6781,6 +6786,7 @@ export const UserTotpRegistrationValidateDocument = gql`
       message
     }
     me {
+      id
       totpEnabled
       phone
       email {
@@ -7605,8 +7611,10 @@ export type ConsumerAccountResolvers<ContextType = any, ParentType extends Resol
   defaultWallet?: Resolver<ResolversTypes['PublicWallet'], ParentType, ContextType>;
   defaultWalletId?: Resolver<ResolversTypes['WalletId'], ParentType, ContextType>;
   displayCurrency?: Resolver<ResolversTypes['DisplayCurrency'], ParentType, ContextType>;
+  firstName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   invoices?: Resolver<Maybe<ResolversTypes['InvoiceConnection']>, ParentType, ContextType, Partial<ConsumerAccountInvoicesArgs>>;
+  lastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   level?: Resolver<ResolversTypes['AccountLevel'], ParentType, ContextType>;
   limits?: Resolver<ResolversTypes['AccountLimits'], ParentType, ContextType>;
   notificationSettings?: Resolver<ResolversTypes['NotificationSettings'], ParentType, ContextType>;

--- a/app/screens/people-screen/circles/circles-dashboard-screen.tsx
+++ b/app/screens/people-screen/circles/circles-dashboard-screen.tsx
@@ -22,6 +22,7 @@ import { DecemberChallengeCard } from "@app/components/december-challenge"
 gql`
   query Circles {
     me {
+      id
       username
       defaultAccount {
         id

--- a/app/screens/people-screen/circles/invite-friends-card.tsx
+++ b/app/screens/people-screen/circles/invite-friends-card.tsx
@@ -17,6 +17,7 @@ import { PressableCard } from "@app/components/pressable-card"
 gql`
   query invite {
     me {
+      id
       username
     }
   }

--- a/app/screens/totp-screen/totp-registration-initiate.tsx
+++ b/app/screens/totp-screen/totp-registration-initiate.tsx
@@ -31,6 +31,7 @@ const generateOtpAuthURI = (
 gql`
   query totpRegistrationScreen {
     me {
+      id
       username
     }
   }

--- a/app/screens/totp-screen/totp-registration-validate.tsx
+++ b/app/screens/totp-screen/totp-registration-validate.tsx
@@ -19,6 +19,7 @@ gql`
         message
       }
       me {
+        id
         totpEnabled
         phone
         email {

--- a/supergraph.graphql
+++ b/supergraph.graphql
@@ -1230,7 +1230,6 @@ type OnboardingFlowStartResult
   workflowRunId: String!
   tokenAndroid: String!
   tokenIos: String!
-  tokenWeb: String!
 }
 
 enum OnboardingStatus


### PR DESCRIPTION
Steps to reproduce the original issue:
- Go to `AllContactsScreen`
- Click back button

The cause:
- The cache was being overwritten by queries without the object id present, this was causing the `contacts` field of me to be undefined when clicking back on the `AllContactsScreen`, `slice()` was then called on `undefined` leading to an error being thrown
- It is also a symptom of using `cache-and-network` fetch policy hiding type issues for when the cache is corrupted or altered by a different query

Fix:
- add `id` field to gql queries