### PR TITLE
fix: webview back button, webview dark-mode on android

### DIFF
--- a/app/screens/webview/webview.tsx
+++ b/app/screens/webview/webview.tsx
@@ -1,13 +1,14 @@
 import { StackNavigationProp } from "@react-navigation/stack"
 import * as React from "react"
-import { Alert, Button } from "react-native"
+import { Alert, TouchableOpacity } from "react-native"
 import { injectJs, onMessageHandler } from "react-native-webln"
 import { WebView, WebViewNavigation } from "react-native-webview"
 import { Screen } from "../../components/screen"
 import { RootStackParamList } from "../../navigation/stack-param-lists"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { makeStyles } from "@rneui/themed"
+import { makeStyles, useTheme } from "@rneui/themed"
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 
 type WebViewDebugScreenRouteProp = RouteProp<RootStackParamList, "webView">
 
@@ -28,6 +29,10 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
   const navigation = useNavigation()
   const [canGoBack, setCanGoBack] = React.useState<boolean>(false)
 
+  const {
+    theme: { colors, mode },
+  } = useTheme()
+
   const handleBackPress = React.useCallback(() => {
     if (webview.current && canGoBack) {
       webview.current.goBack()
@@ -45,15 +50,34 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
   React.useEffect(() => {
     navigation.setOptions({
       headerLeft: () => (
-        //                                  FIXME < is not the same as for other screens
-        <Button onPress={handleBackPress} title={`< ${LL.common.back()}`} />
+        <TouchableOpacity style={styles.iconContainer} onPress={handleBackPress}>
+          <GaloyIcon
+            name="caret-left"
+            size={20}
+            color={mode === "light" ? colors.black : colors._white}
+          />
+        </TouchableOpacity>
       ),
     })
-  }, [navigation, handleBackPress, LL])
+  }, [
+    navigation,
+    handleBackPress,
+    LL,
+    mode,
+    colors.black,
+    colors._white,
+    styles.iconContainer,
+  ])
 
   const handleWebViewNavigationStateChange = (newNavState: WebViewNavigation) => {
     setCanGoBack(newNavState.canGoBack)
     newNavState.title && navigation.setOptions({ title: newNavState.title })
+  }
+
+  const injectThemeJs = () => {
+    return `
+      document.body.setAttribute("data-theme", "${mode}");
+    `
   }
 
   return (
@@ -65,6 +89,7 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
         onLoadProgress={(e) => {
           if (!jsInjected && e.nativeEvent.progress > 0.75) {
             if (webview.current) {
+              webview.current.injectJavaScript(injectThemeJs())
               webview.current.injectJavaScript(injectJs())
               setJsInjected(true)
             } else Alert.alert("Error", "Webview not ready")
@@ -118,4 +143,7 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
 
 const useStyles = makeStyles(({ colors }) => ({
   full: { width: "100%", height: "100%", flex: 1, backgroundColor: colors.transparent },
+  iconContainer: {
+    marginLeft: 10,
+  },
 }))

--- a/app/screens/webview/webview.tsx
+++ b/app/screens/webview/webview.tsx
@@ -55,15 +55,7 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
         </TouchableOpacity>
       ),
     })
-  }, [
-    navigation,
-    handleBackPress,
-    LL,
-    mode,
-    colors.black,
-    colors._white,
-    styles.iconContainer,
-  ])
+  }, [navigation, handleBackPress, LL, styles.iconContainer, colors.black])
 
   const handleWebViewNavigationStateChange = (newNavState: WebViewNavigation) => {
     setCanGoBack(newNavState.canGoBack)

--- a/app/screens/webview/webview.tsx
+++ b/app/screens/webview/webview.tsx
@@ -51,11 +51,7 @@ export const WebViewScreen: React.FC<Props> = ({ route }) => {
     navigation.setOptions({
       headerLeft: () => (
         <TouchableOpacity style={styles.iconContainer} onPress={handleBackPress}>
-          <GaloyIcon
-            name="caret-left"
-            size={20}
-            color={mode === "light" ? colors.black : colors._white}
-          />
+          <GaloyIcon name="caret-left" size={20} color={colors.black} />
         </TouchableOpacity>
       ),
     })


### PR DESCRIPTION
+ Fixed: Change WebView theme to match the app's theme. Previously, if the system theme was set to light but the app's theme was dark, the WebView theme would remain light. With this PR, the WebView theme will align with the app's theme.




<img width="300" alt="image" src="https://github.com/GaloyMoney/galoy-mobile/assets/59279771/f01e0094-419c-4b73-bb30-5e1cb18508e0"> 
 --- to --->

<img width="400" alt="image" src="https://github.com/GaloyMoney/galoy-mobile/assets/59279771/d2e8cebd-f14b-45a4-a8c7-dd5c9edd918f">



+ Fixed: Back button for webview.

<img width="300" alt="image" src="https://github.com/GaloyMoney/galoy-mobile/assets/59279771/5a3f4e0f-162e-4139-b481-2d9742f21521">