### PR TITLE
fix: bulletin notification flickering


### DIFF
--- a/__tests__/components/push-notification.spec.tsx
+++ b/__tests__/components/push-notification.spec.tsx
@@ -1,0 +1,69 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import { PushNotificationComponent } from "@app/components/push-notification/push-notification"
+
+const mockRefetchQueries = jest.fn()
+jest.mock("@apollo/client", () => ({
+  useApolloClient: () => ({
+    refetchQueries: mockRefetchQueries,
+  }),
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  BulletinsDocument: "BulletinsDocument",
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => true,
+}))
+
+jest.mock("@app/utils/notifications", () => ({
+  hasNotificationPermission: jest.fn(() => Promise.resolve(false)),
+  addDeviceToken: jest.fn(),
+}))
+
+let onMessageCallback: (msg: Record<string, unknown>) => void
+const mockUnsubscribe = jest.fn()
+
+jest.mock("@react-native-firebase/messaging", () => {
+  const messagingFn = () => ({
+    onMessage: (cb: (msg: Record<string, unknown>) => void) => {
+      onMessageCallback = cb
+      return mockUnsubscribe
+    },
+    onNotificationOpenedApp: jest.fn(() => mockUnsubscribe),
+    getInitialNotification: jest.fn(() => Promise.resolve(null)),
+    onTokenRefresh: jest.fn(() => jest.fn()),
+  })
+  return {
+    __esModule: true,
+    default: messagingFn,
+  }
+})
+
+describe("PushNotificationComponent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders without crashing", () => {
+    render(<PushNotificationComponent />)
+  })
+
+  it("refetches bulletins when foreground message arrives", () => {
+    render(<PushNotificationComponent />)
+
+    onMessageCallback({ data: {}, notification: { title: "Test" } })
+
+    expect(mockRefetchQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ include: expect.any(Array) }),
+    )
+  })
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = render(<PushNotificationComponent />)
+    unmount()
+    expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/push-notification.spec.tsx
+++ b/__tests__/components/push-notification.spec.tsx
@@ -2,16 +2,14 @@ import React from "react"
 import { render } from "@testing-library/react-native"
 
 import { PushNotificationComponent } from "@app/components/push-notification/push-notification"
+import { BulletinsDocument } from "@app/graphql/generated"
 
 const mockRefetchQueries = jest.fn()
 jest.mock("@apollo/client", () => ({
+  ...jest.requireActual("@apollo/client"),
   useApolloClient: () => ({
     refetchQueries: mockRefetchQueries,
   }),
-}))
-
-jest.mock("@app/graphql/generated", () => ({
-  BulletinsDocument: "BulletinsDocument",
 }))
 
 jest.mock("@app/graphql/is-authed-context", () => ({
@@ -48,7 +46,7 @@ describe("PushNotificationComponent", () => {
   })
 
   it("renders without crashing", () => {
-    render(<PushNotificationComponent />)
+    expect(() => render(<PushNotificationComponent />)).not.toThrow()
   })
 
   it("refetches bulletins when foreground message arrives", () => {
@@ -56,9 +54,7 @@ describe("PushNotificationComponent", () => {
 
     onMessageCallback({ data: {}, notification: { title: "Test" } })
 
-    expect(mockRefetchQueries).toHaveBeenCalledWith(
-      expect.objectContaining({ include: expect.any(Array) }),
-    )
+    expect(mockRefetchQueries).toHaveBeenCalledWith({ include: [BulletinsDocument] })
   })
 
   it("unsubscribes on unmount", () => {

--- a/app/components/push-notification/push-notification.tsx
+++ b/app/components/push-notification/push-notification.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from "react"
 
 import { useApolloClient } from "@apollo/client"
+import { BulletinsDocument } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { addDeviceToken, hasNotificationPermission } from "@app/utils/notifications"
 import messaging, { FirebaseMessagingTypes } from "@react-native-firebase/messaging"
@@ -38,7 +39,7 @@ export const PushNotificationComponent = (): JSX.Element => {
 
     const unsubscribeInApp = messaging().onMessage(async (remoteMessage) => {
       console.log("A new FCM message arrived!", remoteMessage)
-      // TODO: add notifee library to show local notifications
+      client.refetchQueries({ include: [BulletinsDocument] })
     })
 
     // When the application is opened from a quit state.
@@ -54,7 +55,7 @@ export const PushNotificationComponent = (): JSX.Element => {
       unsubscribeInApp()
       unsubscribeBackground()
     }
-  }, [])
+  }, [client])
 
   useEffect(() => {
     ;(async () => {

--- a/app/components/push-notification/push-notification.tsx
+++ b/app/components/push-notification/push-notification.tsx
@@ -37,8 +37,7 @@ export const PushNotificationComponent = (): JSX.Element => {
       },
     )
 
-    const unsubscribeInApp = messaging().onMessage(async (remoteMessage) => {
-      console.log("A new FCM message arrived!", remoteMessage)
+    const unsubscribeInApp = messaging().onMessage(async () => {
       client.refetchQueries({ include: [BulletinsDocument] })
     })
 


### PR DESCRIPTION
## What

When a push notification arrives while the app is in the foreground, the bulletin now shows up right away, without needing to restart the app.

## Why

The foreground `onMessage` handler in `push-notification.tsx` only logged the incoming FCM message and never refreshed the bulletins, so a newly sent bulletin did not appear until the app was restarted. Closes #3723.

## How

- The foreground `onMessage` handler now refetches the bulletins query with `client.refetchQueries({ include: [BulletinsDocument] })`, so a new bulletin is picked up immediately.
- Added `client` to the effect dependency array so the handler always uses the current Apollo client.
- Removed a leftover debug `console.log` from the handler.

## Tests

- Added `__tests__/components/push-notification.spec.tsx`: renders without crashing, refetches the bulletins query when a foreground message arrives, and unsubscribes on unmount.
