### PR TITLE
feat: added confirm modal before logout

### DIFF
--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -968,6 +968,8 @@ export type Mutation = {
   readonly onChainUsdPaymentSend: PaymentSendPayload;
   readonly onChainUsdPaymentSendAsBtcDenominated: PaymentSendPayload;
   readonly onboardingFlowStart: OnboardingFlowStartResult;
+  readonly quizClaim: QuizClaimPayload;
+  /** @deprecated Use quizClaim instead */
   readonly quizCompleted: QuizCompletedPayload;
   /** @deprecated will be moved to AccountContact */
   readonly userContactUpdateAlias: UserContactUpdateAliasPayload;
@@ -1176,6 +1178,11 @@ export type MutationOnChainUsdPaymentSendAsBtcDenominatedArgs = {
 
 export type MutationOnboardingFlowStartArgs = {
   input: OnboardingFlowStartInput;
+};
+
+
+export type MutationQuizClaimArgs = {
+  input: QuizClaimInput;
 };
 
 
@@ -1593,6 +1600,17 @@ export type Quiz = {
   readonly amount: Scalars['SatAmount']['output'];
   readonly completed: Scalars['Boolean']['output'];
   readonly id: Scalars['ID']['output'];
+  readonly notBefore?: Maybe<Scalars['Timestamp']['output']>;
+};
+
+export type QuizClaimInput = {
+  readonly id: Scalars['ID']['input'];
+};
+
+export type QuizClaimPayload = {
+  readonly __typename: 'QuizClaimPayload';
+  readonly errors: ReadonlyArray<Error>;
+  readonly quizzes: ReadonlyArray<Quiz>;
 };
 
 export type QuizCompletedInput = {
@@ -7155,6 +7173,8 @@ export type ResolversTypes = {
   PublicWallet: ResolverTypeWrapper<PublicWallet>;
   Query: ResolverTypeWrapper<{}>;
   Quiz: ResolverTypeWrapper<Quiz>;
+  QuizClaimInput: QuizClaimInput;
+  QuizClaimPayload: ResolverTypeWrapper<QuizClaimPayload>;
   QuizCompletedInput: QuizCompletedInput;
   QuizCompletedPayload: ResolverTypeWrapper<QuizCompletedPayload>;
   RealtimePrice: ResolverTypeWrapper<RealtimePrice>;
@@ -7359,6 +7379,8 @@ export type ResolversParentTypes = {
   PublicWallet: PublicWallet;
   Query: {};
   Quiz: Quiz;
+  QuizClaimInput: QuizClaimInput;
+  QuizClaimPayload: QuizClaimPayload;
   QuizCompletedInput: QuizCompletedInput;
   QuizCompletedPayload: QuizCompletedPayload;
   RealtimePrice: RealtimePrice;
@@ -7905,6 +7927,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   onChainUsdPaymentSend?: Resolver<ResolversTypes['PaymentSendPayload'], ParentType, ContextType, RequireFields<MutationOnChainUsdPaymentSendArgs, 'input'>>;
   onChainUsdPaymentSendAsBtcDenominated?: Resolver<ResolversTypes['PaymentSendPayload'], ParentType, ContextType, RequireFields<MutationOnChainUsdPaymentSendAsBtcDenominatedArgs, 'input'>>;
   onboardingFlowStart?: Resolver<ResolversTypes['OnboardingFlowStartResult'], ParentType, ContextType, RequireFields<MutationOnboardingFlowStartArgs, 'input'>>;
+  quizClaim?: Resolver<ResolversTypes['QuizClaimPayload'], ParentType, ContextType, RequireFields<MutationQuizClaimArgs, 'input'>>;
   quizCompleted?: Resolver<ResolversTypes['QuizCompletedPayload'], ParentType, ContextType, RequireFields<MutationQuizCompletedArgs, 'input'>>;
   userContactUpdateAlias?: Resolver<ResolversTypes['UserContactUpdateAliasPayload'], ParentType, ContextType, RequireFields<MutationUserContactUpdateAliasArgs, 'input'>>;
   userEmailDelete?: Resolver<ResolversTypes['UserEmailDeletePayload'], ParentType, ContextType>;
@@ -8109,6 +8132,13 @@ export type QuizResolvers<ContextType = any, ParentType extends ResolversParentT
   amount?: Resolver<ResolversTypes['SatAmount'], ParentType, ContextType>;
   completed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  notBefore?: Resolver<Maybe<ResolversTypes['Timestamp']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type QuizClaimPayloadResolvers<ContextType = any, ParentType extends ResolversParentTypes['QuizClaimPayload'] = ResolversParentTypes['QuizClaimPayload']> = {
+  errors?: Resolver<ReadonlyArray<ResolversTypes['Error']>, ParentType, ContextType>;
+  quizzes?: Resolver<ReadonlyArray<ResolversTypes['Quiz']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -8499,6 +8529,7 @@ export type Resolvers<ContextType = any> = {
   PublicWallet?: PublicWalletResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Quiz?: QuizResolvers<ContextType>;
+  QuizClaimPayload?: QuizClaimPayloadResolvers<ContextType>;
   QuizCompletedPayload?: QuizCompletedPayloadResolvers<ContextType>;
   RealtimePrice?: RealtimePriceResolvers<ContextType>;
   RealtimePricePayload?: RealtimePricePayloadResolvers<ContextType>;

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -45,6 +45,7 @@ const en: BaseTranslation = {
     skip: "Skip",
     unlock: "Unlock",
     usePin: "Use PIN",
+    confirmLogout: "Are you sure you'd like to logout? This will reset your cache and all local user settings",
   },
   PeopleScreen: {
     title: "People",

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -45,7 +45,7 @@ const en: BaseTranslation = {
     skip: "Skip",
     unlock: "Unlock",
     usePin: "Use PIN",
-    confirmLogout: "Are you sure you'd like to logout? This will reset your cache and all local user settings",
+    confirmLogout: "Are you sure you'd like to log out? This will reset your cache and all local user settings",
   },
   PeopleScreen: {
     title: "People",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -171,6 +171,10 @@ type RootTranslation = {
 		 * U​s​e​ ​P​I​N
 		 */
 		usePin: string
+		/**
+		 * A​r​e​ ​y​o​u​ ​s​u​r​e​ ​y​o​u​'​d​ ​l​i​k​e​ ​t​o​ ​l​o​g​o​u​t​?​ ​T​h​i​s​ ​w​i​l​l​ ​r​e​s​e​t​ ​y​o​u​r​ ​c​a​c​h​e​ ​a​n​d​ ​a​l​l​ ​l​o​c​a​l​ ​u​s​e​r​ ​s​e​t​t​i​n​g​s
+		 */
+		confirmLogout: string
 	}
 	PeopleScreen: {
 		/**
@@ -9000,6 +9004,10 @@ export type TranslationFunctions = {
 		 * Use PIN
 		 */
 		usePin: () => LocalizedString
+		/**
+		 * Are you sure you'd like to logout? This will reset your cache and all local user settings
+		 */
+		confirmLogout: () => LocalizedString
 	}
 	PeopleScreen: {
 		/**

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -172,7 +172,7 @@ type RootTranslation = {
 		 */
 		usePin: string
 		/**
-		 * A​r​e​ ​y​o​u​ ​s​u​r​e​ ​y​o​u​'​d​ ​l​i​k​e​ ​t​o​ ​l​o​g​o​u​t​?​ ​T​h​i​s​ ​w​i​l​l​ ​r​e​s​e​t​ ​y​o​u​r​ ​c​a​c​h​e​ ​a​n​d​ ​a​l​l​ ​l​o​c​a​l​ ​u​s​e​r​ ​s​e​t​t​i​n​g​s
+		 * A​r​e​ ​y​o​u​ ​s​u​r​e​ ​y​o​u​'​d​ ​l​i​k​e​ ​t​o​ ​l​o​g​ ​o​u​t​?​ ​T​h​i​s​ ​w​i​l​l​ ​r​e​s​e​t​ ​y​o​u​r​ ​c​a​c​h​e​ ​a​n​d​ ​a​l​l​ ​l​o​c​a​l​ ​u​s​e​r​ ​s​e​t​t​i​n​g​s
 		 */
 		confirmLogout: string
 	}
@@ -9005,7 +9005,7 @@ export type TranslationFunctions = {
 		 */
 		usePin: () => LocalizedString
 		/**
-		 * Are you sure you'd like to logout? This will reset your cache and all local user settings
+		 * Are you sure you'd like to log out? This will reset your cache and all local user settings
 		 */
 		confirmLogout: () => LocalizedString
 	}

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -35,7 +35,8 @@
         "setUpAuthenticationDescription": "Use biometric to authenticate",
         "skip": "Skip",
         "unlock": "Unlock",
-        "usePin": "Use PIN"
+        "usePin": "Use PIN",
+        "confirmLogout": "Are you sure you'd like to logout? This will reset your cache and all local user settings"
     },
     "PeopleScreen": {
         "title": "People",

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -36,7 +36,7 @@
         "skip": "Skip",
         "unlock": "Unlock",
         "usePin": "Use PIN",
-        "confirmLogout": "Are you sure you'd like to logout? This will reset your cache and all local user settings"
+        "confirmLogout": "Are you sure you'd like to log out? This will reset your cache and all local user settings"
     },
     "PeopleScreen": {
         "title": "People",

--- a/app/screens/authentication-screen/authentication-screen.tsx
+++ b/app/screens/authentication-screen/authentication-screen.tsx
@@ -1,4 +1,4 @@
-import { RouteProp, useFocusEffect, useNavigation } from "@react-navigation/native"
+import { RouteProp, useNavigation } from "@react-navigation/native"
 import * as React from "react"
 import { Alert, View } from "react-native"
 
@@ -37,10 +37,6 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
   const { setAppUnlocked } = useAuthenticationContext()
   const { LL } = useI18nContext()
 
-  React.useEffect(() => {
-    attemptAuthentication()
-  }, [])
-
   const attemptAuthentication = () => {
     let description = "attemptAuthentication. should not be displayed?"
     if (screenPurpose === AuthenticationScreenPurpose.Authenticate) {
@@ -65,6 +61,11 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
     setAppUnlocked()
     navigation.replace("Primary")
   }
+  
+  React.useEffect(() => {
+    attemptAuthentication()
+  }, [attemptAuthentication])
+
 
   const handleAuthenticationFailure = () => {
     // This is called when a user cancels or taps out of the authentication prompt,

--- a/app/screens/authentication-screen/authentication-screen.tsx
+++ b/app/screens/authentication-screen/authentication-screen.tsx
@@ -37,9 +37,9 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
   const { setAppUnlocked } = useAuthenticationContext()
   const { LL } = useI18nContext()
 
-  useFocusEffect(() => {
+  React.useEffect(() => {
     attemptAuthentication()
-  })
+  }, [])
 
   const attemptAuthentication = () => {
     let description = "attemptAuthentication. should not be displayed?"
@@ -71,14 +71,26 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
     // so no action is necessary.
   }
 
-  const logoutAndNavigateToPrimary = async () => {
+  const logoutAndNavigateToLanding = async () => {
     await logout()
-    Alert.alert(LL.common.loggedOut(), "", [
+    Alert.alert(LL.common.logout(), LL.common.loggedOut(), [
       {
         text: LL.common.ok(),
         onPress: () => {
-          navigation.replace("Primary")
+          navigation.replace("getStarted")
         },
+      },
+    ])
+  }
+
+  const confirmLogout = () => {
+    Alert.alert(LL.common.confirm(), LL.AuthenticationScreen.confirmLogout(), [
+      {
+        text: LL.common.cancel(),
+      },
+      {
+        text: LL.common.confirm(),
+        onPress: logoutAndNavigateToLanding,
       },
     ])
   }
@@ -106,7 +118,7 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
         {PinButtonContent}
         <GaloySecondaryButton
           title={LL.common.logout()}
-          onPress={logoutAndNavigateToPrimary}
+          onPress={confirmLogout}
           containerStyle={styles.buttonContainer}
         />
       </>


### PR DESCRIPTION
Fixes #2871. Also went ahead and made the 3 minor changes/bugfixes I suggested in https://github.com/GaloyMoney/galoy-mobile/issues/2871#issuecomment-1869816859. For the 3rd one I opted to add an informative message to the confirmation modal that logging out will clear the user's cache and user settings. 