### PR TITLE
fix: avoid version conflicts with aab

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,21 +135,6 @@ android {
             }
         }
     }
-
-    // https://github.com/react-native-community/discussions-and-proposals/issues/602
-    // applicationVariants are e.g. debug, release
-    applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            // For each separate APK per architecture, set a unique version code as described here:
-            // https://developer.android.com/studio/build/configure-apk-splits.html
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                    versionCodes.get(abi) * 10000000 + defaultConfig.versionCode
-            }
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
**Remove ABI-prefixed versionCode overrides**

Previously, each APK split was assigned a unique versionCode using an ABI multiplier (`armeabi-v7a: 1x`, `x86: 2x`, `arm64-v8a: 3x`, `x86_64: 4x`). This was necessary when uploading multiple APKs directly to Play Store, as it required a unique versionCode per ABI.

Since migrating to AAB, Play Store handles per-device APK generation server-side, so the ABI-prefixed versionCode scheme is no longer needed. The AAB uses `defaultConfig.versionCode` directly without any multiplier, and Play Store accepts a single flat versionCode.

APK splits are still built (for GitHub release assets and BrowserStack e2e), but they no longer need unique versionCodes per ABI since neither GitHub nor BrowserStack enforce that constraint.

**Changes**
- Remove `applicationVariants.all` block that applied ABI versionCode overrides

**Note**
[`build-numbers/android`](https://github.com/blinkbitcoin/blink-mobile/blob/build-numbers/android) needs to be bumped to a value greater than `40000831` (the highest versionCode from the previous multi-APK scheme) before the next release build. Ex: 50000000