### PR TITLE
fix(maps): bump react-native-maps to 1.27.2 (Fabric crash fix)


### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "react-native-keychain": "^10.0.0",
     "react-native-linear-gradient": "^2.8.2",
     "react-native-localize": "^3.1.0",
-    "react-native-maps": "1.26.0",
+    "react-native-maps": "1.27.2",
     "react-native-modal": "^13.0.0",
     "react-native-nfc-manager": "^3.14.14",
     "react-native-nitro-modules": "0.35.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23039,10 +23039,10 @@ react-native-localize@^3.1.0:
   resolved "https://registry.npmjs.org/react-native-localize/-/react-native-localize-3.1.0.tgz#1b322c05af21fd3d78d44e9b747d872ab5155b10"
   integrity sha512-A7Rrxl8vuAr5FAqtMFrM5ELLdmszohK6FoHL6qlgxx4HScyOnadoZksbvKHbn+zV5nE8kud2Z4kJM10cN120Zg==
 
-react-native-maps@1.26.0:
-  version "1.26.0"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.26.0.tgz#34622df208ca9be63d81d448da68752d3467e89f"
-  integrity sha512-TmQbkJeh52INqY0oCwl4o1O9qerc4YdyPfTCcnn41aFAs28ZYjG4QAXcVDALXclRFz6eqog3+zgeU7eJ2YVJ+Q==
+react-native-maps@1.27.2:
+  version "1.27.2"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.27.2.tgz#93cd5a79ea3d6f67b145797022beb149cffcc01a"
+  integrity sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==
   dependencies:
     "@types/geojson" "^7946.0.13"
 


### PR DESCRIPTION
## Summary

- Bumps `react-native-maps` from `1.26.0` to `1.27.2` to resolve a Fabric crash on the new architecture (RN 0.85 + `newArchEnabled=true`).
- Root cause: `1.26.0` has two bugs that surface only on RN 0.85's Fabric pipeline — (1) `ViewAttacherGroup` initialization race on Android causing `NullPointerException` on view remount (e.g. account switch), and (2) codegen specs (`NativeComponentGooglePolygon.ts`, `NativeComponentWMSTile.ts`) using the deprecated `react-native/Libraries/Utilities/codegenNativeComponent` import path, producing C++ `RawPropsParser::prepare<>` SIGSEGV at startup.
- Fixed upstream in PR [react-native-maps#5704](https://github.com/react-native-maps/react-native-maps/pull/5704) and the codegen import migration shipped in `1.26.1+`. `1.27.2` is the latest stable per `npm view react-native-maps`.

## Why this version

The official compatibility table requires `1.26.1+` for Fabric on RN ≥ 0.81.1 — we are on RN 0.85.3, so `1.26.0` is out of the supported Fabric range

<img width="443" height="536" alt="image" src="https://github.com/user-attachments/assets/71a2bf36-62eb-4ac4-a1d7-cc11a5ea1f7d" />
