### PR TITLE
feat: Add link opening functionality in ScanningQRCodeScreen

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2173,6 +2173,8 @@ const en: BaseTranslation = {
       "We found:\n\n{found: string}\n\nThis is not a valid Bitcoin address or Lightning invoice",
     expiredContent: "We found:\n\n{found: string}\n\nThis invoice has expired",
     invalidTitle: "Invalid QR Code",
+    openLinkTitle: "Open Link",
+    confirmOpenLink: "Are you sure you want to open this link?",
     noQrCode: "We could not find a QR code in the image",
     title: "Scan QR",
     permissionCamera: "We need permission to use your camera",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6745,6 +6745,14 @@ type RootTranslation = {
 		 */
 		invalidTitle: string
 		/**
+		 * O​p​e​n​ ​L​i​n​k
+		 */
+		openLinkTitle: string
+		/**
+		 * A​r​e​ ​y​o​u​ ​s​u​r​e​ ​y​o​u​ ​w​a​n​t​ ​t​o​ ​o​p​e​n​ ​t​h​i​s​ ​l​i​n​k​?
+		 */
+		confirmOpenLink: string
+		/**
 		 * W​e​ ​c​o​u​l​d​ ​n​o​t​ ​f​i​n​d​ ​a​ ​Q​R​ ​c​o​d​e​ ​i​n​ ​t​h​e​ ​i​m​a​g​e
 		 */
 		noQrCode: string
@@ -15624,6 +15632,14 @@ export type TranslationFunctions = {
 		 * Invalid QR Code
 		 */
 		invalidTitle: () => LocalizedString
+		/**
+		 * Open Link
+		 */
+		openLinkTitle: () => LocalizedString
+		/**
+		 * Are you sure you want to open this link?
+		 */
+		confirmOpenLink: () => LocalizedString
 		/**
 		 * We could not find a QR code in the image
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2123,6 +2123,8 @@
         "invalidContent": "We found:\n\n{found: string}\n\nThis is not a valid Bitcoin address or Lightning invoice",
         "expiredContent": "We found:\n\n{found: string}\n\nThis invoice has expired",
         "invalidTitle": "Invalid QR Code",
+        "openLinkTitle": "Open Link",
+        "confirmOpenLink": "Are you sure you want to open this link?",
         "noQrCode": "We could not find a QR code in the image",
         "title": "Scan QR",
         "permissionCamera": "We need permission to use your camera",

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -161,8 +161,8 @@ export const ScanningQRCodeScreen: React.FC = () => {
               ],
             )
           : Alert.alert(
-              "Open Link",
-              `${data.toString()}\n\nAre you sure you want to open this link?`,
+              LL.ScanningQRCodeScreen.openLinkTitle(),
+              `${data.toString()}\n\n${LL.ScanningQRCodeScreen.confirmOpenLink()}`,
               [
                 {
                   text: LL.common.No(),

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -103,6 +103,10 @@ export const ScanningQRCodeScreen: React.FC = () => {
     }
   }, [hasPermission, requestPermission])
 
+  const loadInBrowser = (url: string) => {
+    Linking.openURL(url).catch((err) => console.error("Couldn't load page", err))
+  }
+
   const processInvoice = React.useMemo(() => {
     return async (data: string | undefined) => {
       if (pending || !wallets || !bitcoinNetwork || !data) {
@@ -143,23 +147,36 @@ export const ScanningQRCodeScreen: React.FC = () => {
           })
           return
         }
-
-        Alert.alert(
-          LL.ScanningQRCodeScreen.invalidTitle(),
-          destination.invalidReason === "InvoiceExpired"
-            ? LL.ScanningQRCodeScreen.expiredContent({
-                found: data.toString(),
-              })
-            : LL.ScanningQRCodeScreen.invalidContent({
+        destination.invalidReason === "InvoiceExpired"
+          ? Alert.alert(
+              LL.ScanningQRCodeScreen.invalidTitle(),
+              LL.ScanningQRCodeScreen.expiredContent({
                 found: data.toString(),
               }),
-          [
-            {
-              text: LL.common.ok(),
-              onPress: () => setPending(false),
-            },
-          ],
-        )
+              [
+                {
+                  text: LL.common.ok(),
+                  onPress: () => setPending(false),
+                },
+              ],
+            )
+          : Alert.alert(
+              "Open Link",
+              `${data.toString()}\n\nAre you sure you want to open this link?`,
+              [
+                {
+                  text: LL.common.No(),
+                  onPress: () => setPending(false),
+                },
+                {
+                  text: LL.common.yes(),
+                  onPress: () => {
+                    setPending(false)
+                    loadInBrowser(data.toString())
+                  },
+                },
+              ],
+            )
       } catch (err: unknown) {
         if (err instanceof Error) {
           crashlytics().recordError(err)


### PR DESCRIPTION
Fixes #3128

Show an alert to open a URL when QR encodes a URL instead of showing an invalid address error.

![1711725474380](https://github.com/GaloyMoney/galoy-mobile/assets/17739006/432eff37-592d-41bf-870b-731fca625d94)
