### PR TITLE
ci: fix pipeline name to unpause on repipe

### DIFF
--- a/ci/repipe
+++ b/ci/repipe
@@ -19,4 +19,4 @@ ytt -f ci > ${TMPDIR}/pipeline.yml
 echo "Updating pipeline @ ${target}"
 
 fly -t ${target} set-pipeline --team=${team} -p blink-mobile -c ${TMPDIR}/pipeline.yml
-fly -t ${target} unpause-pipeline --team=${team} -p galoy-mobile
+fly -t ${target} unpause-pipeline --team=${team} -p blink-mobile


### PR DESCRIPTION
Small maintenance issue to fix: 
```
./ci/repipe 
Updating pipeline @ ciblink 
no changes to apply 
error: Unexpected Response Status: 409 Conflict
Body: action not allowed for an archived pipeline
```