### PR TITLE
fix: show ln address in all contacts screen

### DIFF
--- a/app/screens/people-screen/contacts/all-contacts.tsx
+++ b/app/screens/people-screen/contacts/all-contacts.tsx
@@ -12,6 +12,7 @@ import { useI18nContext } from "@app/i18n/i18n-react"
 import { PeopleStackParamList } from "@app/navigation/stack-param-lists"
 import { testProps } from "@app/utils/testProps"
 import { toastShow } from "@app/utils/toast"
+import { useAppConfig } from "@app/hooks"
 import { useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { SearchBar } from "@rneui/base"
@@ -37,6 +38,12 @@ export const AllContactsScreen: React.FC = () => {
   const {
     theme: { colors },
   } = useTheme()
+
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname },
+    },
+  } = useAppConfig()
 
   const navigation = useNavigation<StackNavigationProp<PeopleStackParamList>>()
 
@@ -165,19 +172,25 @@ export const AllContactsScreen: React.FC = () => {
         contentContainerStyle={styles.listContainer}
         data={matchingContacts}
         ListEmptyComponent={ListEmptyContent}
-        renderItem={({ item }) => (
-          <ListItem
-            key={item.handle}
-            style={styles.item}
-            containerStyle={styles.itemContainer}
-            onPress={() => navigation.navigate("contactDetail", { contact: item })}
-          >
-            <Icon name={"person-outline"} size={24} color={colors.primary} />
-            <ListItem.Content>
-              <ListItem.Title style={styles.itemText}>{item.alias}</ListItem.Title>
-            </ListItem.Content>
-          </ListItem>
-        )}
+        renderItem={({ item }) => {
+          const handle = item?.handle?.trim() ?? ""
+          const displayHandle =
+            handle && !handle.includes("@") ? `${handle}@${lnAddressHostname}` : handle
+
+          return (
+            <ListItem
+              key={item.handle}
+              style={styles.item}
+              containerStyle={styles.itemContainer}
+              onPress={() => navigation.navigate("contactDetail", { contact: item })}
+            >
+              <Icon name={"person-outline"} size={24} color={colors.primary} />
+              <ListItem.Content>
+                <ListItem.Title style={styles.itemText}>{displayHandle}</ListItem.Title>
+              </ListItem.Content>
+            </ListItem>
+          )
+        }}
         keyExtractor={(item) => item.handle}
       />
     </Screen>

--- a/app/screens/people-screen/contacts/contacts-card.tsx
+++ b/app/screens/people-screen/contacts/contacts-card.tsx
@@ -16,6 +16,7 @@ import {
   RootStackParamList,
 } from "@app/navigation/stack-param-lists"
 import { toastShow } from "@app/utils/toast"
+import { useAppConfig } from "@app/hooks"
 import { useNavigation } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { makeStyles, Text } from "@rneui/themed"
@@ -39,10 +40,19 @@ const Contact = ({ contact }: { contact: UserContact }) => {
   const styles = useStyles()
   const navigation = useNavigation<StackNavigationProp<PeopleStackParamList>>()
   const rootNavigation = navigation.getParent<StackNavigationProp<RootStackParamList>>()
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname },
+    },
+  } = useAppConfig()
+
+  const handle = contact?.handle?.trim() ?? ""
+  const displayHandle =
+    handle && !handle.includes("@") ? `${handle}@${lnAddressHostname}` : handle
 
   return (
     <View style={styles.contactContainer}>
-      <Text type="p1">{contact.handle}</Text>
+      <Text type="p1">{displayHandle}</Text>
       <GaloyIconButton
         onPress={() =>
           rootNavigation.navigate("sendBitcoinDestination", {


### PR DESCRIPTION
### Contacts Display in Blink

The application displays two types of contacts:

- **LN Address contacts**: These are Lightning Network addresses used for external payments.
- **Intra-ledger contacts**: These are internal Blink contacts that are shown with the domain `@blink.sv`.

This functionality is implemented in the following components:
- `contacts-card.tsx`
- `all-contacts.tsx`

<img width="2312" height="2016" alt="imagen" src="https://github.com/user-attachments/assets/7de4c46f-660f-4030-b292-153dbb141409" />
