### PR TITLE
fix: bitcoin address on receive payment screen can use ellipsis

### DIFF
--- a/app/screens/receive-bitcoin-screen/receive-screen.tsx
+++ b/app/screens/receive-bitcoin-screen/receive-screen.tsx
@@ -198,11 +198,11 @@ const ReceiveScreen = () => {
             )}
         </View>
 
-        <TouchableOpacity onPress={request.copyToClipboard}>
-          <View style={styles.extraDetails}>
-            {request.readablePaymentRequest ? (
-              request.type === Invoice.OnChain ? (
-                <View style={styles.btcHighContainer}>
+        <TouchableOpacity style={styles.extraDetails} onPress={request.copyToClipboard}>
+          {request.readablePaymentRequest ? (
+            request.type === Invoice.OnChain ? (
+              <View style={styles.btcHighContainer}>
+                <Text ellipsizeMode="middle" numberOfLines={1}>
                   <Text style={styles.btcHigh}>
                     {request.readablePaymentRequest.slice(0, 6)}
                   </Text>
@@ -215,16 +215,16 @@ const ReceiveScreen = () => {
                   <Text style={styles.btcHigh}>
                     {request.readablePaymentRequest.slice(-6)}
                   </Text>
-                </View>
-              ) : (
-                <Text {...testProps("readable-payment-request")}>
-                  {request.readablePaymentRequest}
                 </Text>
-              )
+              </View>
             ) : (
-              <></>
-            )}
-          </View>
+              <Text {...testProps("readable-payment-request")}>
+                {request.readablePaymentRequest}
+              </Text>
+            )
+          ) : (
+            <></>
+          )}
         </TouchableOpacity>
 
         <ButtonGroup


### PR DESCRIPTION
Fixes #2939 

As you can see below, there's several other fields that need to be fixed for boomer text. Nonetheless, this fixes the section that was requested in the issue.

![responsive-1](https://github.com/GaloyMoney/galoy-mobile/assets/51105802/7d06d5c8-b61f-4001-9273-c3f9924f09e8)


