### PR TITLE
fix(self-custodial): Home infinite spinner on account


### DIFF
--- a/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
+++ b/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
@@ -187,6 +187,17 @@ describe("useSdkLifecycle", () => {
       })
     })
 
+    it("transitions to Ready after the first successful snapshot, even when the Synced event never arrives (regression for #3791)", async () => {
+      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
+      captureListener()
+
+      const { result } = renderHook(() => useSdkLifecycle("acct-1", 0))
+
+      await waitFor(() => {
+        expect(result.current.status).toBe(ActiveWalletStatus.Ready)
+      })
+    })
+
     it("surfaces the lastReceivedPaymentId when a PaymentSucceeded event fires", async () => {
       mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
       const listener = captureListener()
@@ -205,70 +216,6 @@ describe("useSdkLifecycle", () => {
       })
 
       expect(result.current.lastReceivedPaymentId).toBe("p1")
-    })
-  })
-
-  describe("initial sync timeout safety net", () => {
-    beforeEach(() => {
-      jest.useFakeTimers()
-    })
-
-    afterEach(() => {
-      jest.useRealTimers()
-    })
-
-    it("escalates out of Loading when the Synced event does not arrive within the timeout window", async () => {
-      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
-      captureListener()
-
-      const { result } = renderHook(() => useSdkLifecycle("acct-1", 0))
-
-      await waitFor(() => {
-        expect(result.current.sdk).not.toBeNull()
-      })
-
-      expect(result.current.status).toBe(ActiveWalletStatus.Loading)
-
-      await act(async () => {
-        jest.advanceTimersByTime(30_000)
-        await Promise.resolve()
-      })
-
-      await waitFor(() => {
-        expect(result.current.status).not.toBe(ActiveWalletStatus.Loading)
-      })
-      expect(mockRecordError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining("Initial sync did not complete"),
-        }),
-      )
-    })
-
-    it("does not fire the timeout escalation once the Synced event arrives in time", async () => {
-      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
-      const listener = captureListener()
-
-      renderHook(() => useSdkLifecycle("acct-1", 0))
-
-      await waitFor(() => {
-        expect(listener.current).not.toBeNull()
-      })
-      await act(async () => {
-        await listener.current?.({ tag: "Synced" })
-      })
-
-      mockRecordError.mockClear()
-
-      await act(async () => {
-        jest.advanceTimersByTime(60_000)
-        await Promise.resolve()
-      })
-
-      expect(mockRecordError).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringContaining("Initial sync did not complete"),
-        }),
-      )
     })
   })
 

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { AppState } from "react-native"
 
-import {
-  type BreezSdkInterface,
-  SdkEvent_Tags as SdkEventTags,
-} from "@breeztech/breez-sdk-spark-react-native"
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 import crashlytics from "@react-native-firebase/crashlytics"
 
 import { ActiveWalletStatus, type WalletState } from "@app/types/wallet"
@@ -63,8 +60,6 @@ const OFFLINE_EXEMPT_STATUSES: readonly ActiveWalletStatus[] = [
 
 const RECONNECT_BACKOFF_MS: readonly number[] = [1000, 3000, 9000]
 
-const INITIAL_SYNC_TIMEOUT_MS = 30_000
-
 const teardownSdk = async (
   sdk: BreezSdkInterface,
   listenerId: string | null,
@@ -91,8 +86,6 @@ export const useSdkLifecycle = (
   const refreshingRef = useRef(false)
   const pendingRefreshRef = useRef(false)
   const rawTxOffsetRef = useRef(0)
-  const initialSyncCompletedRef = useRef(false)
-  const initialSyncTimeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { schedule: scheduleBackoffRetry, reset: resetBackoff } =
     useBackoffRetry(RECONNECT_BACKOFF_MS)
 
@@ -123,14 +116,12 @@ export const useSdkLifecycle = (
         setWallets(snapshot.wallets)
         setHasMoreTransactions(snapshot.hasMore)
         rawTxOffsetRef.current = snapshot.rawTransactionCount // eslint-disable-line require-atomic-updates
-        if (initialSyncCompletedRef.current) {
-          const serviceStatus = await getServiceStatus()
-          setStatus(
-            isDegradedStatus(serviceStatus)
-              ? ActiveWalletStatus.Degraded
-              : ActiveWalletStatus.Ready,
-          )
-        }
+
+        const serviceStatus = await getServiceStatus()
+        const nextStatus = isDegradedStatus(serviceStatus)
+          ? ActiveWalletStatus.Degraded
+          : ActiveWalletStatus.Ready
+        setStatus(nextStatus)
         resetBackoff()
       } catch (err) {
         logSdkEvent(SdkLogLevel.Error, `Failed to refresh wallets: ${err}`)
@@ -181,7 +172,6 @@ export const useSdkLifecycle = (
     let mounted = true
     abortRef.current = false
     const accountId = activeSelfCustodialAccountId
-    initialSyncCompletedRef.current = false
 
     const connectAndListen = async (mnemonic: string) => {
       const connectedSdk = await initSdk(mnemonic, storageDirFor(accountId))
@@ -198,8 +188,6 @@ export const useSdkLifecycle = (
         if (!mounted) return
         if (!REFRESH_EVENTS.has(event.tag)) return
 
-        if (event.tag === SdkEventTags.Synced) initialSyncCompletedRef.current = true
-
         if (PAYMENT_RECEIVED_EVENTS.has(event.tag)) {
           const paymentId = extractPaymentId(event)
           if (paymentId) setLastReceivedPaymentId(paymentId)
@@ -213,16 +201,6 @@ export const useSdkLifecycle = (
       listenerIdRef.current = listenerId
 
       refreshWallets()
-
-      initialSyncTimeoutIdRef.current = setTimeout(() => {
-        if (!mounted || initialSyncCompletedRef.current) return
-        reportError(
-          "SDK lifecycle: initial sync timeout",
-          new Error(`Initial sync did not complete within ${INITIAL_SYNC_TIMEOUT_MS}ms`),
-        )
-        initialSyncCompletedRef.current = true
-        refreshWallets().catch(() => {})
-      }, INITIAL_SYNC_TIMEOUT_MS)
 
       getUserSettings(connectedSdk)
         .then((settings) => {
@@ -263,11 +241,6 @@ export const useSdkLifecycle = (
       mounted = false
       abortRef.current = true
       resetBackoff()
-
-      if (initialSyncTimeoutIdRef.current) {
-        clearTimeout(initialSyncTimeoutIdRef.current)
-        initialSyncTimeoutIdRef.current = null
-      }
 
       const sdk = sdkRef.current
       const listenerId = listenerIdRef.current


### PR DESCRIPTION
## Summary
- Fixes the infinite spinner on the dashboard when adding a self-custodial account from an existing custodial one (ticket #3791). After accepting the terms, the dashboard would hang on a loading state and the currency pills would animate without ever rendering a value, until the user pulled up and closed the transactions sheet as a workaround.
- Root cause: `useSdkLifecycle` was gating the wallet status transition to `Ready` behind an `initialSyncCompletedRef` flag that waited for the first sync event before showing balances.
- With Breez 0.15.0 emitting real-time token balance events, that gate is no longer needed. Removing it lets the dashboard render the new self-custodial wallet right after the SDK connects, without any manual interaction.