### PR TITLE
chore: improve deep linking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
             <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="lightning"/>
             <data android:scheme="bitcoinbeach"/>
+            <data android:scheme="blink"/>
             <data android:scheme="bitcoin"/>
             <data android:scheme="lapp"/>
         </intent-filter>

--- a/app/config/appinfo.ts
+++ b/app/config/appinfo.ts
@@ -9,6 +9,7 @@ export const PREFIX_LINKING = [
   "https://pay.bbw.sv",
   "https://pay.blink.sv",
   "bitcoinbeach://",
+  "blink://",
 ]
 
 // FIXME this should come from globals.lightningAddressDomainAliases

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -83,12 +83,17 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
     prefixes: [...PREFIX_LINKING, "bitcoin://", "lightning://", "lapp://"],
     config: {
       screens: {
-        sendBitcoinDestination: ":payment",
         Primary: {
           screens: {
-            Home: "/",
+            Home: "home",
+            People: {
+              screens: {
+                circlesDashboard: "circles",
+              },
+            },
           },
         },
+        sendBitcoinDestination: ":payment",
       },
     },
     getInitialURL: async () => {

--- a/ios/GaloyApp/Info.plist
+++ b/ios/GaloyApp/Info.plist
@@ -40,6 +40,7 @@
 				<string>lightning</string>
 				<string>bitcoin</string>
 				<string>bitcoinbeach</string>
+				<string>blink</string>
 				<string>lapp</string>
 			</array>
 		</dict>


### PR DESCRIPTION
With this, if you do `blink://circles` you will get inside the circles screen directly.
This pattern can also be used to [useLinkTo](https://reactnavigation.org/docs/use-link-to) any screen with push notifications.