### PR TITLE
chore: make deconnection on 401 more rapid

### DIFF
--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -187,13 +187,13 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
 
       const retry401ErrorLink = new RetryLink({
         attempts: {
-          max: 3,
+          max: 2,
           retryIf: (error) => {
             return error && error.statusCode === 401
           },
         },
         delay: {
-          initial: 20000, // Initial delay in milliseconds (20 seconds)
+          initial: 5000, // Initial delay in milliseconds (20 seconds)
           max: Infinity,
           jitter: false,
         },


### PR DESCRIPTION
I don't think we have had many 401 issue with kratos lately. this has arise in the past where kratos has issue connecting with the associated postgres, kratos was returning 401 (this bug has been reported but not fixed)

the benefits of reducing the retry/initial delay is that when doing some local development, or also when loging out, if there is an issue with the token, there won't be promise that trigger out of the blue and deconnect back the user one minutes after he had log out/log back in. as may be the case today.

also the reason I think that is ok for going to those settings now, is that, with email now here for many months, it is less an issue if a 401 ever appears compare to if we had a phone only login method