### PR TITLE
fix: add workflow_run_id to webflow URL for Onfido support

### DIFF
--- a/app/screens/full-onboarding-flow/full-onboarding-flow.tsx
+++ b/app/screens/full-onboarding-flow/full-onboarding-flow.tsx
@@ -88,6 +88,7 @@ export const FullOnboardingFlowScreen: React.FC = () => {
       })
 
       const token = res.data?.kycFlowStart?.tokenWeb ?? ""
+      const workflowRunId = res.data?.kycFlowStart?.workflowRunId ?? ""
 
       const theme = mode === "dark" || mode === "light" ? mode : ""
 
@@ -97,7 +98,8 @@ export const FullOnboardingFlowScreen: React.FC = () => {
         ...(theme && { theme }),
       }).toString()
 
-      const url = `${kycUrl}/webflow?${query}`
+      const workflowRunIdParam = workflowRunId ? `&workflow_run_id=${workflowRunId}` : ""
+      const url = `${kycUrl}/webflow?${query}${workflowRunIdParam}`
 
       navigate("webView", {
         url,


### PR DESCRIPTION
## Summary
- Pass `workflow_run_id` from `kycFlowStart` mutation response to the webflow URL
- Required for Onfido KYC provider to link the SDK session to the workflow
- Harmless for Sumsub (the webflow ignores it when using Sumsub)
- Enables switching between KYC providers via backend `KYC_PROVIDER` env without mobile app changes

## Context
This change restores the `workflow_run_id` parameter that was present in v2.4.15 but removed in subsequent versions. The backend returns this value from both mutations, and Onfido requires it for proper workflow linking.

## Test plan
- [ ] Test with `KYC_PROVIDER=onfido` - verify workflow_run_id is passed and Onfido SDK works
- [ ] Test with `KYC_PROVIDER=sumsub` - verify workflow_run_id is passed but Sumsub still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)