### PR TITLE
ci: cleanup mac build runner disk before concourse builds

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -41,6 +41,7 @@ groups:
   - check-code
   - install-deps
   - dev-build
+  - cleanup-mac-build-worker
   - prerelease
   - prod-build
 - name: image
@@ -149,6 +150,7 @@ jobs:
         SPARK_TOKEN_IDENTIFIER: #@ data.values.spark_token_identifier
         BREEZ_API_KEY: #@ data.values.breez_api_key
         BREEZ_NETWORK: #@ data.values.breez_network
+        MIN_BUILD_FREE_GB: 30
   - task: upload-to-gcs
     config:
       platform: linux
@@ -217,6 +219,27 @@ jobs:
     - put: testflight-version
       params:
         file: testflight-version/version
+
+- name: cleanup-mac-build-worker
+  serial: true
+  plan:
+  - in_parallel:
+    - get: daily
+      trigger: true
+    - get: pipeline-tasks
+  - #@ claim_lock()
+  - task: cleanup-mac-build-worker
+    tags: [ mac-m1 ]
+    ensure: #@ release_lock()
+    config:
+      platform: darwin
+      inputs:
+      - name: pipeline-tasks
+      run:
+        path: /bin/sh
+        args: [ "-c", "arch -arm64 pipeline-tasks/ci/tasks/macos-build-disk-cleanup.sh scheduled" ]
+      params:
+        MIN_BUILD_FREE_GB: 35
 
 - name: prod-build
   serial: true
@@ -296,6 +319,7 @@ jobs:
         SPARK_TOKEN_IDENTIFIER: #@ data.values.spark_token_identifier
         BREEZ_API_KEY: #@ data.values.breez_api_key
         BREEZ_NETWORK: #@ data.values.breez_network
+        MIN_BUILD_FREE_GB: 30
   - task: upload-to-gcs
     config:
       platform: linux

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -4,14 +4,20 @@ set -eu
 export CI_ROOT="$(pwd)"
 export ENVFILE=.env.ci
 REACT_NATIVE_CONFIG_ENV="${CI_ROOT}/repo/${ENVFILE}"
+DISK_CLEANUP_TASK="${CI_ROOT}/pipeline-tasks/ci/tasks/macos-build-disk-cleanup.sh"
 
-cleanup_react_native_config_env() {
+cleanup_build_task() {
   rm -f "$REACT_NATIVE_CONFIG_ENV"
+  lsof -ti:8080,8081 | xargs kill -9 || true
+  /bin/bash "$DISK_CLEANUP_TASK" post || true
 }
-trap cleanup_react_native_config_env EXIT
+trap cleanup_build_task EXIT
 
 export PATH=$(cat /Users/m1/concourse/path)
 export PUBLIC_VERSION=$(cat $VERSION_FILE)
+
+echo "    --> Preparing macOS build worker disk"
+/bin/bash "$DISK_CLEANUP_TASK" pre
 
 # Make sure ssh agent is running - to access GaloyMoney ios keystore from github
 echo "    --> Setting up ssh agent"

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -7,6 +7,7 @@ MIN_FREE_GB="${MIN_BUILD_FREE_GB:-${2:-30}}"
 CI_ROOT="${CI_ROOT:-$(pwd)}"
 DISK_CHECK_PATH="${DISK_CHECK_PATH:-$CI_ROOT}"
 CONCOURSE_WORKDIR="${CONCOURSE_WORKDIR:-/Users/m1/concourse/workdir}"
+BUILD_HOME="${HOME:-/Users/m1}"
 
 required_kb=$((MIN_FREE_GB * 1024 * 1024))
 
@@ -89,8 +90,8 @@ print_disk_report() {
     "$CONCOURSE_WORKDIR/volumes/live" \
     "/private/var/root/Library/Developer/Xcode/Archives" \
     "/private/var/root/Library/Developer/Xcode/DerivedData" \
-    "$HOME/Library/Developer/Xcode/Archives" \
-    "$HOME/Library/Developer/Xcode/DerivedData" \
+    "$BUILD_HOME/Library/Developer/Xcode/Archives" \
+    "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
     "/Users/m1/Library/Developer/Xcode/Archives" \
     "/Users/m1/Library/Developer/Xcode/DerivedData" \
     "/Library/Developer/CoreSimulator/Volumes"; do
@@ -115,14 +116,14 @@ cleanup_workspace_build_outputs() {
 cleanup_xcode_artifacts() {
   for dir in \
     "/private/var/root/Library/Developer/Xcode/Archives" \
-    "$HOME/Library/Developer/Xcode/Archives" \
+    "$BUILD_HOME/Library/Developer/Xcode/Archives" \
     "/Users/m1/Library/Developer/Xcode/Archives"; do
     remove_old_children "$dir" 28
   done
 
   for dir in \
     "/private/var/root/Library/Developer/Xcode/DerivedData" \
-    "$HOME/Library/Developer/Xcode/DerivedData" \
+    "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
     "/Users/m1/Library/Developer/Xcode/DerivedData"; do
     if [[ -d "$dir" ]]; then
       echo "Removing GaloyApp DerivedData older than 28d from $dir"

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+
+set -euo pipefail
+
+MODE="${1:-check}"
+MIN_FREE_GB="${MIN_BUILD_FREE_GB:-${2:-30}}"
+CI_ROOT="${CI_ROOT:-$(pwd)}"
+DISK_CHECK_PATH="${DISK_CHECK_PATH:-$CI_ROOT}"
+CONCOURSE_WORKDIR="${CONCOURSE_WORKDIR:-/Users/m1/concourse/workdir}"
+
+required_kb=$((MIN_FREE_GB * 1024 * 1024))
+
+free_kb() {
+  df -Pk "$DISK_CHECK_PATH" | awk 'NR == 2 { print $4 }'
+}
+
+free_gb() {
+  awk "BEGIN { printf \"%.1f\", $(free_kb) / 1024 / 1024 }"
+}
+
+remove_path() {
+  local path="$1"
+
+  if [[ -e "$path" || -L "$path" ]]; then
+    echo "Removing $path"
+    rm -rf -- "$path"
+  fi
+}
+
+remove_old_children() {
+  local dir="$1"
+  local days="$2"
+
+  if [[ -d "$dir" ]]; then
+    echo "Removing children older than ${days}d from $dir"
+    find "$dir" -mindepth 1 -maxdepth 1 -mtime +"$days" -exec rm -rf {} + || true
+  fi
+}
+
+remove_all_children() {
+  local dir="$1"
+
+  if [[ -d "$dir" ]]; then
+    echo "Removing children from $dir"
+    find "$dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} + || true
+  fi
+}
+
+current_ios_runtime_identifier() {
+  local sdk_version
+  sdk_version="$(xcodebuild -version -sdk iphoneos SDKVersion 2>/dev/null | tr -d '[:space:]' || true)"
+
+  if [[ -n "$sdk_version" ]]; then
+    echo "com.apple.CoreSimulator.SimRuntime.iOS-${sdk_version//./-}"
+  fi
+}
+
+installed_ios_runtime_identifiers() {
+  local runtime_list
+
+  if ! command -v xcrun >/dev/null 2>&1; then
+    echo "xcrun is not available on PATH." >&2
+    return 1
+  fi
+
+  if ! runtime_list="$(xcrun simctl runtime list 2>&1)"; then
+    echo "$runtime_list" >&2
+    return 1
+  fi
+
+  printf "%s\n" "$runtime_list" \
+    | sed -n 's/.*\(com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9A-Za-z.-]*\).*/\1/p' \
+    | sort -u
+}
+
+print_disk_report() {
+  echo "---- Disk usage ----"
+  df -h "$DISK_CHECK_PATH" || true
+  df -h || true
+
+  echo "---- Large macOS build paths ----"
+  for path in \
+    "$CI_ROOT/repo/node_modules" \
+    "$CI_ROOT/repo/ios/Pods" \
+    "$CI_ROOT/repo/android/app/build" \
+    "$CI_ROOT/repo/android/build" \
+    "$CI_ROOT/repo/ios/build" \
+    "$CONCOURSE_WORKDIR/volumes/dead" \
+    "$CONCOURSE_WORKDIR/volumes/live" \
+    "/private/var/root/Library/Developer/Xcode/Archives" \
+    "/private/var/root/Library/Developer/Xcode/DerivedData" \
+    "$HOME/Library/Developer/Xcode/Archives" \
+    "$HOME/Library/Developer/Xcode/DerivedData" \
+    "/Users/m1/Library/Developer/Xcode/Archives" \
+    "/Users/m1/Library/Developer/Xcode/DerivedData" \
+    "/Library/Developer/CoreSimulator/Volumes"; do
+    if [[ -e "$path" ]]; then
+      du -sh "$path" 2>/dev/null || true
+    fi
+  done
+
+  echo "---- iOS simulator runtimes ----"
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun simctl runtime list || true
+  fi
+}
+
+cleanup_workspace_build_outputs() {
+  remove_path "$CI_ROOT/repo/android/app/build"
+  remove_path "$CI_ROOT/repo/android/build"
+  remove_path "$CI_ROOT/repo/ios/build"
+  remove_path "$CI_ROOT/repo/ios/Blink.ipa"
+}
+
+cleanup_xcode_artifacts() {
+  for dir in \
+    "/private/var/root/Library/Developer/Xcode/Archives" \
+    "$HOME/Library/Developer/Xcode/Archives" \
+    "/Users/m1/Library/Developer/Xcode/Archives"; do
+    remove_old_children "$dir" 28
+  done
+
+  for dir in \
+    "/private/var/root/Library/Developer/Xcode/DerivedData" \
+    "$HOME/Library/Developer/Xcode/DerivedData" \
+    "/Users/m1/Library/Developer/Xcode/DerivedData"; do
+    if [[ -d "$dir" ]]; then
+      echo "Removing GaloyApp DerivedData older than 28d from $dir"
+      find "$dir" -mindepth 1 -maxdepth 1 -name "GaloyApp-*" -mtime +28 -exec rm -rf {} + || true
+    fi
+  done
+}
+
+cleanup_concourse_dead_volumes() {
+  remove_all_children "$CONCOURSE_WORKDIR/volumes/dead"
+}
+
+cleanup_old_ios_runtimes() {
+  local current_runtime
+  local installed_runtimes
+  current_runtime="$(current_ios_runtime_identifier)"
+
+  if [[ -z "$current_runtime" ]]; then
+    echo "Could not determine current iOS SDK runtime; skipping simulator runtime cleanup."
+    return
+  fi
+
+  echo "Keeping current iOS simulator runtime: $current_runtime"
+
+  if ! installed_runtimes="$(installed_ios_runtime_identifiers)"; then
+    echo "Could not list iOS simulator runtimes; skipping simulator runtime cleanup."
+    return
+  fi
+
+  while IFS= read -r runtime; do
+    [[ -z "$runtime" ]] && continue
+
+    if [[ "$runtime" != "$current_runtime" ]]; then
+      echo "Deleting old iOS simulator runtime: $runtime"
+      xcrun simctl runtime delete "$runtime" || true
+    fi
+  done <<< "$installed_runtimes"
+}
+
+assert_current_ios_runtime_present() {
+  local current_runtime
+  local installed_runtimes
+  current_runtime="$(current_ios_runtime_identifier)"
+
+  if [[ -z "$current_runtime" ]]; then
+    echo "Could not determine current iOS SDK runtime; skipping current runtime assertion."
+    return
+  fi
+
+  if ! installed_runtimes="$(installed_ios_runtime_identifiers)"; then
+    echo "ERROR: Could not list iOS simulator runtimes."
+    echo "Check CoreSimulatorService/simdiskimaged on the Scaleway Mac before running the build."
+    exit 1
+  fi
+
+  if ! printf "%s\n" "$installed_runtimes" | grep -qx "$current_runtime"; then
+    echo "ERROR: Required iOS runtime $current_runtime is not installed."
+    echo "Install the current platform runtime on the Scaleway Mac with: xcodebuild -downloadPlatform iOS"
+    exit 1
+  fi
+}
+
+assert_free_space() {
+  local available
+  available="$(free_kb)"
+
+  if (( available < required_kb )); then
+    echo "ERROR: Only $(free_gb) GB free on $DISK_CHECK_PATH after macOS build cleanup. Required: ${MIN_FREE_GB} GB."
+    echo "Manual follow-up: remove only stale Concourse live volumes with the worker stopped, or run Nix garbage collection with the worker stopped."
+    print_disk_report
+    exit 1
+  fi
+
+  echo "Free disk space on $DISK_CHECK_PATH: $(free_gb) GB (required: ${MIN_FREE_GB} GB)"
+}
+
+case "$MODE" in
+  check)
+    print_disk_report
+    assert_current_ios_runtime_present
+    assert_free_space
+    ;;
+  pre|scheduled)
+    print_disk_report
+    cleanup_workspace_build_outputs
+    cleanup_xcode_artifacts
+    cleanup_concourse_dead_volumes
+    assert_current_ios_runtime_present
+    cleanup_old_ios_runtimes
+    assert_current_ios_runtime_present
+    assert_free_space
+    ;;
+  post)
+    cleanup_workspace_build_outputs
+    cleanup_concourse_dead_volumes
+    print_disk_report
+    ;;
+  *)
+    echo "Usage: $0 {check|pre|post|scheduled}" >&2
+    exit 2
+    ;;
+esac

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -47,17 +47,18 @@ remove_all_children() {
   fi
 }
 
-current_ios_runtime_identifier() {
-  local sdk_version
-  sdk_version="$(xcodebuild -version -sdk iphoneos SDKVersion 2>/dev/null | tr -d '[:space:]' || true)"
-
-  if [[ -n "$sdk_version" ]]; then
-    echo "com.apple.CoreSimulator.SimRuntime.iOS-${sdk_version//./-}"
-  fi
+unique_paths() {
+  printf "%s\n" "$@" | awk 'NF && !seen[$0]++'
 }
 
-installed_ios_runtime_identifiers() {
+current_ios_runtime_version() {
+  xcodebuild -version -sdk iphoneos SDKVersion 2>/dev/null | tr -d '[:space:]' || true
+}
+
+installed_ios_runtimes() {
   local runtime_list
+  local runtime_ids
+  local disk_image_runtimes
 
   if ! command -v xcrun >/dev/null 2>&1; then
     echo "xcrun is not available on PATH." >&2
@@ -69,9 +70,35 @@ installed_ios_runtime_identifiers() {
     return 1
   fi
 
-  printf "%s\n" "$runtime_list" \
-    | sed -n 's/.*\(com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9A-Za-z.-]*\).*/\1/p' \
-    | sort -u
+  runtime_ids="$(
+    printf "%s\n" "$runtime_list" \
+      | sed -n 's/.*\(com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9A-Za-z.-]*\).*/\1/p'
+  )"
+
+  while IFS= read -r runtime_id; do
+    [[ -z "$runtime_id" ]] && continue
+
+    local version="${runtime_id##*iOS-}"
+    version="${version//-/.}"
+    printf "%s\t%s\n" "$version" "$runtime_id"
+  done <<< "$runtime_ids"
+
+  disk_image_runtimes="$(
+    printf "%s\n" "$runtime_list" \
+      | sed -En 's/^[[:space:]]*iOS[[:space:]]+([0-9]+(\.[0-9]+)*)[[:space:]]+\([^)]+\)[[:space:]]+-[[:space:]]+([A-Fa-f0-9-]+).*/\1	\3/p'
+  )"
+
+  if [[ -n "$disk_image_runtimes" ]]; then
+    printf "%s\n" "$disk_image_runtimes"
+  fi
+}
+
+installed_ios_runtime_versions() {
+  installed_ios_runtimes | cut -f1 | sort -u
+}
+
+installed_ios_runtime_delete_refs() {
+  installed_ios_runtimes | sort -u
 }
 
 print_disk_report() {
@@ -80,7 +107,11 @@ print_disk_report() {
   df -h || true
 
   echo "---- Large macOS build paths ----"
-  for path in \
+  while IFS= read -r path; do
+    if [[ -e "$path" ]]; then
+      du -sh "$path" 2>/dev/null || true
+    fi
+  done < <(unique_paths \
     "$CI_ROOT/repo/node_modules" \
     "$CI_ROOT/repo/ios/Pods" \
     "$CI_ROOT/repo/android/app/build" \
@@ -94,11 +125,7 @@ print_disk_report() {
     "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
     "/Users/m1/Library/Developer/Xcode/Archives" \
     "/Users/m1/Library/Developer/Xcode/DerivedData" \
-    "/Library/Developer/CoreSimulator/Volumes"; do
-    if [[ -e "$path" ]]; then
-      du -sh "$path" 2>/dev/null || true
-    fi
-  done
+    "/Library/Developer/CoreSimulator/Volumes")
 
   echo "---- iOS simulator runtimes ----"
   if command -v xcrun >/dev/null 2>&1; then
@@ -114,22 +141,22 @@ cleanup_workspace_build_outputs() {
 }
 
 cleanup_xcode_artifacts() {
-  for dir in \
+  while IFS= read -r dir; do
+    remove_old_children "$dir" 28
+  done < <(unique_paths \
     "/private/var/root/Library/Developer/Xcode/Archives" \
     "$BUILD_HOME/Library/Developer/Xcode/Archives" \
-    "/Users/m1/Library/Developer/Xcode/Archives"; do
-    remove_old_children "$dir" 28
-  done
+    "/Users/m1/Library/Developer/Xcode/Archives")
 
-  for dir in \
-    "/private/var/root/Library/Developer/Xcode/DerivedData" \
-    "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
-    "/Users/m1/Library/Developer/Xcode/DerivedData"; do
+  while IFS= read -r dir; do
     if [[ -d "$dir" ]]; then
       echo "Removing GaloyApp DerivedData older than 28d from $dir"
       find "$dir" -mindepth 1 -maxdepth 1 -name "GaloyApp-*" -mtime +28 -exec rm -rf {} + || true
     fi
-  done
+  done < <(unique_paths \
+    "/private/var/root/Library/Developer/Xcode/DerivedData" \
+    "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
+    "/Users/m1/Library/Developer/Xcode/DerivedData")
 }
 
 cleanup_concourse_dead_volumes() {
@@ -137,50 +164,50 @@ cleanup_concourse_dead_volumes() {
 }
 
 cleanup_old_ios_runtimes() {
-  local current_runtime
+  local current_runtime_version
   local installed_runtimes
-  current_runtime="$(current_ios_runtime_identifier)"
+  current_runtime_version="$(current_ios_runtime_version)"
 
-  if [[ -z "$current_runtime" ]]; then
+  if [[ -z "$current_runtime_version" ]]; then
     echo "Could not determine current iOS SDK runtime; skipping simulator runtime cleanup."
     return
   fi
 
-  echo "Keeping current iOS simulator runtime: $current_runtime"
+  echo "Keeping current iOS simulator runtime version: $current_runtime_version"
 
-  if ! installed_runtimes="$(installed_ios_runtime_identifiers)"; then
+  if ! installed_runtimes="$(installed_ios_runtime_delete_refs)"; then
     echo "Could not list iOS simulator runtimes; skipping simulator runtime cleanup."
     return
   fi
 
-  while IFS= read -r runtime; do
-    [[ -z "$runtime" ]] && continue
+  while IFS=$'\t' read -r runtime_version runtime_delete_ref; do
+    [[ -z "$runtime_version" || -z "$runtime_delete_ref" ]] && continue
 
-    if [[ "$runtime" != "$current_runtime" ]]; then
-      echo "Deleting old iOS simulator runtime: $runtime"
-      xcrun simctl runtime delete "$runtime" || true
+    if [[ "$runtime_version" != "$current_runtime_version" ]]; then
+      echo "Deleting old iOS simulator runtime $runtime_version: $runtime_delete_ref"
+      xcrun simctl runtime delete "$runtime_delete_ref" || true
     fi
   done <<< "$installed_runtimes"
 }
 
 assert_current_ios_runtime_present() {
-  local current_runtime
-  local installed_runtimes
-  current_runtime="$(current_ios_runtime_identifier)"
+  local current_runtime_version
+  local installed_runtime_versions
+  current_runtime_version="$(current_ios_runtime_version)"
 
-  if [[ -z "$current_runtime" ]]; then
+  if [[ -z "$current_runtime_version" ]]; then
     echo "Could not determine current iOS SDK runtime; skipping current runtime assertion."
     return
   fi
 
-  if ! installed_runtimes="$(installed_ios_runtime_identifiers)"; then
+  if ! installed_runtime_versions="$(installed_ios_runtime_versions)"; then
     echo "ERROR: Could not list iOS simulator runtimes."
     echo "Check CoreSimulatorService/simdiskimaged on the Scaleway Mac before running the build."
     exit 1
   fi
 
-  if ! printf "%s\n" "$installed_runtimes" | grep -qx "$current_runtime"; then
-    echo "ERROR: Required iOS runtime $current_runtime is not installed."
+  if ! printf "%s\n" "$installed_runtime_versions" | grep -qx "$current_runtime_version"; then
+    echo "ERROR: Required iOS runtime $current_runtime_version is not installed."
     echo "Install the current platform runtime on the Scaleway Mac with: xcodebuild -downloadPlatform iOS"
     exit 1
   fi


### PR DESCRIPTION
## Summary

- add Concourse macOS build-worker disk cleanup for the `mac-m1` Scaleway runner
- run cleanup before/after `dev-build` and `prod-build`, with early free-space checks
- add a scheduled locked `cleanup-mac-build-worker` Concourse job
- support Xcode 26 `simctl runtime list` disk-image output when preserving the current iOS runtime

## Details

The cleanup targets the Concourse build path, not GitHub Actions. It removes stale repo build outputs, old Xcode archives/DerivedData, and dead Concourse volumes. It also prunes old iOS simulator runtimes while preserving the runtime matching the current iPhoneOS SDK.

The task avoids expensive/nuclear cleanup paths like Nix GC and live Concourse volume removal. If space is still below the threshold after safe cleanup, it fails early with manual follow-up guidance instead of allowing a long build to fail later with ENOSPC.

## Validation

- `shellcheck ci/tasks/macos-build-disk-cleanup.sh`
- `bash -n ci/tasks/macos-build-disk-cleanup.sh`
- mocked Xcode 26 `simctl runtime list` disk-image format
- successful Concourse cleanup run on `scaleway-mac-13342` with current iOS 26.5 runtime preserved