### PR TITLE
chore: update ios sdk used to build app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
 
   test_ios_in_pr:
     macos:
-      xcode: 14.2.0
+      xcode: 15.2.0
     resource_class: macos.x86.medium.gen2
     working_directory: ~/galoy-mobile
     environment:
@@ -224,7 +224,7 @@ jobs:
 
   build_ios:
     macos:
-      xcode: 14.2.0
+      xcode: 15.2.0
     resource_class: macos.x86.medium.gen2
     environment:
       PUBLIC_VERSION: << pipeline.parameters.version >>
@@ -296,7 +296,7 @@ jobs:
 
   upload_to_app_store:
     macos:
-      xcode: 14.2.0
+      xcode: 15.2.0
     resource_class: macos.x86.medium.gen2
     environment:
       GCS_URL: << pipeline.parameters.gcs_url >>


### PR DESCRIPTION
Addresses the following feedback received from App Store Connect:

<img width="689" alt="Screenshot 2024-02-20 at 11 33 16 AM" src="https://github.com/GaloyMoney/galoy-mobile/assets/40622610/22585664-a173-4701-a61a-3ce4d11b6987">
