### PR TITLE
fix(test): suppress InteractionManager deprecation warning in CI logs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -86,6 +86,8 @@ jobs:
       - name: repo
       run:
         path: pipeline-tasks/ci/tasks/test-unit.sh
+      params:
+        CI: true
 
 - name: check-code
   plan:

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "./node_modules/@react-native/jest-preset/jest/setup.js",
     "./node_modules/react-native-gesture-handler/jestSetup.js",
   ],
-  setupFilesAfterEnv: ["@testing-library/jest-native/extend-expect"],
+  setupFilesAfterEnv: ["@testing-library/jest-native/extend-expect", "./jest.setup.js"],
   transform: {
     "\\.(ts|tsx)$": [
       "ts-jest",

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,16 @@
+// In CI, suppress the noisy, non-actionable "InteractionManager has been deprecated"
+// warning emitted during tests by @react-navigation/* internals and by
+// app/screens/transaction-history/transaction-history-screen.tsx, so Concourse/CI
+// logs stay readable. Locally the warning is left intact so developers still see
+// the deprecation. See https://github.com/blinkbitcoin/blink-mobile/issues/3813
+const isCI = Boolean(process.env.CI) && process.env.CI !== "false"
+
+if (isCI) {
+  const SUPPRESSED_WARNINGS = [/InteractionManager has been deprecated/]
+  const originalWarn = console.warn.bind(console)
+  console.warn = (...args) => {
+    const message = typeof args[0] === "string" ? args[0] : ""
+    if (SUPPRESSED_WARNINGS.some((re) => re.test(message))) return
+    originalWarn(...args)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #3813.

Every suite that renders a navigator (or otherwise touches `InteractionManager`) re-triggers React Native's `InteractionManager has been deprecated` warning once per test file (`warnOnce` dedupes per module registry, and Jest resets the registry per file), flooding Concourse/CI logs with repeated warning + stack-trace noise.

### Changes

- **`jest.setup.js`** (new): wraps `console.warn` and drops **only** messages matching `InteractionManager has been deprecated` — and **only when `CI` is set**, so the deprecation stays visible in local dev runs. All other warnings pass through untouched.
- **`jest.config.js`**: registers the setup file via `setupFilesAfterEnv` (re-applied per test file, so it survives Jest's per-file module resets).
- **`ci/pipeline.yml`**: adds `params: { CI: true }` to the Concourse `test-unit` task. GitHub Actions sets `CI=true` automatically, but Concourse deliberately does **not** expose build-metadata env vars to task containers (concourse/concourse#790), so it must be set explicitly — same convention the `build` tasks already use.

### Why not fix the root cause instead

- `@react-navigation` v7 (current, latest stable) still uses `InteractionManager`; it is only removed in v8, which is **alpha-only** today and a breaking migration.
- The app's own `app/screens/transaction-history/transaction-history-screen.tsx` also calls `InteractionManager.runAfterInteractions` directly, so a react-navigation upgrade alone would not silence the warning.

That migration is real future-proofing work but out of scope for this CI-log cleanup; it can be tracked separately.

## Test plan

- [x] Local run (no `CI`): warning still visible — `yarn test __tests__/screens/transaction-history-screen.spec.tsx` → 1 occurrence, tests pass
- [x] `CI=true` run: warning suppressed — same spec → 0 occurrences, tests pass
- [x] `CI=false` behaves like local (warning visible)
- [x] Filter is surgical: a non-matching `console.warn` still prints under `CI=true`; only the InteractionManager message is dropped
- [x] Full suite with `CI=true`: **0** `InteractionManager has been deprecated` occurrences across all suites; 142 suites pass — the single failure (`__tests__/components/blink-card/blink-card.spec.tsx`, locale/env-dependent `"12/ 28"` expectation) fails identically on untouched `main`
- [x] `ci/pipeline.yml` still parses as valid YAML (ytt `#@` lines are comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)