### PR TITLE
revert: "feat: use server-side CAPTCHA bypass for staging"

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,15 +158,6 @@ RootStack (Stack Navigator)
 3. TOTP (authenticator app)
 4. Telegram Passport
 
-### Phone Authentication CAPTCHA Behavior
-
-| Environment | CAPTCHA Handling |
-|-------------|------------------|
-| Production | Geetest challenge shown, server validates |
-| Local/Staging | Dummy values sent ("bypass"), server-side `test_accounts_captcha` handles bypass |
-
-In test environments (Local/Staging), the app calls the API with dummy CAPTCHA values instead of showing the Geetest challenge. The server-side `test_accounts_captcha` config determines which phone numbers can bypass CAPTCHA validation.
-
 ## Bitcoin/Lightning Architecture
 
 ### Wallet Types


### PR DESCRIPTION
Reverts blinkbitcoin/blink-mobile#3588 because it blocks staging usage. Keep in mind staging is not only for our tests so the phone list strategy is not valid (I already try to test this from testflight version, we need to be able to create accounts without adding it to a list in backend)