### PR TITLE
Use RNSecureKeyStore for auth token persistent storage

### DIFF
--- a/app/hooks/use-logout.ts
+++ b/app/hooks/use-logout.ts
@@ -34,6 +34,7 @@ const useLogout = () => {
         await KeyStoreWrapper.removeIsBiometricsEnabled()
         await KeyStoreWrapper.removePin()
         await KeyStoreWrapper.removePinAttempts()
+        await KeyStoreWrapper.removeSecurePersitentState()
 
         logLogout()
         if (stateToDefault) {

--- a/app/store/persistent-state/index.tsx
+++ b/app/store/persistent-state/index.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, PropsWithChildren } from "react"
 import * as React from "react"
 
 import { loadJson, saveJson } from "@app/utils/storage"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 import {
   defaultPersistentState,
@@ -13,11 +14,14 @@ const PERSISTENT_STATE_KEY = "persistentState"
 
 const loadPersistentState = async (): Promise<PersistentState> => {
   const data = await loadJson(PERSISTENT_STATE_KEY)
-  return migrateAndGetPersistentState(data)
+  const secureData = await KeyStoreWrapper.getSecurePersitentState()
+  return migrateAndGetPersistentState({ ...data, ...secureData })
 }
 
 const savePersistentState = async (state: PersistentState) => {
-  return saveJson(PERSISTENT_STATE_KEY, state)
+  const { galoyAuthToken, ...data } = state
+  saveJson(PERSISTENT_STATE_KEY, data)
+  KeyStoreWrapper.setSecurePersitentState({ galoyAuthToken })
 }
 
 // TODO: should not be exported

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -108,6 +108,9 @@ const stateMigrations: StateMigrations = {
 }
 
 export type PersistentState = PersistentState_6
+export type SecurePersistentState = {
+  galoyAuthToken: string
+}
 
 export const defaultPersistentState: PersistentState = {
   schemaVersion: 6,

--- a/app/utils/storage/secureStorage.ts
+++ b/app/utils/storage/secureStorage.ts
@@ -1,9 +1,45 @@
 import RNSecureKeyStore, { ACCESSIBLE } from "react-native-secure-key-store"
 
+import { SecurePersistentState } from "@app/store/persistent-state/state-migrations"
+
 export default class KeyStoreWrapper {
   private static readonly IS_BIOMETRICS_ENABLED = "isBiometricsEnabled"
   private static readonly PIN = "PIN"
   private static readonly PIN_ATTEMPTS = "pinAttempts"
+  private static readonly SECURE_STATE = "secureState"
+
+  public static async getSecurePersitentState(): Promise<
+    SecurePersistentState | Record<string, never>
+  > {
+    try {
+      const data = await RNSecureKeyStore.get(KeyStoreWrapper.SECURE_STATE)
+      return JSON.parse(data)
+    } catch {
+      return {}
+    }
+  }
+
+  public static async setSecurePersitentState(
+    state: SecurePersistentState,
+  ): Promise<boolean> {
+    try {
+      await RNSecureKeyStore.set(KeyStoreWrapper.SECURE_STATE, JSON.stringify(state), {
+        accessible: ACCESSIBLE.ALWAYS_THIS_DEVICE_ONLY,
+      })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  public static async removeSecurePersitentState(): Promise<boolean> {
+    try {
+      await RNSecureKeyStore.remove(KeyStoreWrapper.SECURE_STATE)
+      return true
+    } catch {
+      return false
+    }
+  }
 
   public static async getIsBiometricsEnabled(): Promise<boolean> {
     try {


### PR DESCRIPTION
Related issue: https://github.com/GaloyMoney/galoy-mobile/issues/848

**KeyStoreWrapper** was extended to store/retrieve/remove secure state data.

- SecurePersistentState is a new subset type of PersistentState created to identify which keys of the persistent state should be stored securely
- When loading/saving persistent state the secure part is handled by KeyStore and non secure part keeps being handled by AsyncStorage
- After upgrading, the token will be loaded from AsyncStorage and immediately after loaded it will be persisted in secure storage and it will continue loading from there. This way users don't need to log back in.
- PersitentState type was not modified so migrations were not required