### PR TITLE
chore: update iOS build tooling to Xcode 26.5

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -98,8 +98,8 @@ You can download XCode and Simulator blazingly fast and let the CLI do all of th
 Here are the commands that do it:
 
 ```bash
-xcodes install 16.4 # Or whatever version direnv tells you about
-xcodes runtimes install "iOS 18.5" # Or the latest iOS out there
+xcodes install 26.5 # Or whatever version direnv tells you about
+xcodes runtimes install "iOS 26.5" # Or the latest iOS out there
 ```
 
 Xcodes install for the first time prompts you for Apple ID and Password. This is because Apple's license for XCode prohibits distribution of XCode from other servers than their own. And downloads from it can only work if you are authenticated. Hence, to use XCode, you need an Apple ID.

--- a/docs/technology-stack.md
+++ b/docs/technology-stack.md
@@ -154,7 +154,7 @@ af, ar, ca, cs, da, de, el, en, es, fr, hr, hu, hy, it, ja, ko, ms, nl, no, pl, 
 ### Build Tools
 | Tool | Purpose |
 |------|---------|
-| Xcode 16.4 | iOS builds |
+| Xcode 26.5 | iOS builds |
 | Android SDK 35 | Android builds |
 | JDK 17 | Android compilation |
 | CocoaPods | iOS dependency management |

--- a/flake.nix
+++ b/flake.nix
@@ -122,8 +122,8 @@
               echo no | avdmanager create avd --force -n Pixel_API_35 --abi "google_apis_playstore/$ARCH" --package "system-images;android-35;google_apis_playstore;$ARCH" --device 'pixel_8'
             fi
 
-            XCODE_VERSION="16.4"
-            XCODE_BUILD="16F6" # When updating xcode version, get it by running xcodes installed
+            XCODE_VERSION="26.5"
+            XCODE_BUILD="17F42" # When updating xcode version, get it by running xcodes installed
             if [[ $(uname) == "Darwin" ]] && [ -z "$CI" ]; then
               sudo xcodes install $XCODE_VERSION 2>/dev/null
               sudo xcodes installed

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :ios do
     )
 
     increment_build_number(build_number: ENV["BUILD_NUMBER"], xcodeproj: "GaloyApp.xcodeproj")
-    xcodes(version: "16.4", select_for_current_build_only: true)
+    xcodes(version: "26.5", select_for_current_build_only: true)
     match(type: "appstore", readonly: is_ci, keychain_name: keychain_name, keychain_password: keychain_password)
     gym(scheme: "GaloyApp", clean:true, export_xcargs: "-allowProvisioningUpdates")
   ensure
@@ -66,7 +66,7 @@ platform :ios do
       is_key_content_base64: true
     )
 
-    xcodes(version: "16.4", select_for_current_build_only: true)
+    xcodes(version: "26.5", select_for_current_build_only: true)
     upload_to_testflight(
       ipa: "./Blink.ipa",
       changelog: "No changelog"
@@ -137,7 +137,7 @@ platform :ios do
 
   desc "Build for end to end tests"
   lane :build_e2e do
-    xcodes(version: "16.4", select_for_current_build_only: true)
+    xcodes(version: "26.5", select_for_current_build_only: true)
     match(type: "appstore", readonly: is_ci)
     gym(scheme: "GaloyApp", include_bitcode: false)
   end


### PR DESCRIPTION
Update the Xcode version used by the Nix dev shell and Fastlane lanes from 16.4 to 26.5, matching the rebuilt Scaleway macOS 26 CI host.

This prevents CI from downloading/selecting Xcode 16.4 during iOS builds and aligns the build with the iOS 26 SDK requirement for App Store Connect uploads.

Also update developer docs to reference Xcode 26.5 and the iOS 26.5 simulator runtime.