### PR TITLE
ci: fix tofu package architecture from 386 to amd64

### DIFF
--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L -O "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/te
   rm -f "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 
 ARG TOFU_VERSION=1.7.2
-RUN wget https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_386.apk -O tofu.apk && \
+RUN wget https://github.com/opentofu/opentofu/releases/download/v${TOFU_VERSION}/tofu_${TOFU_VERSION}_amd64.apk -O tofu.apk && \
   apk add --allow-untrusted tofu.apk
 
 ARG HCLEDIT_VERSION=0.2.8


### PR DESCRIPTION
Modifies only the docker image used in Concourse.