### PR TITLE
feat: pressing contact immediately goes to next screen

### DIFF
--- a/app/components/payment-destination-display/payment-destination-display.tsx
+++ b/app/components/payment-destination-display/payment-destination-display.tsx
@@ -34,7 +34,12 @@ export const PaymentDestinationDisplay = ({
 
   if (destination.length < 40) {
     return (
-      <Text type="p1" numberOfLines={1} ellipsizeMode={"middle"}>
+      <Text
+        type="p1"
+        numberOfLines={1}
+        ellipsizeMode={"middle"}
+        style={styles.primaryTextStyle}
+      >
         {destination}
         {paymentType === "intraledger" ? `@${lnDomain}` : ""}
       </Text>

--- a/app/screens/send-bitcoin-screen/destination-information.tsx
+++ b/app/screens/send-bitcoin-screen/destination-information.tsx
@@ -163,6 +163,7 @@ const useStyles = makeStyles(() => ({
     flexDirection: "row",
     alignItems: "center",
     flexWrap: "wrap",
+    marginTop: 5,
   },
   informationText: {
     paddingLeft: 2,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -365,24 +365,15 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
         waitAndValidateDestination(input)
       }
     },
-    [
-      willInitiateValidation,
-      waitAndValidateDestination,
-      destinationState.unparsedDestination,
-    ],
+    [willInitiateValidation, waitAndValidateDestination],
   )
 
   useEffect(() => {
-    if (route.params?.payment) {
+    if (route.params?.autoValidate && route.params.payment) {
       handleChangeText(route.params?.payment)
+      initiateGoToNextScreen(route.params.payment)
     }
-  }, [route.params?.payment, handleChangeText])
-
-  useEffect(() => {
-    if (route.params?.autoValidate) {
-      initiateGoToNextScreen(destinationState.unparsedDestination)
-    }
-  }, [route.params?.autoValidate, initiateGoToNextScreen])
+  }, [route.params, initiateGoToNextScreen, handleChangeText])
 
   useEffect(() => {
     // If we scan a QR code encoded with a payment url for a specific user e.g. https://{domain}/{username}


### PR DESCRIPTION
Addresses #2979 

Plus three other minor ui fixes:
- marginBottom on destination input shouldn't be there. Moved it to marginTop for the error message and the contacts list
- flex: 1 for destination input field in both scenarios (short and long text). Ensures copy button is at the far end of the container
- contact should deselect when a QR code or a Paste is done

Should note that the refactor required for the destination input to be sent as a parameter. The **autovalidation** flow was slightly refactored to follow suit, as well as normal presses of the 'Next' button. They manually input **route.params.payment** or **destinationState.unparsedDestination** respectively now.