### PR TITLE
feat: Add link opening functionality in ScanningQRCodeScreen

### DIFF
--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -103,6 +103,10 @@ export const ScanningQRCodeScreen: React.FC = () => {
     }
   }, [hasPermission, requestPermission])
 
+  const loadInBrowser = (url: string) => {
+    Linking.openURL(url).catch((err) => console.error("Couldn't load page", err))
+  }
+
   const processInvoice = React.useMemo(() => {
     return async (data: string | undefined) => {
       if (pending || !wallets || !bitcoinNetwork || !data) {
@@ -143,23 +147,36 @@ export const ScanningQRCodeScreen: React.FC = () => {
           })
           return
         }
-
-        Alert.alert(
-          LL.ScanningQRCodeScreen.invalidTitle(),
-          destination.invalidReason === "InvoiceExpired"
-            ? LL.ScanningQRCodeScreen.expiredContent({
-                found: data.toString(),
-              })
-            : LL.ScanningQRCodeScreen.invalidContent({
+        destination.invalidReason === "InvoiceExpired"
+          ? Alert.alert(
+              LL.ScanningQRCodeScreen.invalidTitle(),
+              LL.ScanningQRCodeScreen.expiredContent({
                 found: data.toString(),
               }),
-          [
-            {
-              text: LL.common.ok(),
-              onPress: () => setPending(false),
-            },
-          ],
-        )
+              [
+                {
+                  text: LL.common.ok(),
+                  onPress: () => setPending(false),
+                },
+              ],
+            )
+          : Alert.alert(
+              "Open Link",
+              `${data.toString()}\n\nAre you sure you want to open this link?`,
+              [
+                {
+                  text: LL.common.No(),
+                  onPress: () => setPending(false),
+                },
+                {
+                  text: LL.common.yes(),
+                  onPress: () => {
+                    setPending(false)
+                    loadInBrowser(data.toString())
+                  },
+                },
+              ],
+            )
       } catch (err: unknown) {
         if (err instanceof Error) {
           crashlytics().recordError(err)


### PR DESCRIPTION
Fixes #3128 

Show an alert to open a URL when QR encodes a URL instead of showing an invalid address error.

![1711725474380](https://github.com/GaloyMoney/galoy-mobile/assets/17739006/6ce6a9bd-ded5-4453-b7dc-c44ff6ed380b)
