### PR TITLE
fix: refetch notification count after acknowledging notification (#3337)

### DIFF
--- a/app/screens/notification-history-screen/notification.tsx
+++ b/app/screens/notification-history-screen/notification.tsx
@@ -1,6 +1,7 @@
 import {
   StatefulNotification,
   StatefulNotificationsDocument,
+  UnacknowledgedNotificationCountDocument,
   useStatefulNotificationAcknowledgeMutation,
 } from "@app/graphql/generated"
 import { Icon, Text, makeStyles, useTheme } from "@rn-vui/themed"
@@ -41,7 +42,7 @@ export const Notification: React.FC<StatefulNotification> = ({
 
   const [ack, _] = useStatefulNotificationAcknowledgeMutation({
     variables: { input: { notificationId: id } },
-    refetchQueries: [StatefulNotificationsDocument],
+    refetchQueries: [StatefulNotificationsDocument, UnacknowledgedNotificationCountDocument],
   })
 
   return (


### PR DESCRIPTION
## Summary

Fix the notification badge persistence issue on the Settings screen by adding `UnacknowledgedNotificationCountDocument` to the refetch queries when a notification is acknowledged.

## Changes

- Added `UnacknowledgedNotificationCountDocument` import from `@app/graphql/generated`
- Added this document to the `refetchQueries` array in `useStatefulNotificationAcknowledgeMutation`

## Root Cause

When a notification is acknowledged (tapped), the `StatefulNotificationAcknowledgeMutation` only refetched `StatefulNotificationsDocument` but not `UnacknowledgedNotificationCountDocument`. The Settings screen uses `UnacknowledgedNotificationCountQuery` to display the badge count, which remained stale after viewing notifications.

## Testing

- Navigate to Settings screen, note notification badge count
- Tap the notification icon to open notification history  
- Tap an unread notification to acknowledge it
- Navigate back to Settings screen
- Verify badge count decreases by 1 (or disappears if was 1)

## Related

Fixes #3337

---
Implementation plan: https://github.com/blinkbitcoin/blink-mobile/issues/3337#issuecomment-3708351676