### PR TITLE
ci: reorder overlays in flake.nix to ensure nodejsOverlay is applied last

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,9 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            nodejsOverlay
             self.overlay
             ruby-nix.overlays.default
+            nodejsOverlay
           ];
         };
 


### PR DESCRIPTION
Follow up change to cc714c09415f9e7ad80d3839497c2ce77debfa4f to ensure Node 24 being used.