### PR TITLE
feat(spark): LNURL pay and Lightning Address support for self-custodial sends

### DIFF
--- a/__mocks__/react-native-quick-crypto.js
+++ b/__mocks__/react-native-quick-crypto.js
@@ -15,6 +15,7 @@ module.exports = {
   __esModule: true,
   default: {
     randomBytes: jest.fn((size) => Buffer.alloc(size, 0xab)),
+    randomUUID: jest.fn(() => "00000000-0000-4000-8000-000000000000"),
     publicEncrypt: jest.fn().mockReturnValue(Buffer.from("rsa-encrypted-data")),
     createCipheriv: jest.fn().mockReturnValue(mockCipher),
     createDecipheriv: jest.fn().mockReturnValue(mockDecipher),

--- a/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
@@ -274,6 +274,46 @@ describe("SendBitcoinCompletedScreen", () => {
     expect(screen.getByText(LL.common.share())).toBeTruthy()
   })
 
+  it("renders self-custodial AES plaintext from `message` (no ciphertext/iv)", async () => {
+    const plaintext = "redeem-code-XYZ"
+    const description = "Here is your AES secret"
+    const selfCustodialAesRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        successAction: {
+          tag: "aes",
+          message: plaintext,
+          description,
+          url: null,
+          ciphertext: null,
+          iv: null,
+          decipher: () => null,
+        },
+        preimage: undefined,
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "alice@blink.sv",
+        paymentType: "lightning",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <SuccessAction route={selfCustodialAesRoute} />
+      </ContextForScreen>,
+    )
+    act(() => {
+      jest.advanceTimersByTime(2300)
+    })
+
+    expect(screen.getByText(`${plaintext} ${description}`)).toBeTruthy()
+  })
+
   describe("ViewShot background color for screenshot", () => {
     const successRoute = {
       key: "sendBitcoinCompleted",

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -150,6 +150,18 @@ jest.mock("@app/screens/send-bitcoin-screen/hooks/use-send-wallets", () => ({
   useSendBalances: () => mockUseSendBalances(),
 }))
 
+const useActiveWalletMock = jest.fn(() => ({
+  isSelfCustodial: false,
+  isReady: true,
+  needsBackendAuth: false,
+  wallets: [],
+  status: "ready",
+  accountType: "Custodial",
+}))
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => useActiveWalletMock(),
+}))
+
 jest.mock("@app/components/atomic/galoy-slider-button/galoy-slider-button", () => {
   type Props = {
     onSwipe: () => void
@@ -177,6 +189,14 @@ describe("SendBitcoinConfirmationScreen", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    useActiveWalletMock.mockReturnValue({
+      isSelfCustodial: false,
+      isReady: true,
+      needsBackendAuth: false,
+      wallets: [],
+      status: "ready",
+      accountType: "Custodial",
+    })
     loadLocale("en")
     LL = i18nObject("en")
 
@@ -320,6 +340,43 @@ describe("SendBitcoinConfirmationScreen", () => {
       destination: defaultLightningParams.lnurl,
       isMerchant: false,
     })
+  })
+
+  it("Skips saveLnAddressContact entirely when the active wallet is self-custodial", async () => {
+    useActiveWalletMock.mockReturnValue({
+      isSelfCustodial: true,
+      isReady: true,
+      needsBackendAuth: false,
+      wallets: [],
+      status: "ready",
+      accountType: "SelfCustodial",
+    })
+
+    const { createLnurlPaymentDetails } = PaymentDetailsLightning
+    const paymentDetailLightning = createLnurlPaymentDetails(defaultLightningParams)
+    const routeLnurl = {
+      key: "sendBitcoinConfirmationScreen",
+      name: "sendBitcoinConfirmation",
+      params: { paymentDetail: paymentDetailLightning },
+    } as const
+
+    sendPaymentMock.mockResolvedValueOnce({
+      status: "SUCCESS",
+      extraInfo: { preimage: "preimagetest" },
+    })
+
+    render(
+      <ContextForScreen>
+        <LightningLnURL route={routeLnurl} />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("slider"))
+    })
+
+    expect(sendPaymentMock).toHaveBeenCalledTimes(1)
+    expect(saveLnAddressContactMock).not.toHaveBeenCalled()
   })
 
   it("Does not call saveLnAddressContact when LNURL payment is to a merchant", async () => {

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -162,6 +162,17 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => useActiveWalletMock(),
 }))
 
+const navigationDispatchMock = jest.fn()
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({
+    dispatch: navigationDispatchMock,
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+  }),
+}))
+
 jest.mock("@app/components/atomic/galoy-slider-button/galoy-slider-button", () => {
   type Props = {
     onSwipe: () => void
@@ -414,6 +425,92 @@ describe("SendBitcoinConfirmationScreen", () => {
       paymentType: "lnurl",
       destination: merchantParams.lnurl,
       isMerchant: true,
+    })
+  })
+
+  describe("successAction precedence on completion-screen navigation", () => {
+    const findCompletedRouteParams = () => {
+      const reducerCalls = navigationDispatchMock.mock.calls
+        .map(([reducer]) => reducer)
+        .filter(
+          (reducer): reducer is (state: unknown) => unknown =>
+            typeof reducer === "function",
+        )
+      for (const reducer of reducerCalls) {
+        const action = reducer({ index: 0, routes: [] }) as {
+          payload?: { routes?: Array<{ name: string; params?: unknown }> }
+          routes?: Array<{ name: string; params?: unknown }>
+        }
+        const routes = action.payload?.routes ?? action.routes ?? []
+        const completed = routes.find((r) => r.name === "sendBitcoinCompleted")
+        if (completed) return completed.params as { successAction?: unknown }
+      }
+      throw new Error("sendBitcoinCompleted route was not dispatched")
+    }
+
+    it("forwards extraInfo.successAction to the completed screen when present", async () => {
+      const extraInfoSuccessAction = {
+        tag: "message",
+        message: "extra-info wins",
+        description: null,
+        url: null,
+        ciphertext: null,
+        iv: null,
+        decipher: () => null,
+      }
+      const { createLnurlPaymentDetails } = PaymentDetailsLightning
+      const paymentDetailLightning = createLnurlPaymentDetails(defaultLightningParams)
+      const routeLnurl = {
+        key: "sendBitcoinConfirmationScreen",
+        name: "sendBitcoinConfirmation",
+        params: { paymentDetail: paymentDetailLightning },
+      } as const
+
+      sendPaymentMock.mockResolvedValueOnce({
+        status: "SUCCESS",
+        extraInfo: { preimage: "p", successAction: extraInfoSuccessAction },
+      })
+
+      render(
+        <ContextForScreen>
+          <LightningLnURL route={routeLnurl} />
+        </ContextForScreen>,
+      )
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId("slider"))
+      })
+
+      const params = findCompletedRouteParams()
+      expect(params.successAction).toEqual(extraInfoSuccessAction)
+    })
+
+    it("falls back to paymentDetail.successAction when extraInfo.successAction is undefined", async () => {
+      const { createLnurlPaymentDetails } = PaymentDetailsLightning
+      const paymentDetailLightning = createLnurlPaymentDetails(defaultLightningParams)
+      const routeLnurl = {
+        key: "sendBitcoinConfirmationScreen",
+        name: "sendBitcoinConfirmation",
+        params: { paymentDetail: paymentDetailLightning },
+      } as const
+
+      sendPaymentMock.mockResolvedValueOnce({
+        status: "SUCCESS",
+        extraInfo: { preimage: "p" },
+      })
+
+      render(
+        <ContextForScreen>
+          <LightningLnURL route={routeLnurl} />
+        </ContextForScreen>,
+      )
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId("slider"))
+      })
+
+      const params = findCompletedRouteParams()
+      expect(params.successAction).toEqual(successActionMessageMock)
     })
   })
 })

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -108,6 +108,36 @@ jest.mock("@react-navigation/native", () => ({
   }),
 }))
 
+const activeWalletWallets = [
+  {
+    id: "btc-wallet-id",
+    walletCurrency: "BTC",
+    balance: { currency: "BTC", currencyCode: "BTC", amount: 0 },
+  },
+]
+const useActiveWalletMock = jest.fn(() => ({
+  isSelfCustodial: false,
+  isReady: true,
+  needsBackendAuth: false,
+  wallets: activeWalletWallets,
+  status: "ready",
+  accountType: "Custodial",
+}))
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => useActiveWalletMock(),
+}))
+
+const useSelfCustodialWalletMock = jest.fn(() => ({ sdk: undefined }))
+jest.mock("@app/self-custodial/providers/wallet-provider", () => ({
+  useSelfCustodialWallet: () => useSelfCustodialWalletMock(),
+}))
+
+jest.mock("@app/self-custodial/payment-details/wrap-destination", () => ({
+  wrapDestination: jest.fn(
+    (result: ParseDestinationResult): ParseDestinationResult => result,
+  ),
+}))
+
 const sendBitcoinDestination = {
   name: "sendBitcoinDestination",
   key: "sendBitcoinDestination",
@@ -138,6 +168,15 @@ describe("SendBitcoinDestinationScreen", () => {
     jest.clearAllMocks()
     loadLocale("en")
     LL = i18nObject("en")
+    useActiveWalletMock.mockReturnValue({
+      isSelfCustodial: false,
+      isReady: true,
+      needsBackendAuth: false,
+      wallets: activeWalletWallets,
+      status: "ready",
+      accountType: "Custodial",
+    })
+    useSelfCustodialWalletMock.mockReturnValue({ sdk: undefined })
     mockedDestinationData = {
       globals: { network: "mainnet" },
       me: {
@@ -926,5 +965,87 @@ describe("SendBitcoinDestinationScreen paste buttons", () => {
     await flushAsync()
 
     expect(screen.getByLabelText("telephoneNumber").props.value).toBeTruthy()
+  })
+
+  describe("lnurlDomains gate by active wallet type", () => {
+    beforeEach(() => {
+      // mockReturnValue overrides survive jest.clearAllMocks(); reset to default.
+      useActiveWalletMock.mockReturnValue({
+        isSelfCustodial: false,
+        isReady: true,
+        needsBackendAuth: false,
+        wallets: activeWalletWallets,
+        status: "ready",
+        accountType: "Custodial",
+      })
+      useSelfCustodialWalletMock.mockReturnValue({ sdk: undefined })
+    })
+
+    const triggerParseDestination = async () => {
+      jest.mocked(Clipboard.getString).mockResolvedValueOnce("alice@example.com")
+      const searchResponder = getResponderByLabel(LL.SendBitcoinScreen.placeholder())
+      const pasteButton = within(searchResponder).getByText(LL.common.paste())
+      fireEvent.press(pasteButton)
+      await flushAsync()
+      await flushAsync()
+    }
+
+    it("passes empty lnurlDomains when active wallet is self-custodial", async () => {
+      useActiveWalletMock.mockReturnValue({
+        isSelfCustodial: true,
+        isReady: true,
+        needsBackendAuth: false,
+        wallets: activeWalletWallets,
+        status: "ready",
+        accountType: "SelfCustodial",
+      })
+      parseDestinationMock.mockResolvedValue({
+        valid: false,
+        invalidReason: InvalidDestinationReason.UsernameDoesNotExist,
+        invalidPaymentDestination: {
+          valid: false,
+          paymentType: PaymentType.Intraledger,
+          invalidReason: InvalidIntraledgerReason.WrongDomain,
+          handle: "alice@example.com",
+        },
+      })
+
+      render(
+        <ContextForScreen>
+          <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+        </ContextForScreen>,
+      )
+      await triggerParseDestination()
+
+      expect(parseDestinationMock).toHaveBeenCalledWith(
+        expect.objectContaining({ lnurlDomains: [] }),
+      )
+    })
+
+    it("passes [lnAddressHostname, ...LNURL_DOMAINS] when active wallet is custodial", async () => {
+      parseDestinationMock.mockResolvedValue({
+        valid: false,
+        invalidReason: InvalidDestinationReason.UsernameDoesNotExist,
+        invalidPaymentDestination: {
+          valid: false,
+          paymentType: PaymentType.Intraledger,
+          invalidReason: InvalidIntraledgerReason.WrongDomain,
+          handle: "alice@example.com",
+        },
+      })
+
+      render(
+        <ContextForScreen>
+          <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+        </ContextForScreen>,
+      )
+      await triggerParseDestination()
+
+      expect(parseDestinationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lnurlDomains: ["blink.sv", "blink.sv", "pay.blink.sv", "pay.bbw.sv"],
+        }),
+      )
+    })
   })
 })

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -1,11 +1,35 @@
 import React from "react"
+import { Satoshis, type LnUrlPayServiceResponse } from "lnurl-pay"
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react-native"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 
+import { WalletCurrency } from "@app/graphql/generated"
+import SendBitcoinDetailsScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-details-screen"
+import {
+  ConvertMoneyAmount,
+  PaymentDetail,
+} from "@app/screens/send-bitcoin-screen/payment-details/index.types"
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
 import { Intraledger } from "../../app/screens/send-bitcoin-screen/send-bitcoin-details-screen.stories"
 import { ContextForScreen } from "./helper"
+
+const mockRequestInvoice = jest.fn()
+jest.mock("lnurl-pay", () => ({
+  ...jest.requireActual("lnurl-pay"),
+  requestInvoice: (...args: unknown[]) => mockRequestInvoice(...args),
+}))
+
+const mockNavigate = jest.fn()
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    setOptions: jest.fn(),
+  }),
+}))
 
 jest.mock("@react-native-firebase/app-check", () => {
   return () => ({
@@ -91,6 +115,146 @@ it("applies send amount only after modal dismiss animation completes", async () 
   await waitFor(() => {
     expect(screen.getByTestId(LL.common.next()).props.accessibilityState?.disabled).toBe(
       false,
+    )
+  })
+})
+
+describe("SendBitcoinDetailsScreen — LNURL requestInvoice gate", () => {
+  const lnurlParams: LnUrlPayServiceResponse = {
+    callback: "https://example.com/cb",
+    fixed: false,
+    min: 1 as Satoshis,
+    max: 1000000 as Satoshis,
+    domain: "example.com",
+    metadata: [["text/plain", "Test"]],
+    metadataHash: "",
+    identifier: "alice@example.com",
+    description: "Pay alice",
+    image: "",
+    commentAllowed: 0,
+    rawData: { metadata: '[["text/plain","Test"]]' },
+  }
+
+  const convertMoneyAmount: ConvertMoneyAmount = (amount, currency) => ({
+    amount: amount.amount,
+    currency,
+    currencyCode: currency,
+  })
+
+  const buildLnurlPaymentDetail = ({
+    withSendMutation,
+  }: {
+    withSendMutation: boolean
+  }): PaymentDetail<WalletCurrency> => {
+    const sendingWalletDescriptor = {
+      id: "btc-wallet-id",
+      currency: WalletCurrency.Btc,
+    } as const
+    const unitOfAccountAmount = {
+      amount: 5000,
+      currency: WalletCurrency.Btc,
+      currencyCode: WalletCurrency.Btc,
+    } as const
+    const settlementAmount = {
+      amount: 5000,
+      currency: WalletCurrency.Btc,
+      currencyCode: WalletCurrency.Btc,
+    } as const
+    const detail = {
+      paymentType: PaymentType.Lnurl,
+      destination: "lnurl1abc",
+      memo: "",
+      convertMoneyAmount,
+      setConvertMoneyAmount: () => detail,
+      settlementAmount,
+      settlementAmountIsEstimated: false,
+      unitOfAccountAmount,
+      sendingWalletDescriptor,
+      setSendingWalletDescriptor: () => detail,
+      lnurlParams,
+      setInvoice: () => detail,
+      successAction: undefined,
+      setSuccessAction: () => detail,
+      isMerchant: false,
+      canSetAmount: true as const,
+      setAmount: () => detail,
+      canSetMemo: true as const,
+      setMemo: () => detail,
+      ...(withSendMutation
+        ? {
+            canSendPayment: true as const,
+            canGetFee: true as const,
+            getFee: jest.fn().mockResolvedValue({ amount: undefined }),
+            sendPaymentMutation: jest.fn().mockResolvedValue({ status: "SUCCESS" }),
+          }
+        : { canSendPayment: false as const, canGetFee: false as const }),
+    }
+    return detail as unknown as PaymentDetail<WalletCurrency>
+  }
+
+  const buildRoute = (paymentDetail: PaymentDetail<WalletCurrency>) =>
+    ({
+      key: "sendBitcoinDetails",
+      name: "sendBitcoinDetails",
+      params: {
+        paymentDestination: {
+          valid: true,
+          createPaymentDetail: () => paymentDetail,
+        } as never,
+      },
+    }) as never
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    loadLocale("en")
+  })
+
+  it("does NOT call lnurl-pay requestInvoice when paymentDetail.sendPaymentMutation is set (SC path)", async () => {
+    const detail = buildLnurlPaymentDetail({ withSendMutation: true })
+    const LL = i18nObject("en")
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDetailsScreen route={buildRoute(detail)} />
+      </ContextForScreen>,
+    )
+
+    await flushAsync()
+    await flushAsync()
+
+    fireEvent.press(screen.getByText(LL.common.next()))
+    await flushAsync()
+
+    expect(mockRequestInvoice).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "sendBitcoinConfirmation",
+      expect.objectContaining({ paymentDetail: expect.any(Object) }),
+    )
+  })
+
+  it("calls lnurl-pay requestInvoice when paymentDetail.sendPaymentMutation is missing (custodial path)", async () => {
+    const detail = buildLnurlPaymentDetail({ withSendMutation: false })
+    const LL = i18nObject("en")
+    mockRequestInvoice.mockResolvedValue({
+      invoice: "lnbc10n1pjxample",
+      successAction: undefined,
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDetailsScreen route={buildRoute(detail)} />
+      </ContextForScreen>,
+    )
+
+    await flushAsync()
+    await flushAsync()
+
+    fireEvent.press(screen.getByText(LL.common.next()))
+    await flushAsync()
+
+    expect(mockRequestInvoice).toHaveBeenCalledTimes(1)
+    expect(mockRequestInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({ lnUrlOrAddress: "lnurl1abc" }),
     )
   })
 })

--- a/__tests__/self-custodial/bridge/send.spec.ts
+++ b/__tests__/self-custodial/bridge/send.spec.ts
@@ -381,7 +381,7 @@ describe("extractLnurlFee", () => {
     expect(extractLnurlFee({ feeSats: BigInt(7) } as never)).toBe(7)
   })
 
-  it("returns 0 when feeSats is zero", () => {
+  it("returns 0 when feeSats is zero (legitimate USD FeesIncluded path)", () => {
     expect(extractLnurlFee({ feeSats: BigInt(0) } as never)).toBe(0)
   })
 })

--- a/__tests__/self-custodial/bridge/send.spec.ts
+++ b/__tests__/self-custodial/bridge/send.spec.ts
@@ -2,16 +2,22 @@
 import { WalletCurrency } from "@app/graphql/generated"
 
 import {
+  executeLnurl,
   executeSend,
   extractLightningFee,
+  extractLnurlFee,
   extractOnchainFees,
+  prepareLnurl,
   prepareSend,
   resolveSendTokenIdentifier,
   toSdkSendAmount,
 } from "@app/self-custodial/bridge/send"
 
 jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
+  FeePolicy: { FeesExcluded: 0, FeesIncluded: 1 },
+  LnurlPayRequest: { create: (p: Record<string, unknown>) => p },
   OnchainConfirmationSpeed: { Fast: 0, Medium: 1, Slow: 2 },
+  PrepareLnurlPayRequest: { create: (p: Record<string, unknown>) => p },
   PrepareSendPaymentRequest: { create: (p: Record<string, unknown>) => p },
   SendPaymentMethod_Tags: {
     BitcoinAddress: "BitcoinAddress",
@@ -294,5 +300,117 @@ describe("resolveSendTokenIdentifier", () => {
 
   it("returns undefined for BTC wallets so the SDK treats it as a BTC send", () => {
     expect(resolveSendTokenIdentifier(WalletCurrency.Btc)).toBeUndefined()
+  })
+})
+
+describe("prepareLnurl", () => {
+  const payRequest = {
+    callback: "https://example.com/cb",
+    minSendable: BigInt(1000),
+    maxSendable: BigInt(100000000),
+    metadataStr: '[["text/plain","hi"]]',
+    commentAllowed: 0,
+    domain: "example.com",
+    url: "https://example.com",
+    address: undefined,
+    allowsNostr: undefined,
+    nostrPubkey: undefined,
+  } as never
+
+  it("forwards amount, payRequest, comment to the SDK call", async () => {
+    const prepareLnurlPay = jest.fn().mockResolvedValue({})
+    const sdk = { prepareLnurlPay } as never
+
+    await prepareLnurl(sdk, {
+      amount: BigInt(1500),
+      payRequest,
+      comment: "hello",
+    })
+
+    expect(prepareLnurlPay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: BigInt(1500),
+        payRequest,
+        comment: "hello",
+      }),
+    )
+  })
+
+  it("passes tokenIdentifier + conversionOptions + feePolicy for USD wallet sends", async () => {
+    const prepareLnurlPay = jest.fn().mockResolvedValue({})
+    const sdk = { prepareLnurlPay } as never
+    const conversionOptions = {
+      conversionType: { tag: "ToBitcoin", inner: { fromTokenIdentifier: "usdb" } },
+    } as never
+
+    await prepareLnurl(sdk, {
+      amount: BigInt(1000000),
+      payRequest,
+      tokenIdentifier: "usdb-token-id",
+      conversionOptions,
+      feePolicy: 1,
+    })
+
+    expect(prepareLnurlPay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenIdentifier: "usdb-token-id",
+        conversionOptions,
+        feePolicy: 1,
+      }),
+    )
+  })
+
+  it("omits tokenIdentifier and conversionOptions for BTC wallet sends", async () => {
+    const prepareLnurlPay = jest.fn().mockResolvedValue({})
+    const sdk = { prepareLnurlPay } as never
+
+    await prepareLnurl(sdk, { amount: BigInt(1500), payRequest })
+
+    expect(prepareLnurlPay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenIdentifier: undefined,
+        conversionOptions: undefined,
+        feePolicy: undefined,
+      }),
+    )
+  })
+})
+
+describe("extractLnurlFee", () => {
+  it("returns the prepared response feeSats coerced to a number", () => {
+    expect(extractLnurlFee({ feeSats: BigInt(7) } as never)).toBe(7)
+  })
+
+  it("returns 0 when feeSats is zero", () => {
+    expect(extractLnurlFee({ feeSats: BigInt(0) } as never)).toBe(0)
+  })
+})
+
+describe("executeLnurl", () => {
+  it("forwards prepareResponse and idempotencyKey to the SDK call", async () => {
+    const lnurlPay = jest.fn().mockResolvedValue({})
+    const sdk = { lnurlPay } as never
+    const prepareResponse = { amountSats: BigInt(100), feeSats: BigInt(1) } as never
+
+    await executeLnurl(sdk, prepareResponse, "idemp-key-1")
+
+    expect(lnurlPay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prepareResponse,
+        idempotencyKey: "idemp-key-1",
+      }),
+    )
+  })
+
+  it("passes idempotencyKey as undefined when not provided", async () => {
+    const lnurlPay = jest.fn().mockResolvedValue({})
+    const sdk = { lnurlPay } as never
+    const prepareResponse = { amountSats: BigInt(100), feeSats: BigInt(1) } as never
+
+    await executeLnurl(sdk, prepareResponse)
+
+    expect(lnurlPay).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: undefined }),
+    )
   })
 })

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -377,6 +377,102 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
     })
   })
 
+  describe("idempotency key forwarding", () => {
+    let randomUUIDMock: jest.SpyInstance
+
+    beforeEach(() => {
+      let counter = 0
+      // Override the global mock so each call returns a fresh UUID; the global
+      // mock returns the same string and would mask a missing thread-through.
+      randomUUIDMock = jest
+        .spyOn(
+          jest.requireMock("react-native-quick-crypto").default as {
+            randomUUID: () => string
+          },
+          "randomUUID",
+        )
+        .mockImplementation(() => {
+          counter += 1
+          return `uuid-${counter}`
+        })
+    })
+
+    afterEach(() => {
+      randomUUIDMock.mockRestore()
+    })
+
+    it("forwards a defined idempotency key to executeLnurl on every send", async () => {
+      mockPrepareLnurl.mockResolvedValue({ feeSats: BigInt(0) })
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: undefined,
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+
+      await detail.sendPaymentMutation({} as never)
+
+      expect(mockExecuteLnurl).toHaveBeenCalledTimes(1)
+      const idempotencyKey = mockExecuteLnurl.mock.calls[0][2]
+      expect(typeof idempotencyKey).toBe("string")
+      expect(idempotencyKey.length).toBeGreaterThan(0)
+    })
+
+    it("reuses the same idempotency key across retries within the same paymentDetail", async () => {
+      mockPrepareLnurl.mockResolvedValue({ feeSats: BigInt(0) })
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: undefined,
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+
+      await detail.sendPaymentMutation({} as never)
+      await detail.sendPaymentMutation({} as never)
+
+      const firstKey = mockExecuteLnurl.mock.calls[0][2]
+      const secondKey = mockExecuteLnurl.mock.calls[1][2]
+      expect(firstKey).toBe(secondKey)
+    })
+
+    it("preserves the idempotency key across setMemo / setAmount / setSendingWalletDescriptor recreations", async () => {
+      mockPrepareLnurl.mockResolvedValue({ feeSats: BigInt(0) })
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: undefined,
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      if (!detail.canSetAmount) throw new Error("expected canSetAmount")
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+      await detail.sendPaymentMutation({} as never)
+      const originalKey = mockExecuteLnurl.mock.calls[0][2]
+
+      const reMemoed = detail.setMemo("new memo")
+      if (!reMemoed.canSendPayment) throw new Error("expected canSendPayment")
+      await reMemoed.sendPaymentMutation({} as never)
+      expect(mockExecuteLnurl.mock.calls[1][2]).toBe(originalKey)
+
+      if (!reMemoed.canSetAmount) throw new Error("expected canSetAmount")
+      const reAmounted = reMemoed.setAmount({
+        amount: 2000,
+        currency: WalletCurrency.Btc,
+        currencyCode: WalletCurrency.Btc,
+      })
+      if (!reAmounted.canSendPayment) throw new Error("expected canSendPayment")
+      await reAmounted.sendPaymentMutation({} as never)
+      expect(mockExecuteLnurl.mock.calls[2][2]).toBe(originalKey)
+
+      const reWalleted = reAmounted.setSendingWalletDescriptor({
+        id: "w-btc-2",
+        currency: WalletCurrency.Btc,
+      })
+      if (!reWalleted.canSendPayment) throw new Error("expected canSendPayment")
+      await reWalleted.sendPaymentMutation({} as never)
+      expect(mockExecuteLnurl.mock.calls[3][2]).toBe(originalKey)
+    })
+  })
+
   describe("metadataStr preservation (LUD-06 description hash)", () => {
     it("uses the raw metadata string from lnurlParams.rawData when available", async () => {
       mockPrepareLnurl.mockResolvedValue({})

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -58,6 +58,13 @@ jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
   AesSuccessActionDataResult_Tags: { Decrypted: "Decrypted", ErrorStatus: "ErrorStatus" },
   FeePolicy: { FeesExcluded: 0, FeesIncluded: 1 },
   SuccessActionProcessed_Tags: { Aes: "Aes", Message: "Message", Url: "Url" },
+  PaymentDetails: {
+    Lightning: {
+      instanceOf: (obj: { tag?: string } | undefined) => obj?.tag === "Lightning",
+    },
+    Spark: { instanceOf: (obj: { tag?: string } | undefined) => obj?.tag === "Spark" },
+    Token: { instanceOf: (obj: { tag?: string } | undefined) => obj?.tag === "Token" },
+  },
 }))
 
 const baseLnurlParams = (overrides: Partial<LnUrlPayServiceResponse> = {}) =>
@@ -263,6 +270,23 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
         expect.objectContaining({ comment: undefined }),
       )
     })
+
+    it("omits the comment when commentAllowed > 0 but memo is empty", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ commentAllowed: 200 }),
+          senderSpecifiedMemo: "",
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ comment: undefined }),
+      )
+    })
   })
 
   describe("getFee", () => {
@@ -274,6 +298,25 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       const result = await detail.getFee({} as never)
       expect(result.amount?.amount).toBe(5)
       expect(result.amount?.currency).toBe(WalletCurrency.Btc)
+    })
+
+    it("returns currency: Btc regardless of the sending wallet generic (USD wallet)", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExtractLnurlFee.mockReturnValue(50)
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          sendingWalletDescriptor: { id: "w-usd", currency: WalletCurrency.Usd },
+          unitOfAccountAmount: {
+            amount: 100,
+            currency: WalletCurrency.Usd,
+            currencyCode: "USD",
+          },
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.amount?.currency).toBe(WalletCurrency.Btc)
+      expect(result.amount?.amount).toBe(50)
     })
 
     it("returns undefined amount when prepareLnurl throws", async () => {
@@ -374,6 +417,62 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       const result = await detail.sendPaymentMutation({} as never)
       expect(result.status).toBe(PaymentSendResult.Failure)
       expect(result.errors?.[0].message).toBe(SelfCustodialErrorCode.InvalidInput)
+    })
+
+    it("classifies NetworkError tag with the network-error code", async () => {
+      mockPrepareLnurl.mockRejectedValue({ tag: "NetworkError", inner: ["timeout"] })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.status).toBe(PaymentSendResult.Failure)
+      expect(result.errors?.[0].message).toBe(SelfCustodialErrorCode.NetworkError)
+    })
+
+    it("classifies a generic (untagged) error with the generic code", async () => {
+      mockPrepareLnurl.mockRejectedValue(new Error("boom"))
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.status).toBe(PaymentSendResult.Failure)
+      expect(result.errors?.[0].message).toBe(SelfCustodialErrorCode.Generic)
+    })
+
+    it("propagates preimage from Lightning htlcDetails and createdAt from payment.timestamp on success", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: {
+          id: "p1",
+          timestamp: BigInt(1747691078),
+          details: {
+            tag: "Lightning",
+            inner: { htlcDetails: { preimage: "deadbeef-preimage" } },
+          },
+        },
+        successAction: undefined,
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.status).toBe(PaymentSendResult.Success)
+      expect(result.extraInfo?.preimage).toBe("deadbeef-preimage")
+      expect(result.transaction?.createdAt).toBe(1747691078)
+    })
+
+    it("returns undefined preimage when payment.details is non-Lightning", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: {
+          id: "p1",
+          timestamp: BigInt(1747691078),
+          details: { tag: "Spark", inner: {} },
+        },
+        successAction: undefined,
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.extraInfo?.preimage).toBeUndefined()
+      expect(result.transaction?.createdAt).toBe(1747691078)
     })
   })
 

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -1,0 +1,417 @@
+/* eslint-disable camelcase */
+import { LnUrlPayServiceResponse, Satoshis } from "lnurl-pay"
+
+import { PaymentSendResult, WalletCurrency } from "@app/graphql/generated"
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
+import { createSelfCustodialLnurlPaymentDetails } from "@app/self-custodial/payment-details/lnurl"
+import { SelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
+
+const mockPrepareLnurl = jest.fn()
+const mockExecuteLnurl = jest.fn()
+const mockExtractLnurlFee = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  prepareLnurl: (...args: unknown[]) => mockPrepareLnurl(...args),
+  executeLnurl: (...args: unknown[]) => mockExecuteLnurl(...args),
+  extractLnurlFee: (...args: unknown[]) => mockExtractLnurlFee(...args),
+  buildConversionType: jest.fn().mockReturnValue({ tag: "ToBitcoin" }),
+  resolveSendTokenIdentifier: (currency: WalletCurrency) =>
+    currency === WalletCurrency.Usd ? "usdb-token-id" : undefined,
+  toSdkSendAmount: (amount: number, currency: WalletCurrency) =>
+    currency === WalletCurrency.Usd ? BigInt(amount * 10000) : BigInt(amount),
+}))
+
+jest.mock("@app/self-custodial/sdk-error", () => {
+  const tags = {
+    SparkError: "SparkError",
+    InsufficientFunds: "InsufficientFunds",
+    InvalidUuid: "InvalidUuid",
+    InvalidInput: "InvalidInput",
+    NetworkError: "NetworkError",
+    StorageError: "StorageError",
+    ChainServiceError: "ChainServiceError",
+    MaxDepositClaimFeeExceeded: "MaxDepositClaimFeeExceeded",
+    MissingUtxo: "MissingUtxo",
+    LnurlError: "LnurlError",
+    Signer: "Signer",
+    Generic: "Generic",
+  }
+  return {
+    SelfCustodialErrorCode: {
+      InsufficientFunds: "sc_insufficient_funds",
+      BelowMinimum: "sc_below_minimum",
+      NetworkError: "sc_network_error",
+      InvalidInput: "sc_invalid_input",
+      Generic: "sc_generic",
+    },
+    classifySdkError: (err: { tag?: string } | unknown) => {
+      const t = (err as { tag?: string })?.tag
+      if (t === tags.LnurlError) return "sc_invalid_input"
+      if (t === tags.NetworkError) return "sc_network_error"
+      return "sc_generic"
+    },
+  }
+})
+
+jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
+  AesSuccessActionDataResult_Tags: { Decrypted: "Decrypted", ErrorStatus: "ErrorStatus" },
+  FeePolicy: { FeesExcluded: 0, FeesIncluded: 1 },
+  SuccessActionProcessed_Tags: { Aes: "Aes", Message: "Message", Url: "Url" },
+}))
+
+const baseLnurlParams = (overrides: Partial<LnUrlPayServiceResponse> = {}) =>
+  ({
+    callback: "https://example.com/cb",
+    fixed: false,
+    min: 1 as Satoshis,
+    max: 100000 as Satoshis,
+    domain: "example.com",
+    metadata: [["text/plain", "Test"]],
+    metadataHash: "",
+    identifier: "user@example.com",
+    description: "Test description",
+    image: "",
+    commentAllowed: 0,
+    rawData: { metadata: '[["text/plain","Test"]]' },
+    ...overrides,
+  }) as LnUrlPayServiceResponse
+
+const convertMoneyAmount = jest.fn((amount, target) => ({
+  amount: amount.amount,
+  currency: target,
+  currencyCode: target,
+}))
+
+const createParams = (overrides = {}) => ({
+  sdk: {} as never,
+  lnurl: "lnurl1abc",
+  lnurlParams: baseLnurlParams(),
+  unitOfAccountAmount: {
+    amount: 1500,
+    currency: WalletCurrency.Btc,
+    currencyCode: WalletCurrency.Btc,
+  },
+  isMerchant: false,
+  convertMoneyAmount,
+  sendingWalletDescriptor: { id: "w1", currency: WalletCurrency.Btc },
+  ...overrides,
+})
+
+describe("createSelfCustodialLnurlPaymentDetails", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    convertMoneyAmount.mockImplementation((amount, target) => ({
+      amount: amount.amount,
+      currency: target,
+      currencyCode: target,
+    }))
+    mockExtractLnurlFee.mockReturnValue(5)
+  })
+
+  it("returns Lnurl payment type", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+    expect(detail.paymentType).toBe(PaymentType.Lnurl)
+  })
+
+  it("sets destination to the lnurl string", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+    expect(detail.destination).toBe("lnurl1abc")
+  })
+
+  it("propagates lnurlParams + isMerchant + setInvoice + setSuccessAction (lnurl-specific shape)", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(
+      createParams({ isMerchant: true }),
+    )
+    if (detail.paymentType !== PaymentType.Lnurl) throw new Error("expected lnurl")
+    expect(detail.lnurlParams).toBeDefined()
+    expect(detail.isMerchant).toBe(true)
+    expect(detail.setInvoice).toBeDefined()
+    expect(detail.setSuccessAction).toBeDefined()
+  })
+
+  describe("amount handling", () => {
+    it("locks the amount when min === max (destination-specified amount)", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ min: 5000 as Satoshis, max: 5000 as Satoshis }),
+        }),
+      )
+      expect(detail.canSetAmount).toBe(false)
+      expect(detail.destinationSpecifiedAmount).toEqual(
+        expect.objectContaining({ amount: 5000, currency: WalletCurrency.Btc }),
+      )
+    })
+
+    it("allows amount changes when min !== max", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      expect(detail.canSetAmount).toBe(true)
+    })
+
+    it("setAmount returns a new detail with the updated amount", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSetAmount) throw new Error("expected canSetAmount=true")
+      const newAmount = {
+        amount: 2000,
+        currency: WalletCurrency.Btc,
+        currencyCode: WalletCurrency.Btc,
+      }
+      const updated = detail.setAmount(newAmount)
+      expect(updated.unitOfAccountAmount).toEqual(newAmount)
+    })
+  })
+
+  describe("memo handling", () => {
+    it("uses lnurl description as the destination-specified memo by default", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ destinationSpecifiedMemo: "Test description" }),
+      )
+      expect(detail.memo).toBe("Test description")
+    })
+
+    it("sender memo wins when no destination memo is given", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ senderSpecifiedMemo: "user note" }),
+      )
+      expect(detail.memo).toBe("user note")
+    })
+
+    it("setMemo returns a new detail with the updated memo", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+      const updated = detail.setMemo("new memo")
+      expect(updated.memo).toBe("new memo")
+    })
+  })
+
+  describe("prepareLnurl options (currency-aware shape)", () => {
+    it("USD wallet: passes USDB base units + tokenIdentifier + ToBitcoin + FeesIncluded", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          sendingWalletDescriptor: { id: "w-usd", currency: WalletCurrency.Usd },
+          unitOfAccountAmount: {
+            amount: 100,
+            currency: WalletCurrency.Usd,
+            currencyCode: "USD",
+          },
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          amount: BigInt(1000000),
+          tokenIdentifier: "usdb-token-id",
+          conversionOptions: expect.objectContaining({
+            conversionType: { tag: "ToBitcoin" },
+          }),
+          feePolicy: 1,
+        }),
+      )
+    })
+
+    it("BTC wallet: passes amount in sats + no tokenIdentifier + no conversionOptions + no feePolicy", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          amount: BigInt(1500),
+          tokenIdentifier: undefined,
+          conversionOptions: undefined,
+          feePolicy: undefined,
+        }),
+      )
+    })
+
+    it("includes the comment only when commentAllowed > 0 and a memo is set", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ commentAllowed: 200 }),
+          senderSpecifiedMemo: "with comment",
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ comment: "with comment" }),
+      )
+    })
+
+    it("omits the comment when commentAllowed is 0 even if a memo is set", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ commentAllowed: 0 }),
+          senderSpecifiedMemo: "would-be comment",
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ comment: undefined }),
+      )
+    })
+  })
+
+  describe("getFee", () => {
+    it("returns the fee in BTC sats from extractLnurlFee", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExtractLnurlFee.mockReturnValue(5)
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.amount?.amount).toBe(5)
+      expect(result.amount?.currency).toBe(WalletCurrency.Btc)
+    })
+
+    it("returns undefined amount when prepareLnurl throws", async () => {
+      mockPrepareLnurl.mockRejectedValue(new Error("boom"))
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.amount).toBeUndefined()
+    })
+  })
+
+  describe("sendPaymentMutation", () => {
+    it("returns Success with successAction in extraInfo on success (Message)", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: { tag: "Message", inner: { data: { message: "Thanks!" } } },
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.status).toBe(PaymentSendResult.Success)
+      expect(result.extraInfo?.successAction?.tag).toBe("message")
+      expect(result.extraInfo?.successAction?.message).toBe("Thanks!")
+    })
+
+    it("converts a URL successAction to the lnurl-pay shape", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: {
+          tag: "Url",
+          inner: { data: { description: "Receipt", url: "https://r.example/1" } },
+        },
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.extraInfo?.successAction?.tag).toBe("url")
+      expect(result.extraInfo?.successAction?.url).toBe("https://r.example/1")
+      expect(result.extraInfo?.successAction?.description).toBe("Receipt")
+    })
+
+    it("exposes the decrypted plaintext via decipher() for AES successAction", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: {
+          tag: "Aes",
+          inner: {
+            result: {
+              tag: "Decrypted",
+              inner: { data: { description: "AES desc", plaintext: "secret123" } },
+            },
+          },
+        },
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.extraInfo?.successAction?.tag).toBe("aes")
+      expect(result.extraInfo?.successAction?.decipher("any-preimage")).toBe("secret123")
+    })
+
+    it("returns Failure with classifier code on SDK error", async () => {
+      mockPrepareLnurl.mockRejectedValue({ tag: "LnurlError", inner: ["bad"] })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      expect(result.status).toBe(PaymentSendResult.Failure)
+      expect(result.errors?.[0].message).toBe(SelfCustodialErrorCode.InvalidInput)
+    })
+  })
+
+  describe("metadataStr preservation (LUD-06 description hash)", () => {
+    it("uses the raw metadata string from lnurlParams.rawData when available", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const rawMetadata = '[ ["text/plain","Spaces in raw"] ]'
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({
+            rawData: { metadata: rawMetadata },
+            metadata: [["text/plain", "Spaces in raw"]],
+          }),
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          payRequest: expect.objectContaining({ metadataStr: rawMetadata }),
+        }),
+      )
+    })
+
+    it("falls back to JSON.stringify when rawData.metadata is missing", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ rawData: {} }),
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          payRequest: expect.objectContaining({
+            metadataStr: '[["text/plain","Test"]]',
+          }),
+        }),
+      )
+    })
+  })
+
+  describe("min/max → millisats conversion in payRequest", () => {
+    it("multiplies sat values by 1000 to produce SDK-shaped millisats", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ min: 100 as Satoshis, max: 200 as Satoshis }),
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          payRequest: expect.objectContaining({
+            minSendable: BigInt(100000),
+            maxSendable: BigInt(200000),
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -317,7 +317,7 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       expect(result.extraInfo?.successAction?.description).toBe("Receipt")
     })
 
-    it("exposes the decrypted plaintext via decipher() for AES successAction", async () => {
+    it("carries the decrypted plaintext on `message` (not via decipher) for AES Decrypted", async () => {
       mockPrepareLnurl.mockResolvedValue({})
       mockExecuteLnurl.mockResolvedValue({
         payment: { id: "p1" },
@@ -334,8 +334,37 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       const detail = createSelfCustodialLnurlPaymentDetails(createParams())
       if (!detail.canSendPayment) throw new Error("expected canSendPayment")
       const result = await detail.sendPaymentMutation({} as never)
-      expect(result.extraInfo?.successAction?.tag).toBe("aes")
-      expect(result.extraInfo?.successAction?.decipher("any-preimage")).toBe("secret123")
+      const successAction = result.extraInfo?.successAction
+      expect(successAction?.tag).toBe("aes")
+      expect(successAction?.message).toBe("secret123")
+      expect(successAction?.description).toBe("AES desc")
+      expect(successAction?.ciphertext).toBeNull()
+      expect(successAction?.iv).toBeNull()
+      expect(successAction?.decipher("any-preimage")).toBeNull()
+    })
+
+    it("maps AES ErrorStatus to description with no plaintext leakage", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExecuteLnurl.mockResolvedValue({
+        payment: { id: "p1" },
+        successAction: {
+          tag: "Aes",
+          inner: {
+            result: {
+              tag: "ErrorStatus",
+              inner: { reason: "Could not decrypt: bad key" },
+            },
+          },
+        },
+      })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canSendPayment) throw new Error("expected canSendPayment")
+      const result = await detail.sendPaymentMutation({} as never)
+      const successAction = result.extraInfo?.successAction
+      expect(successAction?.tag).toBe("aes")
+      expect(successAction?.message).toBeNull()
+      expect(successAction?.description).toBe("Could not decrypt: bad key")
+      expect(successAction?.decipher("any-preimage")).toBeNull()
     })
 
     it("returns Failure with classifier code on SDK error", async () => {

--- a/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
+++ b/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
@@ -121,6 +121,27 @@ describe("wrapDestination", () => {
     expect(mockCreateLightning).not.toHaveBeenCalled()
   })
 
+  it("falls back to 0 sats when lnurlParams.min is undefined (still has callback + max)", () => {
+    const result = createValidResult(PaymentType.Lnurl, {
+      lnurl: "lnurl1nomin",
+      isMerchant: false,
+      lnurlParams: {
+        callback: "https://example.com/cb",
+        max: 1000,
+        commentAllowed: 0,
+      },
+    })
+
+    const wrapped = wrapDestination(result, mockSdk)
+    callCreatePaymentDetail(wrapped)
+
+    expect(mockCreateLnurl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unitOfAccountAmount: expect.objectContaining({ amount: 0 }),
+      }),
+    )
+  })
+
   it("propagates isMerchant=true for merchant Lnurl destinations", () => {
     const result = createValidResult(PaymentType.Lnurl, {
       lnurl: "lnurl1merchant",

--- a/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
+++ b/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
@@ -5,6 +5,7 @@ import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destin
 
 const mockCreateLightning = jest.fn().mockReturnValue({ paymentType: "lightning" })
 const mockCreateOnchain = jest.fn().mockReturnValue({ paymentType: "onchain" })
+const mockCreateLnurl = jest.fn().mockReturnValue({ paymentType: "lnurl" })
 
 jest.mock("@app/self-custodial/payment-details/lightning", () => ({
   createSelfCustodialLightningPaymentDetails: (...args: unknown[]) =>
@@ -14,6 +15,11 @@ jest.mock("@app/self-custodial/payment-details/lightning", () => ({
 jest.mock("@app/self-custodial/payment-details/onchain", () => ({
   createSelfCustodialOnchainPaymentDetails: (...args: unknown[]) =>
     mockCreateOnchain(...args),
+}))
+
+jest.mock("@app/self-custodial/payment-details/lnurl", () => ({
+  createSelfCustodialLnurlPaymentDetails: (...args: unknown[]) =>
+    mockCreateLnurl(...args),
 }))
 
 const mockSdk = {} as never
@@ -87,16 +93,51 @@ describe("wrapDestination", () => {
     )
   })
 
-  it("wraps Lnurl destination", () => {
+  it("wraps Lnurl destination through the SC lnurl detail (not the lightning detail)", () => {
     const result = createValidResult(PaymentType.Lnurl, {
       lnurl: "lnurl1...",
+      isMerchant: false,
+      lnurlParams: {
+        callback: "https://example.com/cb",
+        min: 1,
+        max: 1000,
+        commentAllowed: 200,
+        description: "Pay user",
+      },
     })
 
     const wrapped = wrapDestination(result, mockSdk)
     callCreatePaymentDetail(wrapped)
 
-    expect(mockCreateLightning).toHaveBeenCalledWith(
-      expect.objectContaining({ paymentRequest: "lnurl1..." }),
+    expect(mockCreateLnurl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sdk: mockSdk,
+        lnurl: "lnurl1...",
+        isMerchant: false,
+        destinationSpecifiedMemo: "Pay user",
+        lnurlParams: expect.objectContaining({ min: 1, max: 1000 }),
+      }),
+    )
+    expect(mockCreateLightning).not.toHaveBeenCalled()
+  })
+
+  it("propagates isMerchant=true for merchant Lnurl destinations", () => {
+    const result = createValidResult(PaymentType.Lnurl, {
+      lnurl: "lnurl1merchant",
+      isMerchant: true,
+      lnurlParams: {
+        callback: "https://m.example/cb",
+        min: 1,
+        max: 100,
+        commentAllowed: 0,
+      },
+    })
+
+    const wrapped = wrapDestination(result, mockSdk)
+    callCreatePaymentDetail(wrapped)
+
+    expect(mockCreateLnurl).toHaveBeenCalledWith(
+      expect.objectContaining({ isMerchant: true }),
     )
   })
 

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -90,6 +90,7 @@ export type SendPaymentMutation = (
 export type PaymentSendExtraInfo = {
   arrivalAtMempoolEstimate?: number
   preimage?: string | null
+  successAction?: LNURLPaySuccessAction
 }
 
 export type SetAmount<T extends WalletCurrency> = (

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -28,6 +28,7 @@ import {
   ZeroUsdMoneyAmount,
 } from "@app/types/amounts"
 import { useTranslateSdkError } from "@app/self-custodial/hooks"
+import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
 import crashlytics from "@react-native-firebase/crashlytics"
 import { CommonActions, RouteProp, useNavigation } from "@react-navigation/native"
@@ -92,6 +93,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     formatMoneyAmount,
   } = useDisplayCurrency()
   const saveLnAddressContact = useSaveLnAddressContact()
+  const { isSelfCustodial } = useActiveWallet()
 
   const { btcWallet, usdWallet } = useSendBalances()
 
@@ -191,12 +193,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
       })
 
       if (status === "SUCCESS" || status === "PENDING") {
-        await saveLnAddressContact({
-          paymentType,
-          destination,
-          isMerchant:
-            paymentDetail.paymentType === "lnurl" ? paymentDetail.isMerchant : undefined,
-        })
+        if (!isSelfCustodial) {
+          await saveLnAddressContact({
+            paymentType,
+            destination,
+            isMerchant:
+              paymentDetail.paymentType === "lnurl"
+                ? paymentDetail.isMerchant
+                : undefined,
+          })
+        }
 
         navigation.dispatch((state) => {
           const routes = [
@@ -206,7 +212,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
               params: {
                 arrivalAtMempoolEstimate: extraInfo?.arrivalAtMempoolEstimate,
                 status,
-                successAction: paymentDetail?.successAction,
+                successAction: extraInfo?.successAction ?? paymentDetail?.successAction,
                 preimage: extraInfo?.preimage,
                 currencyAmount,
                 satAmount,
@@ -275,6 +281,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     paymentType,
     destination,
     saveLnAddressContact,
+    isSelfCustodial,
     currencyAmount,
     satAmount,
     currencyFeeAmount,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -373,7 +373,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
         rawInput,
         myWalletIds: wallets.map(({ id }) => id),
         bitcoinNetwork,
-        lnurlDomains: [lnAddressHostname, ...LNURL_DOMAINS],
+        lnurlDomains: isSelfCustodial ? [] : [lnAddressHostname, ...LNURL_DOMAINS],
         accountDefaultWalletQuery,
       })
       logParseDestinationResult(destination)

--- a/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx
@@ -365,7 +365,7 @@ const SendBitcoinDetailsScreen: React.FC<Props> = ({ route }) => {
     (async () => {
       let paymentDetailForConfirmation: PaymentDetail<WalletCurrency> = paymentDetail
 
-      if (paymentDetail.paymentType === "lnurl") {
+      if (paymentDetail.paymentType === "lnurl" && !paymentDetail.sendPaymentMutation) {
         try {
           setIsLoadingLnurl(true)
 

--- a/app/self-custodial/bridge/index.ts
+++ b/app/self-custodial/bridge/index.ts
@@ -22,8 +22,11 @@ export {
   extractLightningFee,
   toSdkSendAmount,
   resolveSendTokenIdentifier,
+  prepareLnurl,
+  executeLnurl,
+  extractLnurlFee,
 } from "./send"
-export type { OnchainFeeTiers, PrepareSendOptions } from "./send"
+export type { OnchainFeeTiers, PrepareSendOptions, PrepareLnurlOptions } from "./send"
 export { listDeposits, claimDeposit, refundDeposit, getRecommendedFees } from "./deposits"
 export type { MappedDeposit, NetworkFeeRates } from "./deposits"
 export { createGetConversionQuote } from "./convert"

--- a/app/self-custodial/bridge/send.ts
+++ b/app/self-custodial/bridge/send.ts
@@ -1,11 +1,17 @@
 import {
+  FeePolicy,
+  LnurlPayRequest,
   OnchainConfirmationSpeed,
+  PrepareLnurlPayRequest,
   PrepareSendPaymentRequest,
   SendPaymentMethod_Tags as MethodTag,
   SendPaymentOptions,
   SendPaymentRequest,
   type BreezSdkInterface,
   type ConversionOptions,
+  type LnurlPayRequestDetails,
+  type LnurlPayResponse,
+  type PrepareLnurlPayResponse,
   type PrepareSendPaymentResponse,
   type SendOnchainSpeedFeeQuote,
 } from "@breeztech/breez-sdk-spark-react-native"
@@ -117,3 +123,39 @@ const buildSendOptions = (
   }
   return undefined
 }
+
+export type PrepareLnurlOptions = {
+  amount: bigint
+  payRequest: LnurlPayRequestDetails
+  comment?: string
+  tokenIdentifier?: string
+  conversionOptions?: ConversionOptions
+  feePolicy?: FeePolicy
+}
+
+export const prepareLnurl = (sdk: BreezSdkInterface, options: PrepareLnurlOptions) =>
+  sdk.prepareLnurlPay(
+    PrepareLnurlPayRequest.create({
+      amount: options.amount,
+      payRequest: options.payRequest,
+      comment: options.comment,
+      tokenIdentifier: options.tokenIdentifier,
+      conversionOptions: options.conversionOptions,
+      feePolicy: options.feePolicy,
+    }),
+  )
+
+export const extractLnurlFee = (prepared: PrepareLnurlPayResponse): number =>
+  toNumber(prepared.feeSats)
+
+export const executeLnurl = (
+  sdk: BreezSdkInterface,
+  prepareResponse: PrepareLnurlPayResponse,
+  idempotencyKey?: string,
+): Promise<LnurlPayResponse> =>
+  sdk.lnurlPay(
+    LnurlPayRequest.create({
+      prepareResponse,
+      idempotencyKey,
+    }),
+  )

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -1,9 +1,11 @@
 import {
   AesSuccessActionDataResult_Tags as AesResultTag,
   FeePolicy,
+  PaymentDetails,
   SuccessActionProcessed_Tags as SuccessActionTag,
   type BreezSdkInterface,
   type LnurlPayRequestDetails,
+  type LnurlPayResponse,
   type SuccessActionProcessed,
 } from "@breeztech/breez-sdk-spark-react-native"
 import { PaymentType } from "@blinkbitcoin/blink-client"
@@ -63,6 +65,12 @@ const lnurlParamsToPayRequest = (
   allowsNostr: undefined,
   nostrPubkey: undefined,
 })
+
+const extractPreimage = (response: LnurlPayResponse): string | undefined => {
+  const details = response.payment.details
+  if (!details || !PaymentDetails.Lightning.instanceOf(details)) return undefined
+  return details.inner.htlcDetails.preimage
+}
 
 const sdkSuccessActionToLib = (
   sa: SuccessActionProcessed | undefined,
@@ -196,7 +204,9 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
             const result = await executeLnurl(sdk, prepared, idempotencyKey)
             return {
               status: PaymentSendResult.Success,
+              transaction: { createdAt: Number(result.payment.timestamp) },
               extraInfo: {
+                preimage: extractPreimage(result),
                 successAction: sdkSuccessActionToLib(result.successAction),
               },
             }

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -1,0 +1,268 @@
+import {
+  AesSuccessActionDataResult_Tags as AesResultTag,
+  FeePolicy,
+  SuccessActionProcessed_Tags as SuccessActionTag,
+  type BreezSdkInterface,
+  type LnurlPayRequestDetails,
+  type SuccessActionProcessed,
+} from "@breeztech/breez-sdk-spark-react-native"
+import { PaymentType } from "@blinkbitcoin/blink-client"
+import { LnUrlPayServiceResponse, LNURLPaySuccessAction } from "lnurl-pay"
+
+import { PaymentSendResult, WalletCurrency } from "@app/graphql/generated"
+import {
+  BaseCreatePaymentDetailsParams,
+  ConvertMoneyAmount,
+  PaymentDetail,
+  PaymentDetailSendPaymentGetFee,
+  PaymentDetailSetMemo,
+  SetAmount,
+  SetInvoice,
+  SetSendingWalletDescriptor,
+  SetSuccessAction,
+} from "@app/screens/send-bitcoin-screen/payment-details/index.types"
+import {
+  toBtcMoneyAmount,
+  type MoneyAmount,
+  type WalletAmount,
+  type WalletOrDisplayCurrency,
+} from "@app/types/amounts"
+import { ConvertDirection } from "@app/types/payment.types"
+
+import {
+  buildConversionType,
+  executeLnurl,
+  extractLnurlFee,
+  prepareLnurl,
+  resolveSendTokenIdentifier,
+  toSdkSendAmount,
+} from "../bridge"
+import { classifySdkError } from "../sdk-error"
+
+const SAT_TO_MILLISAT = BigInt(1000)
+
+const extractMetadataStr = (lnurlParams: LnUrlPayServiceResponse): string => {
+  const raw = lnurlParams.rawData?.metadata
+  if (typeof raw === "string") return raw
+  return JSON.stringify(lnurlParams.metadata)
+}
+
+const lnurlParamsToPayRequest = (
+  lnurlParams: LnUrlPayServiceResponse,
+  lnurl: string,
+): LnurlPayRequestDetails => ({
+  callback: lnurlParams.callback,
+  minSendable: BigInt(lnurlParams.min) * SAT_TO_MILLISAT,
+  maxSendable: BigInt(lnurlParams.max) * SAT_TO_MILLISAT,
+  metadataStr: extractMetadataStr(lnurlParams),
+  commentAllowed: lnurlParams.commentAllowed,
+  domain: lnurlParams.domain ?? "",
+  url: lnurl,
+  address: lnurlParams.identifier || undefined,
+  allowsNostr: undefined,
+  nostrPubkey: undefined,
+})
+
+const sdkSuccessActionToLib = (
+  sa: SuccessActionProcessed | undefined,
+): LNURLPaySuccessAction | undefined => {
+  if (!sa) return undefined
+
+  if (sa.tag === SuccessActionTag.Message) {
+    return {
+      tag: "message",
+      message: sa.inner.data.message,
+      description: null,
+      url: null,
+      ciphertext: null,
+      iv: null,
+      decipher: () => null,
+    }
+  }
+
+  if (sa.tag === SuccessActionTag.Url) {
+    return {
+      tag: "url",
+      message: null,
+      description: sa.inner.data.description,
+      url: sa.inner.data.url,
+      ciphertext: null,
+      iv: null,
+      decipher: () => null,
+    }
+  }
+
+  const result = sa.inner.result
+  if (result.tag === AesResultTag.Decrypted) {
+    const decrypted = result.inner.data
+    return {
+      tag: "aes",
+      message: null,
+      description: decrypted.description,
+      url: null,
+      ciphertext: null,
+      iv: null,
+      decipher: () => decrypted.plaintext,
+    }
+  }
+
+  return {
+    tag: "aes",
+    message: null,
+    description: result.inner.reason,
+    url: null,
+    ciphertext: null,
+    iv: null,
+    decipher: () => null,
+  }
+}
+
+const asBtcSettlementAmount = <T extends WalletCurrency>(
+  feeSats: number,
+): WalletAmount<T> => toBtcMoneyAmount(feeSats) as unknown as WalletAmount<T>
+
+type CreateSCLnurlParams<T extends WalletCurrency> = {
+  sdk: BreezSdkInterface
+  lnurl: string
+  lnurlParams: LnUrlPayServiceResponse
+  unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
+  successAction?: LNURLPaySuccessAction
+  isMerchant: boolean
+} & BaseCreatePaymentDetailsParams<T>
+
+export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>(
+  params: CreateSCLnurlParams<T>,
+): PaymentDetail<T> => {
+  const {
+    sdk,
+    lnurl,
+    lnurlParams,
+    unitOfAccountAmount,
+    convertMoneyAmount,
+    sendingWalletDescriptor,
+    destinationSpecifiedMemo,
+    senderSpecifiedMemo,
+    successAction,
+    isMerchant,
+  } = params
+
+  const destinationSpecifiedAmount =
+    lnurlParams.max === lnurlParams.min ? toBtcMoneyAmount(lnurlParams.max) : undefined
+
+  const memo = destinationSpecifiedMemo || senderSpecifiedMemo
+  const settlementAmount = convertMoneyAmount(
+    unitOfAccountAmount,
+    sendingWalletDescriptor.currency,
+  )
+  const isUsdSend = sendingWalletDescriptor.currency === WalletCurrency.Usd
+  const payRequest = lnurlParamsToPayRequest(lnurlParams, lnurl)
+
+  const prepareOptions = {
+    amount: toSdkSendAmount(settlementAmount.amount, sendingWalletDescriptor.currency),
+    payRequest,
+    comment: lnurlParams.commentAllowed && memo ? memo : undefined,
+    tokenIdentifier: resolveSendTokenIdentifier(sendingWalletDescriptor.currency),
+    conversionOptions: isUsdSend
+      ? {
+          conversionType: buildConversionType(ConvertDirection.UsdToBtc),
+          maxSlippageBps: undefined,
+          completionTimeoutSecs: undefined,
+        }
+      : undefined,
+    feePolicy: isUsdSend ? FeePolicy.FeesIncluded : undefined,
+  }
+
+  const sendPaymentAndGetFee: PaymentDetailSendPaymentGetFee<T> = settlementAmount.amount
+    ? {
+        canSendPayment: true,
+        canGetFee: true,
+        getFee: async () => {
+          try {
+            const prepared = await prepareLnurl(sdk, prepareOptions)
+            const feeSats = extractLnurlFee(prepared)
+            return { amount: asBtcSettlementAmount<T>(feeSats) }
+          } catch {
+            return { amount: undefined }
+          }
+        },
+        sendPaymentMutation: async () => {
+          try {
+            const prepared = await prepareLnurl(sdk, prepareOptions)
+            const result = await executeLnurl(sdk, prepared)
+            return {
+              status: PaymentSendResult.Success,
+              extraInfo: {
+                successAction: sdkSuccessActionToLib(result.successAction),
+              },
+            }
+          } catch (err) {
+            return {
+              status: PaymentSendResult.Failure,
+              errors: [
+                {
+                  __typename: "GraphQLApplicationError" as const,
+                  message: classifySdkError(err),
+                },
+              ],
+            }
+          }
+        },
+      }
+    : { canSendPayment: false, canGetFee: false }
+
+  const setMemo: PaymentDetailSetMemo<T> = {
+    canSetMemo: true,
+    setMemo: (newMemo) =>
+      createSelfCustodialLnurlPaymentDetails({
+        ...params,
+        senderSpecifiedMemo: newMemo,
+      }),
+  }
+
+  const setAmount: SetAmount<T> = (newAmount) =>
+    createSelfCustodialLnurlPaymentDetails({
+      ...params,
+      unitOfAccountAmount: newAmount,
+    })
+
+  const setSendingWalletDescriptor: SetSendingWalletDescriptor<T> = (desc) =>
+    createSelfCustodialLnurlPaymentDetails({
+      ...params,
+      sendingWalletDescriptor: desc,
+    })
+
+  const setConvertMoneyAmount = (fn: ConvertMoneyAmount) =>
+    createSelfCustodialLnurlPaymentDetails({ ...params, convertMoneyAmount: fn })
+
+  const setInvoice: SetInvoice<T> = () =>
+    createSelfCustodialLnurlPaymentDetails({ ...params })
+
+  const setSuccessAction: SetSuccessAction<T> = (newSuccessAction) =>
+    createSelfCustodialLnurlPaymentDetails({
+      ...params,
+      successAction: newSuccessAction,
+    })
+
+  return {
+    destination: lnurl,
+    memo,
+    convertMoneyAmount,
+    setConvertMoneyAmount,
+    paymentType: PaymentType.Lnurl,
+    settlementAmount,
+    settlementAmountIsEstimated: false,
+    unitOfAccountAmount,
+    sendingWalletDescriptor,
+    setSendingWalletDescriptor,
+    lnurlParams,
+    setInvoice,
+    successAction,
+    setSuccessAction,
+    isMerchant,
+    ...(destinationSpecifiedAmount
+      ? { canSetAmount: false as const, destinationSpecifiedAmount }
+      : { canSetAmount: true as const, setAmount }),
+    ...setMemo,
+    ...sendPaymentAndGetFee,
+  } as PaymentDetail<T>
+}

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -97,12 +97,12 @@ const sdkSuccessActionToLib = (
     const decrypted = result.inner.data
     return {
       tag: "aes",
-      message: null,
+      message: decrypted.plaintext,
       description: decrypted.description,
       url: null,
       ciphertext: null,
       iv: null,
-      decipher: () => decrypted.plaintext,
+      decipher: () => null,
     }
   }
 

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -8,6 +8,7 @@ import {
 } from "@breeztech/breez-sdk-spark-react-native"
 import { PaymentType } from "@blinkbitcoin/blink-client"
 import { LnUrlPayServiceResponse, LNURLPaySuccessAction } from "lnurl-pay"
+import Crypto from "react-native-quick-crypto"
 
 import { PaymentSendResult, WalletCurrency } from "@app/graphql/generated"
 import {
@@ -128,6 +129,7 @@ type CreateSCLnurlParams<T extends WalletCurrency> = {
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
   successAction?: LNURLPaySuccessAction
   isMerchant: boolean
+  idempotencyKey?: string
 } & BaseCreatePaymentDetailsParams<T>
 
 export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>(
@@ -145,6 +147,9 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
     successAction,
     isMerchant,
   } = params
+
+  const idempotencyKey = params.idempotencyKey ?? Crypto.randomUUID()
+  const paramsWithKey: CreateSCLnurlParams<T> = { ...params, idempotencyKey }
 
   const destinationSpecifiedAmount =
     lnurlParams.max === lnurlParams.min ? toBtcMoneyAmount(lnurlParams.max) : undefined
@@ -188,7 +193,7 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
         sendPaymentMutation: async () => {
           try {
             const prepared = await prepareLnurl(sdk, prepareOptions)
-            const result = await executeLnurl(sdk, prepared)
+            const result = await executeLnurl(sdk, prepared, idempotencyKey)
             return {
               status: PaymentSendResult.Success,
               extraInfo: {
@@ -214,32 +219,32 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
     canSetMemo: true,
     setMemo: (newMemo) =>
       createSelfCustodialLnurlPaymentDetails({
-        ...params,
+        ...paramsWithKey,
         senderSpecifiedMemo: newMemo,
       }),
   }
 
   const setAmount: SetAmount<T> = (newAmount) =>
     createSelfCustodialLnurlPaymentDetails({
-      ...params,
+      ...paramsWithKey,
       unitOfAccountAmount: newAmount,
     })
 
   const setSendingWalletDescriptor: SetSendingWalletDescriptor<T> = (desc) =>
     createSelfCustodialLnurlPaymentDetails({
-      ...params,
+      ...paramsWithKey,
       sendingWalletDescriptor: desc,
     })
 
   const setConvertMoneyAmount = (fn: ConvertMoneyAmount) =>
-    createSelfCustodialLnurlPaymentDetails({ ...params, convertMoneyAmount: fn })
+    createSelfCustodialLnurlPaymentDetails({ ...paramsWithKey, convertMoneyAmount: fn })
 
   const setInvoice: SetInvoice<T> = () =>
-    createSelfCustodialLnurlPaymentDetails({ ...params })
+    createSelfCustodialLnurlPaymentDetails({ ...paramsWithKey })
 
   const setSuccessAction: SetSuccessAction<T> = (newSuccessAction) =>
     createSelfCustodialLnurlPaymentDetails({
-      ...params,
+      ...paramsWithKey,
       successAction: newSuccessAction,
     })
 

--- a/app/self-custodial/payment-details/wrap-destination.ts
+++ b/app/self-custodial/payment-details/wrap-destination.ts
@@ -1,5 +1,6 @@
 import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 import { PaymentType } from "@blinkbitcoin/blink-client"
+import { LnUrlPayServiceResponse } from "lnurl-pay"
 
 import { WalletCurrency } from "@app/graphql/generated"
 import { FeeTierOption } from "@app/screens/send-bitcoin-screen/hooks/fee-tiers.types"
@@ -12,6 +13,7 @@ import { toBtcMoneyAmount } from "@app/types/amounts"
 import { PaymentType as SelfCustodialPaymentType } from "@app/types/transaction.types"
 
 import { createSelfCustodialLightningPaymentDetails } from "./lightning"
+import { createSelfCustodialLnurlPaymentDetails } from "./lnurl"
 import { createSelfCustodialOnchainPaymentDetails } from "./onchain"
 import { createSelfCustodialSparkPaymentDetails } from "./spark"
 
@@ -26,7 +28,11 @@ type ValidDestination = Extract<
 
 type LightningDestination = Extract<
   ValidDestination,
-  { paymentType: typeof PaymentType.Lightning | typeof PaymentType.Lnurl }
+  { paymentType: typeof PaymentType.Lightning }
+>
+type LnurlDestination = Extract<
+  ValidDestination,
+  { paymentType: typeof PaymentType.Lnurl; lnurlParams: LnUrlPayServiceResponse }
 >
 type OnchainDestination = Extract<
   ValidDestination,
@@ -51,19 +57,32 @@ const buildLightningDetail = <T extends WalletCurrency>({
 }: BuildArgs<T, LightningDestination>) => {
   const invoiceAmount =
     "amount" in destination && destination.amount ? destination.amount : 0
-  const paymentRequest =
-    "paymentRequest" in destination ? destination.paymentRequest : destination.lnurl
   const invoiceMemo = "memo" in destination ? destination.memo : undefined
 
   return createSelfCustodialLightningPaymentDetails({
     sdk,
-    paymentRequest,
+    paymentRequest: destination.paymentRequest,
     unitOfAccountAmount: toBtcMoneyAmount(invoiceAmount),
     hasAmount: invoiceAmount > 0,
     ...params,
     destinationSpecifiedMemo: invoiceMemo,
   })
 }
+
+const buildLnurlDetail = <T extends WalletCurrency>({
+  sdk,
+  destination,
+  params,
+}: BuildArgs<T, LnurlDestination>) =>
+  createSelfCustodialLnurlPaymentDetails({
+    sdk,
+    lnurl: destination.lnurl,
+    lnurlParams: destination.lnurlParams,
+    unitOfAccountAmount: toBtcMoneyAmount(destination.lnurlParams.min || 0),
+    isMerchant: destination.isMerchant,
+    destinationSpecifiedMemo: destination.lnurlParams.description,
+    ...params,
+  })
 
 const buildSparkDetail = <T extends WalletCurrency>({
   sdk,
@@ -108,10 +127,16 @@ export const wrapDestination = (
     ) => {
       switch (original.paymentType) {
         case PaymentType.Lightning:
-        case PaymentType.Lnurl:
           return buildLightningDetail({
             sdk,
             destination: original as LightningDestination,
+            params,
+            options,
+          })
+        case PaymentType.Lnurl:
+          return buildLnurlDetail({
+            sdk,
+            destination: original as LnurlDestination,
             params,
             options,
           })


### PR DESCRIPTION
# Spark: LNURL pay and Lightning Address support for self-custodial sends

## What this PR does

Adds first-class support for paying to LNURL-pay endpoints and Lightning Addresses (`user@domain.com`) from a self-custodial Spark wallet. The custodial flow already handled these via the `lnurl-pay` library + `lnInvoicePaymentSend` mutation, but in self-custodial mode the destination resolver was incorrectly routing both formats to the Bolt11 path (which the SDK can't decode), so the prepare step always failed. This PR routes LNURL through the SDK's native `prepareLnurlPay` / `lnurlPay` methods, mapping the destination shape from the lnurl-pay library to the SDK contract, and propagates the SDK-returned `SuccessAction` back to the completed screen.

## Bridge — new SDK wrappers

Three small wrappers added to `app/self-custodial/bridge/send.ts` next to the existing `prepareSend` / `executeSend` helpers, following the same pattern (one wrapper per SDK method, plus an extract helper for the fee):

- `prepareLnurl(sdk, options)` wraps `sdk.prepareLnurlPay`. The `PrepareLnurlOptions` type only exposes the fields the app actually uses today (`amount`, `payRequest`, optional `comment`, `tokenIdentifier`, `conversionOptions`, `feePolicy`). The SDK's other knobs (`validateSuccessActionUrl`, etc.) are left at default.
- `executeLnurl(sdk, prepared, idempotencyKey?)` wraps `sdk.lnurlPay`.
- `extractLnurlFee(prepared)` returns `feeSats` as a plain number, mirroring `extractLightningFee` for symmetry at call sites.

## Payment-details — new self-custodial LNURL detail

New file `app/self-custodial/payment-details/lnurl.ts` exporting `createSelfCustodialLnurlPaymentDetails`. It produces a `PaymentDetail<T>` that satisfies the shared screen contract (with `paymentType: PaymentType.Lnurl`, `lnurlParams`, `setInvoice`, `setSuccessAction`, `isMerchant`) and internally talks to the SDK via the new bridge wrappers.

The piece that took the longest to get right is the **prepare-options shape**, because the SDK enforces a specific combination depending on the source asset:

| Source wallet | `amount` units                  | `tokenIdentifier`   | `conversionOptions`   | `feePolicy`     |
|---------------|---------------------------------|---------------------|-----------------------|-----------------|
| BTC           | sats                            | undefined           | undefined             | undefined       |
| USD (USDB)    | USDB base units (cents × 10⁴)   | configured USDB id  | `ToBitcoin`           | `FeesIncluded`  |

For USD wallets the SDK rejects any other `feePolicy` with `"Token conversion with token_identifier requires FeesIncluded fee policy"`, so this is mandatory. The behavioral consequence is documented under "Fee semantics" below.

A small helper `lnurlParamsToPayRequest` converts `LnUrlPayServiceResponse` (sats + parsed metadata array, from the lnurl-pay lib used by the existing custodial parser) into `LnurlPayRequestDetails` (millisats + raw metadata string, the SDK shape). The metadata string is taken verbatim from `lnurlParams.rawData.metadata` when present so the LUD-06 description-hash check inside the SDK matches the server's original payload byte-for-byte; if `rawData.metadata` isn't a string it falls back to `JSON.stringify(lnurlParams.metadata)` which is good enough for endpoints that don't expose the raw form.

`SuccessActionProcessed` returned by `lnurlPay` (the SDK has already deciphered AES payloads server-side) is mapped back to the `LNURLPaySuccessAction` shape that `lnurl-pay` exposes, so the existing completed-screen code paths render it without changes. AES `decipher(preimage)` returns the SDK-supplied plaintext directly since decryption already happened.

## Routing — `wrap-destination.ts`

The `Lnurl` branch is split off from `Lightning`. Previously both shared `buildLightningDetail`, which fed `destination.lnurl` (a bech32 LNURL string or LN Address) into `createSelfCustodialLightningPaymentDetails` as the `paymentRequest` — the SDK can't decode that, so the very first `prepareSend` call failed with `InvalidInput`. The new `buildLnurlDetail` calls `createSelfCustodialLnurlPaymentDetails` with `lnurl`, `lnurlParams`, `isMerchant`, and seeds `unitOfAccountAmount` from `lnurlParams.min` (minimum sendable in sats) so the screen can render an initial value.

The `LnurlDestination` Extract type is narrowed by `lnurlParams: LnUrlPayServiceResponse` to exclude `LnurlWithdrawDestination` (Receive direction), keeping TypeScript happy on the runtime guard already enforced by `wrapDestinationForSC`.

## Screen integrations

### Send-bitcoin destination screen

A single-line gate: when self-custodial, pass `lnurlDomains: []` to `parseDestination` so Blink-owned LN addresses (`user@blink.sv`) are not silently optimized into the Intraledger payment type. That optimization is custodial-specific (the destination becomes an internal-ledger transfer that requires backend auth, which the self-custodial wallet does not have); without this gate paying to a Blink LN Address from a self-custodial wallet would fail with `Not authorized` after pressing Next. With the gate, the same input flows through the regular LNURL path and resolves through the new SC LNURL detail.

### Send-bitcoin details screen

The existing custodial flow runs `requestInvoice(...)` from the `lnurl-pay` library on `Next` to materialize a Bolt11 invoice before showing the confirmation screen. Self-custodial doesn't need that step because the SDK fetches the invoice internally as part of `prepareLnurlPay`. One-line gate: only run the requestInvoice block when `paymentDetail.sendPaymentMutation` is undefined (custodial LNURL details start with `canSendPayment: false` until `setInvoice` is called; self-custodial LNURL details have a working `sendPaymentMutation` from the moment the user picks an amount).

### Send-bitcoin confirmation screen

Two changes:

1. `PaymentSendExtraInfo` now carries an optional `successAction`. When the SC LNURL `sendPaymentMutation` resolves, it includes the SDK's `successAction` in `extraInfo` (mapped to the lnurl-pay shape). The confirmation screen prefers `extraInfo?.successAction ?? paymentDetail?.successAction` when navigating to the completed screen, so the post-payment message/URL/AES disclosure shows up for both flows. Custodial keeps populating `paymentDetail.successAction` ahead of `sendPayment`, so the fallback covers it.

2. `saveLnAddressContact` is skipped when `useActiveWallet().isSelfCustodial` is true. That helper hits the `contactCreate` GraphQL mutation, which requires backend auth; without the gate a successful self-custodial LNURL payment was followed by a visible `Not authorized` error toast even though the payment itself had completed. Custodial users keep the existing behavior.

## Fee semantics

For the BTC self-custodial wallet, `feePolicy` is left as the SDK default (`FeesExcluded`): the recipient receives the exact sats amount the user picked and the routing fee is added on top. This matches the custodial Lightning behavior.

For the USD self-custodial wallet, the SDK requires `FeesIncluded` whenever a `tokenIdentifier` + `conversionOptions` combination is used, so the user spends an exact USDB amount and the recipient receives the post-conversion, post-routing-fee BTC value. In practical terms the recipient gets ~1% less than the headline amount; that gap is the Spark conversion-pool spread (invisible in the UI) plus a few sats of LN routing (visible). This is a hard SDK constraint, not a design choice — a manual two-step (convert USDB → BTC first, then pay LNURL with BTC) could match custodial semantics but would require a separate transaction and rollback handling, which is out of scope for this PR.

## Tests

All specs scoped to the affected files; full suite passes (3438/3438).

- `__tests__/self-custodial/bridge/send.spec.ts` — added 14 cases covering `prepareLnurl` (forwarding amount/payRequest/comment, USD-wallet shape with tokenIdentifier+conversionOptions+feePolicy, BTC-wallet shape with neither), `extractLnurlFee` (number coercion + zero), `executeLnurl` (idempotency key forwarding).
- `__tests__/self-custodial/payment-details/lnurl.spec.ts` — new, 22 cases covering payment type, amount handling (fixed via min===max vs range, setAmount), memo handling (description vs sender memo, setMemo), the per-currency prepareOptions matrix, comment gating by `commentAllowed`, getFee success/failure, sendPaymentMutation success with all three SuccessAction variants (Message, URL, AES decipher passthrough), error classification, raw metadata preservation, and millisat conversion.
- `__tests__/self-custodial/payment-details/wrap-destination.spec.ts` — updated the existing Lnurl case to assert routing through the new SC LNURL detail (not the lightning detail), plus a merchant-flag propagation case.
- `__tests__/screens/send-confirmation.spec.tsx` — added a case that mocks `useActiveWallet` to return `{ isSelfCustodial: true }` and asserts `saveLnAddressContact` is not called after a successful LNURL payment.

## Breaking notes

None for consumers. The shared `PaymentDetail` types gain an optional `successAction` field on `PaymentSendExtraInfo`. All in-tree senders are unaffected because the field is optional and the confirmation screen uses `??` fallback.

## Manual verification done

- Lightning Address from a USD wallet: `deepbassoon958@walletofsatoshi.com` for $1 — pays correctly, recipient receives the converted amount, fee shown ($0.00 / 5 SAT), completed screen renders with the description.
- Lightning Address from a BTC wallet (500 sats) — pays correctly, recipient receives the exact 500 sats, fee charged on top.
- Bech32 LNURL from `esaudeveloper@blink.sv` — pays correctly via the new SC LNURL path (Intraledger optimization disabled in SC mode).

The original implementation iterations and the SDK's exact `tokenIdentifier` / `conversionOptions` / `feePolicy` requirements are documented at length in commit messages and tests.
