### PR TITLE
fix: border for circle card

### DIFF
--- a/app/components/invite-modal/invite-modal.tsx
+++ b/app/components/invite-modal/invite-modal.tsx
@@ -190,7 +190,7 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   cross: {},
   qrCard: {
-    backgroundColor: colors.black,
+    backgroundColor: colors._white,
     padding: 20,
     borderRadius: 12,
   },


### PR DESCRIPTION
fix #3204

cc @sandipndev @UncleSamtoshi border around QR code should always be white