### PR TITLE
fix(price-history): restore Bitcoin price text under reanimated v4


### DIFF
--- a/__tests__/components/price-history.spec.tsx
+++ b/__tests__/components/price-history.spec.tsx
@@ -1,0 +1,211 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import { PriceHistory } from "@app/components/price-history/price-history"
+
+const mockUseBtcPriceListQuery = jest.fn()
+const mockFormatMoneyAmount = jest.fn()
+
+jest.mock("@app/graphql/generated", () => {
+  const actual = jest.requireActual("@app/graphql/generated")
+  return {
+    ...actual,
+    useBtcPriceListQuery: (args: unknown) => mockUseBtcPriceListQuery(args),
+  }
+})
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: (args: unknown) => mockFormatMoneyAmount(args),
+  }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      PriceHistoryScreen: {
+        satPrice: () => "sat-price",
+        last24Hours: () => "Last 24 hours",
+        lastWeek: () => "Last week",
+        lastMonth: () => "Last month",
+        lastYear: () => "Last year",
+        lastFiveYears: () => "Last 5 years",
+        oneDay: () => "1D",
+        oneWeek: () => "1W",
+        oneMonth: () => "1M",
+        oneYear: () => "1Y",
+        fiveYears: () => "5Y",
+      },
+    },
+  }),
+}))
+
+jest.mock("@app/utils/testProps", () => ({
+  testProps: (id: string) => ({ testID: id }),
+}))
+
+jest.mock("victory-native", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View } = jest.requireActual("react-native")
+  type CartesianChartProps = {
+    children: (args: { points: { y: unknown[] } }) => React.ReactNode
+  }
+  return {
+    CartesianChart: ({ children }: CartesianChartProps) =>
+      ReactActual.createElement(
+        View,
+        { testID: "cartesian-chart" },
+        children({ points: { y: [] } }),
+      ),
+    Line: () => null,
+    useChartPressState: () => ({
+      state: {
+        x: { position: { value: 0 } },
+        y: { y: { value: { value: 0 }, position: { value: 0 } } },
+      },
+      isActive: false,
+    }),
+  }
+})
+
+jest.mock("@shopify/react-native-skia", () => ({
+  Circle: () => null,
+}))
+
+jest.mock("react-native-reanimated", () => {
+  const ReactActual = jest.requireActual("react")
+  const { TextInput } = jest.requireActual("react-native")
+
+  type Factory<T> = () => T
+  const useDerivedValue = <T,>(factory: Factory<T>) => ({ value: factory() })
+  const useAnimatedProps = <T,>(factory: Factory<T>) => factory()
+
+  type AnimatedComponentProps = {
+    value?: string
+    style?: unknown
+    testID?: string
+  }
+
+  const createAnimatedComponent = () => (props: AnimatedComponentProps) =>
+    ReactActual.createElement(TextInput, { ...props, editable: false })
+
+  return {
+    __esModule: true,
+    default: {
+      createAnimatedComponent,
+      addWhitelistedNativeProps: jest.fn(),
+    },
+    createAnimatedComponent,
+    useDerivedValue,
+    useAnimatedProps,
+    addWhitelistedNativeProps: jest.fn(),
+  }
+})
+
+jest.mock("@rn-vui/themed", () => {
+  const ReactActual = jest.requireActual("react")
+  const { Text: RNText } = jest.requireActual("react-native")
+  return {
+    makeStyles:
+      (fn: (theme: { colors: Record<string, string> }) => Record<string, object>) => () =>
+        fn({
+          colors: {
+            primary: "#fc5805",
+            black: "#000",
+            red: "#f00",
+            _green: "#0f0",
+            grey3: "#999",
+            transparent: "transparent",
+          },
+        }),
+    useTheme: () => ({
+      theme: {
+        colors: {
+          primary: "#fc5805",
+          black: "#000",
+          red: "#f00",
+          _green: "#0f0",
+          grey3: "#999",
+          transparent: "transparent",
+        },
+      },
+    }),
+    Text: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(RNText, null, children),
+  }
+})
+
+jest.mock("@rn-vui/base", () => {
+  const ReactActual = jest.requireActual("react")
+  const { TouchableOpacity, Text } = jest.requireActual("react-native")
+  return {
+    Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+      ReactActual.createElement(
+        TouchableOpacity,
+        { onPress, testID: `range-${title}` },
+        ReactActual.createElement(Text, null, title),
+      ),
+  }
+})
+
+const makePricePoint = (timestamp: number, base: number) => ({
+  __typename: "PricePoint" as const,
+  timestamp,
+  price: { base, offset: 4, currencyUnit: "USDCENT" },
+})
+
+describe("PriceHistory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFormatMoneyAmount.mockImplementation(
+      ({ moneyAmount }: { moneyAmount: { amount: number } }) =>
+        `$${moneyAmount.amount.toFixed(2)}`,
+    )
+  })
+
+  it("renders the latest price as the visible price text", () => {
+    mockUseBtcPriceListQuery.mockReturnValue({
+      loading: false,
+      data: {
+        btcPriceList: [
+          makePricePoint(1700000000, 800_000_000),
+          makePricePoint(1700100000, 1_000_000_000),
+        ],
+      },
+    })
+
+    const { getByTestId, getAllByDisplayValue } = render(<PriceHistory />)
+
+    // The wrapping View carries the satPrice testID; the AnimatedText sits inside.
+    expect(getByTestId("sat-price")).toBeTruthy()
+
+    // The latest price (base=1_000_000_000, offset=4 -> 100000) must reach the TextInput.
+    expect(getAllByDisplayValue("$100000.00").length).toBeGreaterThan(0)
+  })
+
+  it("renders an empty price string while loading", () => {
+    mockUseBtcPriceListQuery.mockReturnValue({ loading: true, data: undefined })
+
+    const { getAllByDisplayValue } = render(<PriceHistory />)
+
+    expect(getAllByDisplayValue("").length).toBeGreaterThan(0)
+  })
+
+  it("still surfaces the latest price even when intermediate prices are null", () => {
+    mockUseBtcPriceListQuery.mockReturnValue({
+      loading: false,
+      data: {
+        btcPriceList: [
+          makePricePoint(1700000000, 500_000_000),
+          null,
+          makePricePoint(1700100000, 1_200_000_000),
+        ],
+      },
+    })
+
+    const { getAllByDisplayValue } = render(<PriceHistory />)
+
+    // 1_200_000_000 / 10^4 = 120000
+    expect(getAllByDisplayValue("$120000.00").length).toBeGreaterThan(0)
+  })
+})

--- a/app/components/price-history/price-history.tsx
+++ b/app/components/price-history/price-history.tsx
@@ -145,11 +145,9 @@ export const PriceHistory = () => {
   return (
     <View style={styles.screen}>
       <View {...testProps(LL.PriceHistoryScreen.satPrice())} style={styles.textView}>
-        <AnimText
-          // @ts-ignore-next-line
+        <AnimatedText
           text={activePrice}
-          style={styles.priceText}
-          color={colors.black}
+          style={[styles.priceText, { color: colors.black }]}
         />
         <View style={styles.subtextContainer}>
           {!isActive && !loading ? (
@@ -160,11 +158,9 @@ export const PriceHistory = () => {
               {label()}
             </Text>
           ) : (
-            <AnimText
-              // @ts-ignore-next-line
+            <AnimatedText
               text={activeTimestamp}
-              style={styles.subtext}
-              color={colors.black}
+              style={[styles.subtext, { color: colors.black }]}
             />
           )}
         </View>
@@ -258,7 +254,7 @@ type AnimatedTextProps = Omit<TextInputProps, "editable" | "value"> & {
   style?: React.ComponentProps<typeof AnimText>["style"]
 }
 
-export function AnimatedText({ text, ...rest }: AnimatedTextProps) {
+function AnimatedText({ text, ...rest }: AnimatedTextProps) {
   const animProps = useAnimatedProps(() => {
     return {
       text: text.value,


### PR DESCRIPTION
## Summary

Restores the Bitcoin price text on the chart screen, which stopped rendering after the React Native 0.85 / reanimated v4 upgrade (PR #3781).

## Root cause

The price-history component bound a `SharedValue<string>` directly to a `text` prop on a component returned by `Reanimated.createAnimatedComponent(TextInput)`. That pattern relied on reanimated v3 behavior that automatically wired whitelisted native props to shared values. The reanimated v4 release removed that shortcut: shared values must now be threaded through `useAnimatedProps` explicitly. With v4 in place, the underlying `TextInput` no longer received a `value`, so the price text rendered as an empty string.

The file already contained a correctly written wrapper, `AnimatedText`, using `useAnimatedProps`, but it was defined and exported without ever being consumed by the component itself.

## Fix

Replaced the raw animated component usage with the existing `AnimatedText` wrapper in the two places that render shared-value-driven text: the current price and the active timestamp shown on chart press. The wrapper passes both a static `value` and an animated `animatedProps`, so reanimated v4 correctly drives the native text updates on every shared-value change.

Additional cleanup applied in the same change:

- Removed the two `// @ts-ignore-next-line` comments that were silencing the type error caused by the prior incorrect usage. The typed wrapper covers the contract correctly.
- Moved `color` from a separate prop into the `style` array, matching the standard `TextInput` styling API.
- Demoted `AnimatedText` to an internal helper. The previous `export` had no external consumers.

## Coverage

Added a unit test for `PriceHistory` that renders the component with mocked Apollo, reanimated, and victory-native, and asserts that the latest formatted price reaches the underlying `TextInput.value`. The test guards the rendering chain `useDerivedValue` → `AnimatedText` → `TextInput.value`, so a regression on the same code path will fail the build.