### PR TITLE
fix(settings): persist theme preference across account switches


### DIFF
--- a/.storybook/views/story-screen.tsx
+++ b/.storybook/views/story-screen.tsx
@@ -5,7 +5,7 @@ const PersistentStateWrapper: React.FC<React.PropsWithChildren> = ({ children })
   <PersistentStateContext.Provider
     value={{
       persistentState: {
-        schemaVersion: 11,
+        schemaVersion: 12,
         galoyInstance: {
           id: "Main",
         },

--- a/__tests__/hooks/use-effective-display-currency.spec.ts
+++ b/__tests__/hooks/use-effective-display-currency.spec.ts
@@ -14,7 +14,7 @@ const mockUseAccountUpdateDisplayCurrencyMutation = jest.fn(
 )
 const mockUpdateState = jest.fn()
 let mockPersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: undefined as string | undefined,
@@ -51,7 +51,7 @@ describe("useEffectiveDisplayCurrency", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPersistentState = {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
       activeAccountId: undefined,

--- a/__tests__/hooks/use-effective-language.spec.ts
+++ b/__tests__/hooks/use-effective-language.spec.ts
@@ -14,7 +14,7 @@ const mockUseUserUpdateLanguageMutation = jest.fn(
 )
 const mockUpdateState = jest.fn()
 let mockPersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: undefined as string | undefined,
@@ -47,7 +47,7 @@ describe("useEffectiveLanguage", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPersistentState = {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
       activeAccountId: undefined,

--- a/__tests__/hooks/use-show-warning-secure-account.spec.tsx
+++ b/__tests__/hooks/use-show-warning-secure-account.spec.tsx
@@ -16,7 +16,7 @@ jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
     persistentState: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
     },

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -33,7 +33,7 @@ it("migration from 5 to current returns ok with the migrated state", async () =>
   expect(result).toEqual({
     status: MigrationStatus.Ok,
     state: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "myToken",
     },

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -33,7 +33,7 @@ jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
     persistentState: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
     },

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -20,7 +20,7 @@ jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
     persistentState: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
     },

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -35,7 +35,7 @@ jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
     persistentState: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
     },

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -74,7 +74,7 @@ jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
     persistentState: {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
     },

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -84,7 +84,7 @@ describe("PersistentStateProvider", () => {
     })
 
     expect(screen.getByTestId("token").props.children).toBe("saved-token")
-    expect(screen.getByTestId("schema").props.children).toBe(11)
+    expect(screen.getByTestId("schema").props.children).toBe(12)
   })
 
   it("falls back to default state when no persisted data exists", async () => {

--- a/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-language.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-language.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -23,7 +23,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state6)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.galoyAuthToken).toBe("test-token")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -39,7 +39,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state7)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.activeAccountId).toBe("custodial-default")
   })
 
@@ -52,7 +52,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state5)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.galoyAuthToken).toBe("old-token")
     expect(result.activeAccountId).toBeUndefined()
   })
@@ -68,7 +68,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -89,7 +89,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "USD",
       "self-custodial-id-2": "BTC",
@@ -105,14 +105,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toBeUndefined()
     expect(result.selfCustodialLanguageByAccountId).toBeUndefined()
   })
 
   it("preserves schema 11 per-account display currency and language maps as-is", async () => {
     const state11 = {
-      schemaVersion: 11,
+      schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "token",
       activeAccountId: "self-custodial-id-1",
@@ -128,7 +128,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state11)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "EUR",
       "self-custodial-id-2": "JPY",
@@ -174,7 +174,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state4)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.galoyAuthToken).toBe("token-v4")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -203,14 +203,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state3)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.galoyAuthToken).toBe("token-v3")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
   })
 
   it("default state has schema version 11", () => {
-    expect(defaultPersistentState.schemaVersion).toBe(11)
+    expect(defaultPersistentState.schemaVersion).toBe(12)
     expect(defaultPersistentState.activeAccountId).toBeUndefined()
     expect(
       defaultPersistentState.selfCustodialDefaultWalletCurrencyByAccountId,
@@ -228,7 +228,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -247,7 +247,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "BTC",
@@ -263,7 +263,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -278,7 +278,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -294,7 +294,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -314,7 +314,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(11)
+    expect(result.schemaVersion).toBe(12)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "BTC",

--- a/__tests__/store/persistent-state/theme-preference.spec.ts
+++ b/__tests__/store/persistent-state/theme-preference.spec.ts
@@ -1,0 +1,180 @@
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  getThemePreference,
+  withThemePreference,
+} from "@app/store/persistent-state/theme-preference"
+import { DefaultAccountId } from "@app/types/wallet"
+
+const baseState: PersistentState = {
+  schemaVersion: 12,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+describe("getThemePreference", () => {
+  it("returns 'system' as the ultimate default", () => {
+    expect(getThemePreference(baseState)).toBe("system")
+  })
+
+  it("returns the per-account map value when set for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      themeByAccountId: {
+        "self-custodial-1": "dark",
+        "self-custodial-2": "light",
+      },
+    }
+
+    expect(getThemePreference(state)).toBe("dark")
+  })
+
+  it("isolates theme per active account", () => {
+    const map = {
+      "self-custodial-1": "dark",
+      "self-custodial-2": "light",
+    } as const
+
+    expect(
+      getThemePreference({
+        ...baseState,
+        activeAccountId: "self-custodial-1",
+        themeByAccountId: map,
+      }),
+    ).toBe("dark")
+
+    expect(
+      getThemePreference({
+        ...baseState,
+        activeAccountId: "self-custodial-2",
+        themeByAccountId: map,
+      }),
+    ).toBe("light")
+  })
+
+  it("does not leak the custodial theme into a self-custodial account", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      themeByAccountId: { [DefaultAccountId.Custodial]: "dark" },
+    }
+
+    expect(getThemePreference(state)).toBe("system")
+  })
+
+  it("does not leak a self-custodial theme into the custodial slot", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: DefaultAccountId.Custodial,
+      themeByAccountId: { "self-custodial-1": "dark" },
+    }
+
+    expect(getThemePreference(state)).toBe("system")
+  })
+
+  it("falls back to 'system' when map is absent for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-new",
+      themeByAccountId: { "self-custodial-other": "dark" },
+    }
+
+    expect(getThemePreference(state)).toBe("system")
+  })
+
+  it("returns the custodial-slot value when active is custodial", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: DefaultAccountId.Custodial,
+      themeByAccountId: { [DefaultAccountId.Custodial]: "light" },
+    }
+
+    expect(getThemePreference(state)).toBe("light")
+  })
+
+  it("falls back to the custodial slot when there is no active account", () => {
+    const state: PersistentState = {
+      ...baseState,
+      themeByAccountId: { [DefaultAccountId.Custodial]: "dark" },
+    }
+
+    expect(getThemePreference(state)).toBe("dark")
+  })
+})
+
+describe("withThemePreference", () => {
+  it("writes the theme under the active self-custodial id", () => {
+    const state: PersistentState = { ...baseState, activeAccountId: "self-custodial-1" }
+
+    const next = withThemePreference(state, "dark")
+
+    expect(next.themeByAccountId).toEqual({
+      "self-custodial-1": "dark",
+    })
+  })
+
+  it("writes under the custodial slot when active is custodial", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: DefaultAccountId.Custodial,
+    }
+
+    const next = withThemePreference(state, "light")
+
+    expect(next.themeByAccountId).toEqual({
+      [DefaultAccountId.Custodial]: "light",
+    })
+  })
+
+  it("writes under the custodial slot when there is no active account", () => {
+    const next = withThemePreference(baseState, "dark")
+
+    expect(next.themeByAccountId).toEqual({
+      [DefaultAccountId.Custodial]: "dark",
+    })
+  })
+
+  it("preserves entries for other accounts when writing", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-2",
+      themeByAccountId: { "self-custodial-1": "dark" },
+    }
+
+    const next = withThemePreference(state, "light")
+
+    expect(next.themeByAccountId).toEqual({
+      "self-custodial-1": "dark",
+      "self-custodial-2": "light",
+    })
+  })
+
+  it("overwrites the existing value for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      themeByAccountId: { "self-custodial-1": "dark" },
+    }
+
+    const next = withThemePreference(state, "light")
+
+    expect(next.themeByAccountId).toEqual({
+      "self-custodial-1": "light",
+    })
+  })
+
+  it("does not overwrite the custodial slot when writing for a self-custodial account", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      themeByAccountId: { [DefaultAccountId.Custodial]: "dark" },
+    }
+
+    const next = withThemePreference(state, "light")
+
+    expect(next.themeByAccountId).toEqual({
+      [DefaultAccountId.Custodial]: "dark",
+      "self-custodial-1": "light",
+    })
+  })
+})

--- a/app/components/galoy-theme-provider/index.tsx
+++ b/app/components/galoy-theme-provider/index.tsx
@@ -1,24 +1,23 @@
 import * as React from "react"
 import { Appearance } from "react-native"
 
-import { useColorSchemeQuery } from "@app/graphql/generated"
+import { useEffectiveTheme } from "@app/hooks/use-effective-theme"
 import theme from "@app/rne-theme/theme"
 import { ThemeMode, ThemeProvider } from "@rn-vui/themed"
 
 export const GaloyThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const data = useColorSchemeQuery()
+  const { theme: themePreference } = useEffectiveTheme()
 
-  const colorScheme = data?.data?.colorScheme
   let mode: ThemeMode = "light"
-  if (colorScheme === "system" || !colorScheme) {
+  if (themePreference === "system") {
     const systemScheme = Appearance.getColorScheme()
     if (systemScheme && systemScheme !== "unspecified") {
       mode = systemScheme
     }
   } else {
-    mode = colorScheme as ThemeMode
+    mode = themePreference
   }
 
   return (

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -95,9 +95,6 @@ export const createCache = () =>
           beta: {
             read: (value) => value ?? false,
           },
-          colorScheme: {
-            read: (value) => value ?? "system",
-          },
           countryCode: {
             read: (value) => value ?? "SV",
           },

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -6,8 +6,6 @@ import { ApolloClient, gql } from "@apollo/client"
 import {
   BetaDocument,
   BetaQuery,
-  ColorSchemeDocument,
-  ColorSchemeQuery,
   CountryCodeDocument,
   CountryCodeQuery,
   FeedbackModalShownDocument,
@@ -45,10 +43,6 @@ export default gql`
 
   query beta {
     beta @client
-  }
-
-  query colorScheme {
-    colorScheme @client # "system" | "light" | "dark"
   }
 
   query countryCode {
@@ -148,20 +142,6 @@ export const activateBeta = (client: ApolloClient<unknown>, status: boolean) => 
     })
   } catch {
     console.warn("impossible to update beta")
-  }
-}
-
-export const updateColorScheme = (client: ApolloClient<unknown>, colorScheme: string) => {
-  try {
-    client.writeQuery<ColorSchemeQuery>({
-      query: ColorSchemeDocument,
-      data: {
-        __typename: "Query",
-        colorScheme,
-      },
-    })
-  } catch {
-    console.warn("impossible to update color scheme")
   }
 }
 

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -2191,7 +2191,6 @@ export type Query = {
   readonly cardHolder: CardHolder;
   readonly cardSecretsEncrypted: CardSecretsEncrypted;
   readonly cardTransactionsPaginated: CardTransactionConnection;
-  readonly colorScheme: Scalars['String']['output'];
   readonly countryCode: Scalars['String']['output'];
   /** Returns an estimated conversion rate for the given amount and currency */
   readonly currencyConversionEstimation: CurrencyConversionEstimation;
@@ -3178,11 +3177,6 @@ export type BetaQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type BetaQuery = { readonly __typename: 'Query', readonly beta: boolean };
-
-export type ColorSchemeQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type ColorSchemeQuery = { readonly __typename: 'Query', readonly colorScheme: string };
 
 export type CountryCodeQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4510,43 +4504,6 @@ export type BetaQueryHookResult = ReturnType<typeof useBetaQuery>;
 export type BetaLazyQueryHookResult = ReturnType<typeof useBetaLazyQuery>;
 export type BetaSuspenseQueryHookResult = ReturnType<typeof useBetaSuspenseQuery>;
 export type BetaQueryResult = Apollo.QueryResult<BetaQuery, BetaQueryVariables>;
-export const ColorSchemeDocument = gql`
-    query colorScheme {
-  colorScheme @client
-}
-    `;
-
-/**
- * __useColorSchemeQuery__
- *
- * To run a query within a React component, call `useColorSchemeQuery` and pass it any options that fit your needs.
- * When your component renders, `useColorSchemeQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useColorSchemeQuery({
- *   variables: {
- *   },
- * });
- */
-export function useColorSchemeQuery(baseOptions?: Apollo.QueryHookOptions<ColorSchemeQuery, ColorSchemeQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<ColorSchemeQuery, ColorSchemeQueryVariables>(ColorSchemeDocument, options);
-      }
-export function useColorSchemeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<ColorSchemeQuery, ColorSchemeQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<ColorSchemeQuery, ColorSchemeQueryVariables>(ColorSchemeDocument, options);
-        }
-export function useColorSchemeSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<ColorSchemeQuery, ColorSchemeQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<ColorSchemeQuery, ColorSchemeQueryVariables>(ColorSchemeDocument, options);
-        }
-export type ColorSchemeQueryHookResult = ReturnType<typeof useColorSchemeQuery>;
-export type ColorSchemeLazyQueryHookResult = ReturnType<typeof useColorSchemeLazyQuery>;
-export type ColorSchemeSuspenseQueryHookResult = ReturnType<typeof useColorSchemeSuspenseQuery>;
-export type ColorSchemeQueryResult = Apollo.QueryResult<ColorSchemeQuery, ColorSchemeQueryVariables>;
 export const CountryCodeDocument = gql`
     query countryCode {
   countryCode @client
@@ -10936,7 +10893,6 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   cardHolder?: Resolver<ResolversTypes['CardHolder'], ParentType, ContextType, RequireFields<QueryCardHolderArgs, 'cardId'>>;
   cardSecretsEncrypted?: Resolver<ResolversTypes['CardSecretsEncrypted'], ParentType, ContextType, RequireFields<QueryCardSecretsEncryptedArgs, 'cardId' | 'sessionId'>>;
   cardTransactionsPaginated?: Resolver<ResolversTypes['CardTransactionConnection'], ParentType, ContextType, RequireFields<QueryCardTransactionsPaginatedArgs, 'cardId' | 'first'>>;
-  colorScheme?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   countryCode?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   currencyConversionEstimation?: Resolver<ResolversTypes['CurrencyConversionEstimation'], ParentType, ContextType, RequireFields<QueryCurrencyConversionEstimationArgs, 'amount' | 'currency'>>;
   currencyList?: Resolver<ReadonlyArray<ResolversTypes['Currency']>, ParentType, ContextType>;

--- a/app/graphql/local-schema.gql
+++ b/app/graphql/local-schema.gql
@@ -7,7 +7,6 @@ extend type Query {
   hiddenBalanceToolTip: Boolean!
   price: String # FIXME test only?
   beta: Boolean!
-  colorScheme: String!
   countryCode: String!
   region: Region
   feedbackModalShown: Boolean!

--- a/app/hooks/use-effective-theme.ts
+++ b/app/hooks/use-effective-theme.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react"
+
+import { usePersistentStateContext } from "@app/store/persistent-state"
+import {
+  getThemePreference,
+  type ThemePreference,
+  withThemePreference,
+} from "@app/store/persistent-state/theme-preference"
+
+type EffectiveThemeReturn = {
+  theme: ThemePreference
+  setTheme: (theme: ThemePreference) => void
+}
+
+export const useEffectiveTheme = (): EffectiveThemeReturn => {
+  const { persistentState, updateState } = usePersistentStateContext()
+
+  const setTheme = useCallback(
+    (theme: ThemePreference) => {
+      updateState((prev) => prev && withThemePreference(prev, theme))
+    },
+    [updateState],
+  )
+
+  return {
+    theme: getThemePreference(persistentState),
+    setTheme,
+  }
+}

--- a/app/screens/settings-screen/settings/preferences-theme.tsx
+++ b/app/screens/settings-screen/settings/preferences-theme.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { useColorSchemeQuery } from "@app/graphql/generated"
+import { useEffectiveTheme } from "@app/hooks/use-effective-theme"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { useNavigation } from "@react-navigation/native"
@@ -11,21 +11,21 @@ export const ThemeSetting: React.FC = () => {
   const { LL } = useI18nContext()
   const { navigate } = useNavigation<StackNavigationProp<RootStackParamList>>()
 
-  const colorSchemeData = useColorSchemeQuery()
-  let colorScheme = LL.SettingsScreen.setByOs()
+  const { theme } = useEffectiveTheme()
+  let label = LL.SettingsScreen.setByOs()
 
-  switch (colorSchemeData?.data?.colorScheme) {
+  switch (theme) {
     case "light":
-      colorScheme = LL.ThemeScreen.setToLight()
+      label = LL.ThemeScreen.setToLight()
       break
     case "dark":
-      colorScheme = LL.ThemeScreen.setToDark()
+      label = LL.ThemeScreen.setToDark()
       break
   }
 
   return (
     <SettingsRow
-      title={`${LL.SettingsScreen.theme()}: ${colorScheme}`}
+      title={`${LL.SettingsScreen.theme()}: ${label}`}
       leftGaloyIcon="brush"
       action={() => navigate("theme")}
     />

--- a/app/screens/settings-screen/theme-screen.tsx
+++ b/app/screens/settings-screen/theme-screen.tsx
@@ -1,12 +1,11 @@
 import * as React from "react"
 import { View } from "react-native"
 
-import { useApolloClient } from "@apollo/client"
 import { GaloyInfo } from "@app/components/atomic/galoy-info"
 import { MenuSelect, MenuSelectItem } from "@app/components/menu-select"
-import { updateColorScheme } from "@app/graphql/client-only-query"
-import { useColorSchemeQuery } from "@app/graphql/generated"
+import { useEffectiveTheme } from "@app/hooks/use-effective-theme"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { type ThemePreference } from "@app/store/persistent-state/theme-preference"
 import { makeStyles } from "@rn-vui/themed"
 
 import { Screen } from "../../components/screen"
@@ -21,14 +20,12 @@ const useStyles = makeStyles(() => ({
 }))
 
 export const ThemeScreen: React.FC = () => {
-  const client = useApolloClient()
-  const colorSchemeData = useColorSchemeQuery()
-  const colorScheme = colorSchemeData?.data?.colorScheme ?? "system"
+  const { theme, setTheme } = useEffectiveTheme()
 
   const { LL } = useI18nContext()
   const styles = useStyles()
 
-  const Themes = [
+  const Themes: { id: ThemePreference; text: string }[] = [
     {
       id: "system",
       text: LL.ThemeScreen.system(),
@@ -46,8 +43,8 @@ export const ThemeScreen: React.FC = () => {
   return (
     <Screen style={styles.container} preset="scroll">
       <MenuSelect
-        value={colorScheme}
-        onChange={async (scheme) => updateColorScheme(client, scheme)}
+        value={theme}
+        onChange={async (value) => setTheme(value as ThemePreference)}
       >
         {Themes.map(({ id, text }) => (
           <MenuSelectItem key={id} value={id}>

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -75,8 +75,23 @@ type PersistentState_11 = {
   selfCustodialLanguageByAccountId?: Record<string, string>
 }
 
-const migrate11ToCurrent = (state: PersistentState_11): Promise<PersistentState> =>
+type PersistentState_12 = {
+  schemaVersion: 12
+  galoyInstance: GaloyInstanceInput
+  galoyAuthToken: string
+  activeAccountId?: string
+  selfCustodialDefaultWalletCurrency?: "BTC" | "USD"
+  selfCustodialDefaultWalletCurrencyByAccountId?: Record<string, "BTC" | "USD">
+  selfCustodialDisplayCurrencyByAccountId?: Record<string, string>
+  selfCustodialLanguageByAccountId?: Record<string, string>
+  themeByAccountId?: Record<string, "system" | "light" | "dark">
+}
+
+const migrate12ToCurrent = (state: PersistentState_12): Promise<PersistentState> =>
   Promise.resolve(state)
+
+const migrate11ToCurrent = (state: PersistentState_11): Promise<PersistentState> =>
+  migrate12ToCurrent({ ...state, schemaVersion: 12 })
 
 const migrateLegacyDefaultCurrencyToActiveAccount = (
   state: PersistentState_10,
@@ -187,6 +202,7 @@ type StateMigrations = {
   9: (state: PersistentState_9) => Promise<PersistentState>
   10: (state: PersistentState_10) => Promise<PersistentState>
   11: (state: PersistentState_11) => Promise<PersistentState>
+  12: (state: PersistentState_12) => Promise<PersistentState>
 }
 
 const stateMigrations: StateMigrations = {
@@ -199,12 +215,13 @@ const stateMigrations: StateMigrations = {
   9: migrate9ToCurrent,
   10: migrate10ToCurrent,
   11: migrate11ToCurrent,
+  12: migrate12ToCurrent,
 }
 
-export type PersistentState = PersistentState_11
+export type PersistentState = PersistentState_12
 
 export const defaultPersistentState: PersistentState = {
-  schemaVersion: 11,
+  schemaVersion: 12,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }
@@ -231,7 +248,7 @@ export const migratePersistentState = async (
   if (!data || !(data.schemaVersion in stateMigrations)) {
     return { status: MigrationStatus.NoData }
   }
-  const schemaVersion: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 = data.schemaVersion
+  const schemaVersion: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 = data.schemaVersion
   try {
     const migration = stateMigrations[schemaVersion]
     const state = await migration(data)

--- a/app/store/persistent-state/theme-preference.ts
+++ b/app/store/persistent-state/theme-preference.ts
@@ -1,0 +1,27 @@
+import { DefaultAccountId } from "@app/types/wallet"
+
+import { PersistentState } from "./state-migrations"
+
+export type ThemePreference = "system" | "light" | "dark"
+
+const resolveAccountKey = (state: PersistentState): string =>
+  state.activeAccountId ?? DefaultAccountId.Custodial
+
+export const getThemePreference = (state: PersistentState): ThemePreference => {
+  const key = resolveAccountKey(state)
+  return state.themeByAccountId?.[key] ?? "system"
+}
+
+export const withThemePreference = (
+  state: PersistentState,
+  theme: ThemePreference,
+): PersistentState => {
+  const key = resolveAccountKey(state)
+  return {
+    ...state,
+    themeByAccountId: {
+      ...state.themeByAccountId,
+      [key]: theme,
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes the bug where the theme setting reset to "Set by OS" when switching between accounts (ticket #3793). For example, if the theme was set to Dark, creating a new self-custodial account and switching back would silently revert it.
- Root cause: the theme was stored as a local field inside the Apollo cache. When the active account changes, the Apollo client is rebuilt, the cache is reset, and (for self-custodial sessions) the cache restore step is skipped on purpose to avoid leaking the custodial cache. The theme value got wiped in that process and fell back to its default.
- The theme now lives in `persistentState`, the same storage layer that already handles language, display currency and the default wallet. It is keyed by the active account id, so each account keeps its own theme without ever mixing with the others.

## What changed
- New schema version `12` adds a `themeByAccountId` map to `persistentState`.
- New helpers `getThemePreference` / `withThemePreference` mirror the pattern already used for language and display currency.
- New `useEffectiveTheme` hook reads and writes through `persistentState`.
- The theme provider, the theme screen and the settings row now consume the new hook instead of the Apollo query.
- The old Apollo `colorScheme @client` query, the `updateColorScheme` writer, the type policy entry and the schema field were removed since they are no longer needed.

## Why this approach
The codebase already uses `persistentState` for account-scoped preferences (language, display currency, default wallet). Moving the theme there:
- Keeps it safe from the Apollo cache lifecycle on account switch.
- Isolates it per account, so custodial and self-custodial accounts never share or overwrite each other.
- Removes dead Apollo code that was only there to support this one preference.