### PR TITLE
Add BTC Map places to merchant map

### DIFF
--- a/__tests__/screens/map-screen/btc-map.spec.ts
+++ b/__tests__/screens/map-screen/btc-map.spec.ts
@@ -1,0 +1,96 @@
+import { MapMarker } from "@app/graphql/generated"
+import {
+  btcMapPlaceToMarker,
+  btcMapSearchUrlForRegion,
+  calculateBtcMapRadiusKm,
+  mergeMapMarkers,
+} from "@app/screens/map-screen/btc-map"
+
+const blinkMarker = {
+  username: "hope-house",
+  mapInfo: {
+    title: "Hope House",
+    coordinates: {
+      latitude: 13.4972995,
+      longitude: -89.4414673,
+    },
+  },
+} as MapMarker
+
+const osmIdField = "osm_id"
+const verifiedAtField = "verified_at"
+
+describe("btc map markers", () => {
+  it("maps BTC Map places to mobile map markers", () => {
+    const marker = btcMapPlaceToMarker({
+      id: 239,
+      lat: 13.4972995,
+      lon: -89.4414673,
+      name: "Hope House",
+      address: "El Zonte",
+      website: "https://hopehouseelsalvador.org/",
+      [osmIdField]: "node:10065166137",
+      [verifiedAtField]: "2026-01-06T00:00:00Z",
+    })
+
+    expect(marker).toEqual({
+      source: "btcmap",
+      id: "btcmap:239",
+      btcMapId: 239,
+      btcMapUrl: "https://btcmap.org/merchant/239",
+      address: "El Zonte",
+      website: "https://hopehouseelsalvador.org/",
+      osmId: "node:10065166137",
+      verifiedAt: "2026-01-06T00:00:00Z",
+      mapInfo: {
+        title: "Hope House",
+        coordinates: {
+          latitude: 13.4972995,
+          longitude: -89.4414673,
+        },
+      },
+    })
+  })
+
+  it("does not create markers without coordinates", () => {
+    expect(btcMapPlaceToMarker({ id: 1, name: "Missing Coordinates" })).toBeUndefined()
+  })
+
+  it("caps wide viewport searches before calling BTC Map", () => {
+    const radiusKm = calculateBtcMapRadiusKm({
+      latitude: 13.496743,
+      longitude: -89.439462,
+      latitudeDelta: 15,
+      longitudeDelta: 15,
+    })
+
+    expect(radiusKm).toBe(100)
+    expect(
+      btcMapSearchUrlForRegion({
+        latitude: 13.496743,
+        longitude: -89.439462,
+        latitudeDelta: 15,
+        longitudeDelta: 15,
+      }),
+    ).toBe(
+      "https://api.btcmap.org/v4/places/search/?lat=13.496743&lon=-89.439462&radius_km=100.0",
+    )
+  })
+
+  it("keeps Blink markers when BTC Map returns a duplicate coordinate", () => {
+    const duplicateMarker = btcMapPlaceToMarker({
+      id: 239,
+      lat: 13.4972995,
+      lon: -89.4414673,
+      name: "Hope House",
+    })
+
+    expect(duplicateMarker).toBeDefined()
+    const markers = mergeMapMarkers(
+      [blinkMarker],
+      duplicateMarker ? [duplicateMarker] : [],
+    )
+
+    expect(markers).toEqual([blinkMarker])
+  })
+})

--- a/app/components/map-component/index.tsx
+++ b/app/components/map-component/index.tsx
@@ -6,7 +6,11 @@ import { PermissionStatus, RESULTS, request } from "react-native-permissions"
 
 import { useApolloClient } from "@apollo/client"
 import { updateMapLastCoords } from "@app/graphql/client-only-query"
-import { BusinessMapMarkersQuery, MapMarker } from "@app/graphql/generated"
+import {
+  MerchantMapMarker,
+  getMarkerKey,
+  isBtcMapMarker,
+} from "@app/screens/map-screen/btc-map"
 import { LOCATION_PERMISSION, getUserRegion } from "@app/screens/map-screen/functions"
 import { isIOS } from "@rn-vui/base"
 import { makeStyles, useTheme } from "@rn-vui/themed"
@@ -17,15 +21,16 @@ import MapStyles from "./map-styles.json"
 import { OpenSettingsElement, OpenSettingsModal } from "./open-settings-modal"
 
 type Props = {
-  data?: BusinessMapMarkersQuery
+  data?: readonly MerchantMapMarker[]
   userLocation?: Region
   permissionsStatus?: PermissionStatus
   setPermissionsStatus: (_: PermissionStatus) => void
   handleMapPress: () => void
-  handleMarkerPress: (_: MapMarker) => void
-  focusedMarker: MapMarker | null
+  handleMarkerPress: (_: MerchantMapMarker, _ref?: MapMarkerType) => void
+  focusedMarker: MerchantMapMarker | null
   focusedMarkerRef: React.MutableRefObject<MapMarkerType | null>
-  handleCalloutPress: (_: MapMarker) => void
+  handleCalloutPress: (_: MerchantMapMarker) => void
+  handleRegionChangeComplete: (_: Region) => void
   alertOnLocationError: () => void
 }
 
@@ -39,6 +44,7 @@ export default function MapComponent({
   focusedMarker,
   focusedMarkerRef,
   handleCalloutPress,
+  handleRegionChangeComplete,
   alertOnLocationError,
 }: Props) {
   const {
@@ -119,6 +125,7 @@ export default function MapComponent({
         customMapStyle={themeMode === "dark" ? MapStyles.dark : MapStyles.light}
         onPress={handleMapPress}
         onRegionChange={debouncedHandleRegionChange}
+        onRegionChangeComplete={handleRegionChangeComplete}
         onMarkerSelect={(e) => {
           // react-native-maps has a very annoying error on iOS
           // When two markers are almost on top of each other onSelect will get called for a nearby Marker
@@ -136,14 +143,16 @@ export default function MapComponent({
           }
         }}
       >
-        {(data?.businessMapMarkers ?? []).map((item: MapMarker) => (
+        {(data ?? []).map((item) => (
           <MapMarkerComponent
-            key={item.username}
+            key={getMarkerKey(item)}
             item={item}
-            color={colors._orange}
+            color={isBtcMapMarker(item) ? colors._green : colors._orange}
             handleCalloutPress={handleCalloutPress}
             handleMarkerPress={handleMarkerPress}
-            isFocused={focusedMarker?.username === item.username}
+            isFocused={
+              focusedMarker ? getMarkerKey(focusedMarker) === getMarkerKey(item) : false
+            }
           />
         ))}
       </MapView>

--- a/app/components/map-marker-component/index.tsx
+++ b/app/components/map-marker-component/index.tsx
@@ -7,8 +7,8 @@ import {
   Marker,
 } from "react-native-maps"
 
-import { MapMarker } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { MerchantMapMarker, isBtcMapMarker } from "@app/screens/map-screen/btc-map"
 import { isIos } from "@app/utils/helper"
 import { Text, makeStyles } from "@rn-vui/themed"
 
@@ -19,10 +19,10 @@ import { Text, makeStyles } from "@rn-vui/themed"
 */
 
 type Props = {
-  item: MapMarker
+  item: MerchantMapMarker
   color: string
-  handleMarkerPress: (_item: MapMarker, _ref?: MapMarkerType) => void
-  handleCalloutPress: (item: MapMarker) => void
+  handleMarkerPress: (_item: MerchantMapMarker, _ref?: MapMarkerType) => void
+  handleCalloutPress: (item: MerchantMapMarker) => void
   isFocused: boolean
 }
 
@@ -36,6 +36,7 @@ export default function MapMarkerComponent({
   const ref = useRef<MapMarkerType>(null)
   const { LL } = useI18nContext()
   const styles = useStyles()
+  const actionText = isBtcMapMarker(item) ? "Open in BTC Map" : LL.MapScreen.payBusiness()
 
   useEffect(() => {
     if (isFocused && ref.current) {
@@ -45,7 +46,7 @@ export default function MapMarkerComponent({
 
   return (
     <Marker
-      id={item.username}
+      id={isBtcMapMarker(item) ? item.id : item.username}
       ref={ref}
       coordinate={item.mapInfo.coordinates}
       pinColor={color}
@@ -61,15 +62,20 @@ export default function MapMarkerComponent({
               <Text type="h1" style={styles.title} numberOfLines={2} ellipsizeMode="tail">
                 {item.mapInfo.title}
               </Text>
+              {isBtcMapMarker(item) && item.address && (
+                <Text style={styles.subtitle} numberOfLines={2} ellipsizeMode="tail">
+                  {item.address}
+                </Text>
+              )}
               {isIos ? (
                 <CalloutSubview onPress={() => handleCalloutPress(item)}>
                   <View style={styles.pseudoButton}>
-                    <Text style={styles.text}>{LL.MapScreen.payBusiness()}</Text>
+                    <Text style={styles.text}>{actionText}</Text>
                   </View>
                 </CalloutSubview>
               ) : (
                 <View style={styles.pseudoButton}>
-                  <Text style={styles.text}>{LL.MapScreen.payBusiness()}</Text>
+                  <Text style={styles.text}>{actionText}</Text>
                 </View>
               )}
             </View>
@@ -110,6 +116,13 @@ const useStyles = makeStyles(({ colors }) => ({
   },
 
   title: { color: colors.black, textAlign: "center" },
+
+  subtitle: {
+    color: colors.grey2,
+    fontSize: 14,
+    lineHeight: 18,
+    textAlign: "center",
+  },
 
   text: {
     fontSize: 20,

--- a/app/screens/map-screen/btc-map.ts
+++ b/app/screens/map-screen/btc-map.ts
@@ -1,0 +1,139 @@
+import { Region } from "react-native-maps"
+
+import { MapMarker } from "@app/graphql/generated"
+
+const BTC_MAP_API_URL = "https://api.btcmap.org/v4/places/search/"
+const BTC_MAP_PLACE_URL = "https://btcmap.org/merchant"
+const KM_PER_LATITUDE_DEGREE = 111.32
+const MIN_RADIUS_KM = 2
+const MAX_RADIUS_KM = 100
+
+export type BtcMapPlace = {
+  id?: number
+  lat?: number
+  lon?: number
+  name?: string | null
+  address?: string | null
+  website?: string | null
+  osm_id?: string | null
+  verified_at?: string | null
+}
+
+export type BtcMapMarker = {
+  source: "btcmap"
+  id: string
+  btcMapId: number
+  btcMapUrl: string
+  address?: string
+  website?: string
+  osmId?: string
+  verifiedAt?: string
+  mapInfo: {
+    title: string
+    coordinates: {
+      latitude: number
+      longitude: number
+    }
+  }
+}
+
+export type MerchantMapMarker = MapMarker | BtcMapMarker
+
+export const isBtcMapMarker = (marker: MerchantMapMarker): marker is BtcMapMarker =>
+  "source" in marker && marker.source === "btcmap"
+
+export const getMarkerKey = (marker: MerchantMapMarker): string =>
+  isBtcMapMarker(marker) ? marker.id : marker.username
+
+const cleanOptionalString = (value?: string | null) => {
+  const cleaned = value?.trim()
+  return cleaned ? cleaned : undefined
+}
+
+const coordinatesKey = (marker: MerchantMapMarker) => {
+  const { latitude, longitude } = marker.mapInfo.coordinates
+  return `${latitude.toFixed(5)}:${longitude.toFixed(5)}`
+}
+
+export const calculateBtcMapRadiusKm = (region: Region) => {
+  const latitudeRadians = (Math.min(Math.abs(region.latitude), 85) * Math.PI) / 180
+  const halfLatitudeKm = (region.latitudeDelta * KM_PER_LATITUDE_DEGREE) / 2
+  const halfLongitudeKm =
+    (region.longitudeDelta * KM_PER_LATITUDE_DEGREE * Math.cos(latitudeRadians)) / 2
+  const viewportRadiusKm = Math.sqrt(
+    halfLatitudeKm * halfLatitudeKm + halfLongitudeKm * halfLongitudeKm,
+  )
+
+  return Math.min(Math.max(viewportRadiusKm, MIN_RADIUS_KM), MAX_RADIUS_KM)
+}
+
+export const btcMapSearchUrlForRegion = (region: Region) => {
+  const radiusKm = calculateBtcMapRadiusKm(region).toFixed(1)
+  return `${BTC_MAP_API_URL}?lat=${region.latitude.toFixed(
+    6,
+  )}&lon=${region.longitude.toFixed(6)}&radius_km=${radiusKm}`
+}
+
+export const btcMapPlaceToMarker = (place: BtcMapPlace): BtcMapMarker | undefined => {
+  if (
+    !Number.isFinite(place.id) ||
+    !Number.isFinite(place.lat) ||
+    !Number.isFinite(place.lon)
+  ) {
+    return undefined
+  }
+
+  const btcMapId = place.id as number
+  const title = cleanOptionalString(place.name) ?? "BTC Map place"
+
+  return {
+    source: "btcmap",
+    id: `btcmap:${btcMapId}`,
+    btcMapId,
+    btcMapUrl: `${BTC_MAP_PLACE_URL}/${btcMapId}`,
+    address: cleanOptionalString(place.address),
+    website: cleanOptionalString(place.website),
+    osmId: cleanOptionalString(place.osm_id),
+    verifiedAt: cleanOptionalString(place.verified_at),
+    mapInfo: {
+      title,
+      coordinates: {
+        latitude: place.lat as number,
+        longitude: place.lon as number,
+      },
+    },
+  }
+}
+
+export const fetchBtcMapMarkers = async (region: Region): Promise<BtcMapMarker[]> => {
+  const response = await fetch(btcMapSearchUrlForRegion(region), {
+    headers: {
+      Accept: "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error("Unable to load BTC Map places")
+  }
+
+  const places = (await response.json()) as unknown
+  if (!Array.isArray(places)) {
+    throw new Error("Unexpected BTC Map response")
+  }
+
+  return places
+    .map((place) => btcMapPlaceToMarker(place as BtcMapPlace))
+    .filter((marker): marker is BtcMapMarker => Boolean(marker))
+}
+
+export const mergeMapMarkers = (
+  blinkMarkers: readonly MapMarker[],
+  btcMapMarkers: readonly BtcMapMarker[],
+): MerchantMapMarker[] => {
+  const blinkCoordinates = new Set(blinkMarkers.map(coordinatesKey))
+
+  return [
+    ...blinkMarkers,
+    ...btcMapMarkers.filter((marker) => !blinkCoordinates.has(coordinatesKey(marker))),
+  ]
+}

--- a/app/screens/map-screen/map-screen.tsx
+++ b/app/screens/map-screen/map-screen.tsx
@@ -1,17 +1,13 @@
 import { CountryCode } from "libphonenumber-js/mobile"
 import * as React from "react"
 // eslint-disable-next-line react-native/split-platform-components
-import { Alert, Dimensions } from "react-native"
+import { Alert, Dimensions, Linking } from "react-native"
 import { Region, MapMarker as MapMarkerType } from "react-native-maps"
 import { check, PermissionStatus, RESULTS } from "react-native-permissions"
 
 import { gql } from "@apollo/client"
 import MapComponent from "@app/components/map-component"
-import {
-  MapMarker,
-  useBusinessMapMarkersQuery,
-  useRegionQuery,
-} from "@app/graphql/generated"
+import { useBusinessMapMarkersQuery, useRegionQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import useDeviceLocation from "@app/hooks/use-device-location"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -23,7 +19,9 @@ import countryCodes from "../../../utils/countryInfo.json"
 import { Screen } from "../../components/screen"
 import { RootStackParamList } from "../../navigation/stack-param-lists"
 import { toastShow } from "../../utils/toast"
+import { MerchantMapMarker, isBtcMapMarker, mergeMapMarkers } from "./btc-map"
 import { LOCATION_PERMISSION, getUserRegion } from "./functions"
+import { useBtcMapMarkers } from "./use-btc-map-markers"
 
 const EL_ZONTE_COORDS = {
   latitude: 13.496743,
@@ -77,10 +75,17 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
   const focusedMarkerRef = React.useRef<MapMarkerType | null>(null)
 
   const [initialLocation, setInitialLocation] = React.useState<Region>()
+  const [visibleRegion, setVisibleRegion] = React.useState<Region>()
   const [isRefreshed, setIsRefreshed] = React.useState(false)
-  const [focusedMarker, setFocusedMarker] = React.useState<MapMarker | null>(null)
+  const [focusedMarker, setFocusedMarker] = React.useState<MerchantMapMarker | null>(null)
   const [isInitializing, setInitializing] = React.useState(true)
   const [permissionsStatus, setPermissionsStatus] = React.useState<PermissionStatus>()
+  const { markers: btcMapMarkers, error: btcMapError } = useBtcMapMarkers(visibleRegion)
+
+  const mapMarkers = React.useMemo(
+    () => mergeMapMarkers(data?.businessMapMarkers ?? [], btcMapMarkers),
+    [data?.businessMapMarkers, btcMapMarkers],
+  )
 
   useFocusEffect(() => {
     if (!isRefreshed) {
@@ -91,6 +96,10 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
 
   if (error) {
     toastShow({ message: error.message, LL })
+  }
+
+  if (btcMapError) {
+    toastShow({ message: btcMapError.message, LL })
   }
 
   // On screen load, check (NOT request) if location permissions are given
@@ -120,9 +129,16 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
     if (lastRegionError) {
       setInitializing(false)
       setInitialLocation(EL_ZONTE_COORDS)
+      setVisibleRegion(EL_ZONTE_COORDS)
       alertOnLocationError()
     }
   }, [lastRegionError, alertOnLocationError])
+
+  React.useEffect(() => {
+    if (initialLocation && !visibleRegion) {
+      setVisibleRegion(initialLocation)
+    }
+  }, [initialLocation, visibleRegion])
 
   // Flow when location permissions are denied
   React.useEffect(() => {
@@ -137,6 +153,7 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
           longitudeDelta,
         }
         setInitialLocation(region)
+        setVisibleRegion(region)
         // User is using maps for the first time, so we center on the center of their IP's country
       } else {
         // JSON 'hashmap' with every countrys' code listed with their lat and lng
@@ -153,15 +170,24 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
             longitudeDelta: LONGITUDE_DELTA,
           }
           setInitialLocation(region)
+          setVisibleRegion(region)
           // backup if country code is not recognized
         } else {
           setInitialLocation(EL_ZONTE_COORDS)
+          setVisibleRegion(EL_ZONTE_COORDS)
         }
       }
     }
   }, [isInitializing, countryCode, lastRegion, loading, initialLocation])
 
-  const handleCalloutPress = (item: MapMarker) => {
+  const handleCalloutPress = (item: MerchantMapMarker) => {
+    if (isBtcMapMarker(item)) {
+      Linking.openURL(item.btcMapUrl).catch(() =>
+        toastShow({ message: item.btcMapUrl, LL }),
+      )
+      return
+    }
+
     if (isAuthed) {
       navigation.navigate("sendBitcoinDestination", { username: item.username })
     } else {
@@ -169,7 +195,7 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
     }
   }
 
-  const handleMarkerPress = (item: MapMarker, ref?: MapMarkerType) => {
+  const handleMarkerPress = (item: MerchantMapMarker, ref?: MapMarkerType) => {
     setFocusedMarker(item)
     if (ref) {
       focusedMarkerRef.current = ref
@@ -185,8 +211,9 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
     <Screen>
       {initialLocation && (
         <MapComponent
-          data={data}
+          data={mapMarkers}
           userLocation={initialLocation}
+          handleRegionChangeComplete={setVisibleRegion}
           permissionsStatus={permissionsStatus}
           setPermissionsStatus={setPermissionsStatus}
           handleMapPress={handleMapPress}

--- a/app/screens/map-screen/use-btc-map-markers.ts
+++ b/app/screens/map-screen/use-btc-map-markers.ts
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { Region } from "react-native-maps"
+
+import { BtcMapMarker, fetchBtcMapMarkers } from "./btc-map"
+
+type BtcMapMarkersState = {
+  markers: BtcMapMarker[]
+  error?: Error
+  loading: boolean
+}
+
+export const useBtcMapMarkers = (region?: Region): BtcMapMarkersState => {
+  const [state, setState] = React.useState<BtcMapMarkersState>({
+    markers: [],
+    loading: false,
+  })
+
+  React.useEffect(() => {
+    if (!region) {
+      return
+    }
+
+    let active = true
+    setState((current) => ({ ...current, error: undefined, loading: true }))
+
+    fetchBtcMapMarkers(region)
+      .then((markers) => {
+        if (!active) {
+          return
+        }
+        setState({ markers, loading: false })
+      })
+      .catch((error) => {
+        if (!active) {
+          return
+        }
+        setState({
+          markers: [],
+          loading: false,
+          error:
+            error instanceof Error ? error : new Error("Unable to load BTC Map places"),
+        })
+      })
+
+    return () => {
+      active = false
+    }
+  }, [region])
+
+  return state
+}


### PR DESCRIPTION
## Summary
- fetch nearby BTC Map places for the visible mobile map region
- render BTC Map places as a second marker source while preserving Blink merchant payment markers
- open BTC Map place details from BTC Map callouts and keep Blink callouts routed to payments

## Tests
- ./node_modules/.bin/tsc -p . --noEmit
- ./node_modules/.bin/jest __tests__/screens/map-screen/btc-map.spec.ts --runInBand --forceExit
- ./node_modules/.bin/eslint app/screens/map-screen/map-screen.tsx app/screens/map-screen/btc-map.ts app/screens/map-screen/use-btc-map-markers.ts app/components/map-component/index.tsx app/components/map-marker-component/index.tsx __tests__/screens/map-screen/btc-map.spec.ts --ext .ts,.tsx

BTC bounty payout address: 39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ