### PR TITLE
fix: support bitcoin and lightning links without //

### DIFF
--- a/__tests__/navigation/linking-prefixes.spec.ts
+++ b/__tests__/navigation/linking-prefixes.spec.ts
@@ -1,0 +1,9 @@
+import { COMPATIBLE_LINK_PREFIXES } from "@app/navigation/linking-prefixes"
+
+describe("compatible link prefixes", () => {
+  it("supports both single-colon and double-slash bitcoin/lightning schemes", () => {
+    expect(COMPATIBLE_LINK_PREFIXES).toEqual(
+      expect.arrayContaining(["bitcoin://", "bitcoin:", "lightning://", "lightning:"]),
+    )
+  })
+})

--- a/app/navigation/linking-prefixes.ts
+++ b/app/navigation/linking-prefixes.ts
@@ -1,0 +1,10 @@
+export const COMPATIBLE_LINK_PREFIXES = [
+  "bitcoin://",
+  "bitcoin:",
+  "lightning://",
+  "lightning:",
+  "lapp://",
+  "lnurlw://",
+  "lnurlp://",
+  "lnurl://",
+] as const

--- a/app/navigation/navigation-container-wrapper.tsx
+++ b/app/navigation/navigation-container-wrapper.tsx
@@ -18,6 +18,7 @@ import { RootStackParamList } from "./stack-param-lists"
 
 import { PREFIX_LINKING, TELEGRAM_CALLBACK_PATH } from "@app/config"
 import { Action, useActionsContext } from "@app/components/actions"
+import { COMPATIBLE_LINK_PREFIXES } from "@app/navigation/linking-prefixes"
 
 export type AuthenticationContextType = {
   isAppLocked: boolean
@@ -99,15 +100,7 @@ export const NavigationContainerWrapper: React.FC<React.PropsWithChildren> = ({
   }
 
   const linking: LinkingOptions<RootStackParamList> = {
-    prefixes: [
-      ...PREFIX_LINKING,
-      "bitcoin://",
-      "lightning://",
-      "lapp://",
-      "lnurlw://",
-      "lnurlp://",
-      "lnurl://",
-    ],
+    prefixes: [...PREFIX_LINKING, ...COMPATIBLE_LINK_PREFIXES],
     config: {
       screens: {
         Primary: {


### PR DESCRIPTION
## Summary
- add `bitcoin:` and `lightning:` deep-link prefixes while keeping existing `bitcoin://` and `lightning://`
- extract compatible payment prefixes into a dedicated navigation constant
- add a unit test to ensure both URI formats remain supported

## Context
Refs #8.
Some wallets/QR links use single-colon schemes (`bitcoin:...`, `lightning:...`), but navigation prefix matching only included `scheme://` variants.

## Testing
- `yarn test __tests__/navigation/linking-prefixes.spec.ts`
- `yarn test __tests__/screens/send-destination.spec.tsx -t "deep link payment processing"`
