### PR TITLE
fix: confirm payment slider bug in rtl layouts

### DIFF
--- a/app/assets/icons-redesign/arrow-left.svg
+++ b/app/assets/icons-redesign/arrow-left.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20.25 12H3.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M10.5 5.25L3.75 12L10.5 18.75" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/app/components/atomic/galoy-icon/galoy-icon.tsx
+++ b/app/components/atomic/galoy-icon/galoy-icon.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { StyleProp, View, ViewStyle } from "react-native"
 
+import ArrowLeft from "@app/assets/icons-redesign/arrow-left.svg"
 import ArrowRight from "@app/assets/icons-redesign/arrow-right.svg"
 import BackSpace from "@app/assets/icons-redesign/back-space.svg"
 import Bank from "@app/assets/icons-redesign/bank.svg"
@@ -54,6 +55,7 @@ import { makeStyles, useTheme } from "@rneui/themed"
 
 export const icons = {
   "arrow-right": ArrowRight,
+  "arrow-left": ArrowLeft,
   "back-space": BackSpace,
   "bank": Bank,
   "bitcoin": Bitcoin,

--- a/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
+++ b/app/components/atomic/galoy-slider-button/galoy-slider-button.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react"
-import { ActivityIndicator, Dimensions, View } from "react-native"
+import { ActivityIndicator, Dimensions, View, I18nManager } from "react-native"
 import { PanGestureHandler } from "react-native-gesture-handler"
 import Animated, {
   Extrapolate,
@@ -21,6 +21,7 @@ import { GaloyIcon } from "../galoy-icon"
 
 const BUTTON_WIDTH = Dimensions.get("screen").width - 40
 const SWIPE_RANGE = BUTTON_WIDTH - 50
+const isRTL = I18nManager.isRTL
 
 type SwipeButtonPropsType = {
   onSwipe: () => void
@@ -53,7 +54,7 @@ const GaloySliderButton = ({
 
   const animatedGestureHandler = useAnimatedGestureHandler({
     onActive: (e) => {
-      const newValue = e.translationX
+      const newValue = Math.abs(e.translationX)
 
       if (newValue >= 0 && newValue <= SWIPE_RANGE) {
         X.value = newValue
@@ -70,34 +71,37 @@ const GaloySliderButton = ({
 
   const AnimatedStyles = {
     swipeButton: useAnimatedStyle(() => {
+      const translateX = interpolate(
+        X.value,
+        [20, BUTTON_WIDTH],
+        [0, BUTTON_WIDTH],
+        Extrapolation.CLAMP,
+      )
+
       return {
         transform: [
           {
-            translateX: interpolate(
-              X.value,
-              [20, BUTTON_WIDTH],
-              [0, BUTTON_WIDTH],
-              Extrapolation.CLAMP,
-            ),
+            translateX: isRTL ? -translateX : translateX,
           },
         ],
       }
-    }, [X]),
+    }, [X, isRTL]),
     swipeText: useAnimatedStyle(() => {
+      const translateX = interpolate(
+        X.value,
+        [20, SWIPE_RANGE],
+        [0, BUTTON_WIDTH / 3],
+        Extrapolate.CLAMP,
+      )
       return {
         opacity: interpolate(X.value, [0, BUTTON_WIDTH / 4], [1, 0], Extrapolate.CLAMP),
         transform: [
           {
-            translateX: interpolate(
-              X.value,
-              [20, SWIPE_RANGE],
-              [0, BUTTON_WIDTH / 3],
-              Extrapolate.CLAMP,
-            ),
+            translateX: isRTL ? -translateX : translateX,
           },
         ],
       }
-    }, [X]),
+    }, [X, isRTL]),
   }
 
   return (
@@ -116,7 +120,11 @@ const GaloySliderButton = ({
             ]}
             exiting={FadeOut.duration(400)}
           >
-            <GaloyIcon size={30} name="arrow-right" color="white" />
+            {isRTL ? (
+              <GaloyIcon size={30} name="arrow-left" color="white" />
+            ) : (
+              <GaloyIcon size={30} name="arrow-right" color="white" />
+            )}
           </Animated.View>
         </PanGestureHandler>
       )}


### PR DESCRIPTION
Fixes #3055 

I could reproduce the bug and slider button to confirm the transaction was stuck in the left corner.

Now, I have fixed this to move from the right to left direction, changed the button icon to the left arrow, and fixed the slider text animation.

Here is how it works now:

https://github.com/GaloyMoney/galoy-mobile/assets/17739006/fca2f433-8961-42aa-8877-3b50816258c4

