### PR TITLE
fix(phone-input): ensure placeholder vertical alignment

### DIFF
--- a/app/components/phone-input/phone-input.tsx
+++ b/app/components/phone-input/phone-input.tsx
@@ -211,6 +211,7 @@ const useStyles = makeStyles(({ colors }, props: { bgColor?: string }) => ({
     marginLeft: 20,
     paddingLeft: 0,
     paddingRight: 0,
+    justifyContent: "center",
   },
   inputContainerStyle: {
     flex: 1,
@@ -219,6 +220,7 @@ const useStyles = makeStyles(({ colors }, props: { bgColor?: string }) => ({
     paddingHorizontal: 10,
     backgroundColor: props.bgColor || colors.grey5,
     borderRadius: 8,
+    justifyContent: "center",
   },
   disabledInput: { opacity: 0.6 },
 }))


### PR DESCRIPTION
## Summary
- Adds `justifyContent: "center"` to phone input container styles to ensure placeholder text is always vertically centered
- Fixes reported alignment issue on certain iOS devices

## Changes
- Added `justifyContent: "center"` to `inputComponentContainerStyle`
- Added `justifyContent: "center"` to `inputContainerStyle`