### PR TITLE
fix: fastlane issue with app store upload

### DIFF
--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 ruby '2.7.7'
 
-gem 'fastlane', '2.212.1'
+gem 'fastlane', '2.213.0'
 gem 'cocoapods', '~> 1.14', '>= 1.14.3'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')


### PR DESCRIPTION
App Store Upload was causing error: "A parameter has an invalid value - 'prices' is not a valid relationship name"

Fixed using https://github.com/fastlane/fastlane/issues/21819