### PR TITLE
fix: toasts now have responsive height

### DIFF
--- a/app/components/galoy-toast/galoy-toast.tsx
+++ b/app/components/galoy-toast/galoy-toast.tsx
@@ -19,6 +19,10 @@ const styles = {
     fontSize: 14,
     color: light._black,
   },
+  container: {
+    height: undefined,
+    paddingVertical: 5,
+  },
 }
 
 const toastConfig = {
@@ -26,7 +30,7 @@ const toastConfig = {
     <SuccessToast
       {...props}
       text2NumberOfLines={2}
-      style={{ borderLeftColor: light._green }}
+      style={[{ borderLeftColor: light._green }, styles.container]}
       text1Style={styles.text1StyleSuccess}
       text2Style={styles.text2Style}
     />
@@ -35,7 +39,7 @@ const toastConfig = {
     <ErrorToast
       {...props}
       text2NumberOfLines={2}
-      style={{ borderLeftColor: light.red }}
+      style={[{ borderLeftColor: light.red }, styles.container]}
       text1Style={styles.text1StyleError}
       text2Style={styles.text2Style}
     />


### PR DESCRIPTION
Fixes #2947 

Toasts have responsive height now instead of static. Added some vertical padding to ensure smaller toasts look nice

![responsive-2](https://github.com/GaloyMoney/galoy-mobile/assets/51105802/9cf1deda-4c95-4a40-bb29-ea09f9f3ea1a)
