### PR TITLE
fix: add missing .csv extension to exported transaction file (#3311)

### DIFF
--- a/app/screens/settings-screen/settings/advanced-export-csv.tsx
+++ b/app/screens/settings-screen/settings/advanced-export-csv.tsx
@@ -51,7 +51,7 @@ export const ExportCsvSetting: React.FC = () => {
     try {
       await Share.open({
         title: "blink-transactions",
-        filename: "blink-transactions",
+        filename: "blink-transactions.csv",
         url: `data:text/comma-separated-values;base64,${csvEncoded}`,
         type: "text/comma-separated-values",
       })


### PR DESCRIPTION
## Summary

Add the missing `.csv` extension to the exported transaction filename. When exporting transactions, the file was being saved as "blink-transactions" without an extension, causing confusion for users who needed to manually add it.

## Changes

- Updated `filename` property in `Share.open` call from `"blink-transactions"` to `"blink-transactions.csv"` in `advanced-export-csv.tsx`

## Testing

- Export transactions from Settings > Advanced > Export CSV
- Verify the saved file has `.csv` extension

## Related

Fixes #3311

---
Implementation plan: https://github.com/blinkbitcoin/blink-mobile/issues/3311#issuecomment-3706947218