### PR TITLE
chore: deep link all pages

### DIFF
--- a/app/components/push-notification/push-notification.tsx
+++ b/app/components/push-notification/push-notification.tsx
@@ -1,13 +1,8 @@
 import { useApolloClient } from "@apollo/client"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
-import {
-  PeopleStackParamList,
-  PrimaryStackParamList,
-} from "@app/navigation/stack-param-lists"
 import { addDeviceToken, hasNotificationPermission } from "@app/utils/notifications"
 import messaging, { FirebaseMessagingTypes } from "@react-native-firebase/messaging"
-import { useNavigation } from "@react-navigation/native"
-import { StackNavigationProp } from "@react-navigation/stack"
+import { useLinkTo } from "@react-navigation/native"
 import React, { useEffect } from "react"
 
 const circlesNotificationTypes = [
@@ -24,8 +19,8 @@ const circlesNotificationTypes = [
 export const PushNotificationComponent = (): JSX.Element => {
   const client = useApolloClient()
   const isAuthed = useIsAuthed()
-  const primaryNavigation = useNavigation<StackNavigationProp<PrimaryStackParamList>>()
-  const circlesNavigation = useNavigation<StackNavigationProp<PeopleStackParamList>>()
+
+  const linkTo = useLinkTo()
 
   useEffect(() => {
     const showNotification = (remoteMessage: FirebaseMessagingTypes.RemoteMessage) => {
@@ -42,8 +37,12 @@ export const PushNotificationComponent = (): JSX.Element => {
         typeof notificationType === "string" &&
         circlesNotificationTypes.includes(notificationType)
       ) {
-        primaryNavigation.navigate("People")
-        setTimeout(() => circlesNavigation.navigate("circlesDashboard"), 200)
+        linkTo("/people/circles")
+      }
+
+      const linkToScreen = remoteMessage.data?.linkTo ?? ""
+      if (typeof linkToScreen === "string") {
+        linkTo(linkToScreen)
       }
     }
 
@@ -69,7 +68,7 @@ export const PushNotificationComponent = (): JSX.Element => {
       })
 
     return unsubscribe
-  }, [circlesNavigation, primaryNavigation])
+  }, [linkTo])
 
   useEffect(() => {
     ;(async () => {

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -87,13 +87,22 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
           screens: {
             Home: "home",
             People: {
+              path: "people",
               screens: {
                 circlesDashboard: "circles",
               },
             },
+            Earn: "earn",
+            Map: "map",
           },
         },
         sendBitcoinDestination: ":payment",
+        receiveBitcoin: "receive",
+        conversionDetails: "convert",
+        scanningQRCode: "scan-qr",
+        transactionDetail: {
+          path: "transaction/:txid",
+        },
       },
     },
     getInitialURL: async () => {


### PR DESCRIPTION
With this PR, you can send an extra `linkTo` in the data of the notification packet to open the specific screen.

---

Builds on https://github.com/GaloyMoney/galoy-mobile/pull/3004#issuecomment-1894172245

@agbegin With this we can do the following deep links:

| Link | Screen |
|---|---|
| blink://home | Home Tab |
| blink://people | People Tab |
| blink://people/circles | Circles Screen |
| blink://earn | Earn Screen |
| blink://map | Map Screen |
| blink://receive | Receive Screen |
| blink://convert | Conversion Screen |
| blink://scan-qr | Scan QR Screen |
| blink://transaction/:txid | Transaction Screen with the User's Transaction ID (Blink Internal ID) |
| blink://:address | Send to Bitcoin Onchain Address / LNURL Address |

Do you guys feel there are any more screen needed to deeplink?