### PR TITLE
fix: persist default-account modal flag across sessions


### DIFF
--- a/.storybook/views/story-screen.tsx
+++ b/.storybook/views/story-screen.tsx
@@ -5,7 +5,7 @@ const PersistentStateWrapper: React.FC<React.PropsWithChildren> = ({ children })
   <PersistentStateContext.Provider
     value={{
       persistentState: {
-        schemaVersion: 12,
+        schemaVersion: 13,
         galoyInstance: {
           id: "Main",
         },

--- a/__tests__/hooks/use-default-account-modal-shown.spec.ts
+++ b/__tests__/hooks/use-default-account-modal-shown.spec.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { useDefaultAccountModalShown } from "@app/hooks/use-default-account-modal-shown"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+
+const mockUpdateState = jest.fn()
+let mockPersistentState: PersistentState
+
+jest.mock("@app/store/persistent-state", () => ({
+  usePersistentStateContext: () => ({
+    persistentState: mockPersistentState,
+    updateState: mockUpdateState,
+  }),
+}))
+
+const baseState: PersistentState = {
+  schemaVersion: 13,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+describe("useDefaultAccountModalShown", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockPersistentState = { ...baseState }
+  })
+
+  describe("defaultAccountModalShown (read)", () => {
+    it("reflects false when the flag has never been set", () => {
+      const { result } = renderHook(() => useDefaultAccountModalShown())
+
+      expect(result.current.defaultAccountModalShown).toBe(false)
+    })
+
+    it("reflects true when the active account's flag is set", () => {
+      mockPersistentState = {
+        ...baseState,
+        activeAccountId: "self-custodial-1",
+        defaultAccountModalShownByAccountId: { "self-custodial-1": true },
+      }
+
+      const { result } = renderHook(() => useDefaultAccountModalShown())
+
+      expect(result.current.defaultAccountModalShown).toBe(true)
+    })
+  })
+
+  describe("markDefaultAccountModalShown (write)", () => {
+    it("calls updateState with a functional updater, not a direct value", () => {
+      const { result } = renderHook(() => useDefaultAccountModalShown())
+
+      act(() => result.current.markDefaultAccountModalShown())
+
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+      expect(typeof mockUpdateState.mock.calls[0][0]).toBe("function")
+    })
+
+    it("the captured updater sets the flag for the active account", () => {
+      const { result } = renderHook(() => useDefaultAccountModalShown())
+
+      act(() => result.current.markDefaultAccountModalShown())
+
+      const updater = mockUpdateState.mock.calls[0][0]
+      const next = updater({ ...baseState, activeAccountId: "self-custodial-1" })
+
+      expect(next.defaultAccountModalShownByAccountId).toEqual({
+        "self-custodial-1": true,
+      })
+    })
+
+    it("the captured updater returns a falsy value when prev is undefined (no write)", () => {
+      const { result } = renderHook(() => useDefaultAccountModalShown())
+
+      act(() => result.current.markDefaultAccountModalShown())
+
+      const updater = mockUpdateState.mock.calls[0][0]
+
+      expect(updater(undefined)).toBeFalsy()
+    })
+  })
+})

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -33,7 +33,7 @@ it("migration from 5 to current returns ok with the migrated state", async () =>
   expect(result).toEqual({
     status: MigrationStatus.Ok,
     state: {
-      schemaVersion: 12,
+      schemaVersion: 13,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "myToken",
     },

--- a/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
+++ b/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
@@ -1,6 +1,6 @@
 import {
   getDefaultAccountModalShown,
-  markDefaultAccountModalShown,
+  withDefaultAccountModalShown,
 } from "@app/store/persistent-state/default-account-modal-shown"
 import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
@@ -76,14 +76,14 @@ describe("getDefaultAccountModalShown", () => {
   })
 })
 
-describe("markDefaultAccountModalShown", () => {
+describe("withDefaultAccountModalShown", () => {
   it("creates the per-account map when absent and sets the flag for the active id", () => {
     const state: PersistentState = {
       ...baseState,
       activeAccountId: "self-custodial-1",
     }
 
-    const next = markDefaultAccountModalShown(state)
+    const next = withDefaultAccountModalShown(state)
 
     expect(next.defaultAccountModalShownByAccountId).toEqual({
       "self-custodial-1": true,
@@ -100,7 +100,7 @@ describe("markDefaultAccountModalShown", () => {
       },
     }
 
-    const next = markDefaultAccountModalShown(state)
+    const next = withDefaultAccountModalShown(state)
 
     expect(next.defaultAccountModalShownByAccountId).toEqual({
       "self-custodial-1": true,
@@ -109,7 +109,7 @@ describe("markDefaultAccountModalShown", () => {
   })
 
   it("uses the custodial slot when activeAccountId is undefined", () => {
-    const next = markDefaultAccountModalShown(baseState)
+    const next = withDefaultAccountModalShown(baseState)
 
     expect(next.defaultAccountModalShownByAccountId).toEqual({
       [DefaultAccountId.Custodial]: true,
@@ -126,7 +126,7 @@ describe("markDefaultAccountModalShown", () => {
     }
     const snapshot = JSON.parse(JSON.stringify(original))
 
-    markDefaultAccountModalShown(original)
+    withDefaultAccountModalShown(original)
 
     expect(original).toEqual(snapshot)
   })

--- a/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
+++ b/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
@@ -1,0 +1,133 @@
+import {
+  getDefaultAccountModalShown,
+  markDefaultAccountModalShown,
+} from "@app/store/persistent-state/default-account-modal-shown"
+import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import { DefaultAccountId } from "@app/types/wallet"
+
+const baseState: PersistentState = {
+  schemaVersion: 13,
+  galoyInstance: { id: "Main" },
+  galoyAuthToken: "",
+}
+
+describe("getDefaultAccountModalShown", () => {
+  it("returns false as the ultimate default", () => {
+    expect(getDefaultAccountModalShown(baseState)).toBe(false)
+  })
+
+  it("returns the per-account map value when set for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      defaultAccountModalShownByAccountId: {
+        "self-custodial-1": true,
+        "self-custodial-2": false,
+      },
+    }
+
+    expect(getDefaultAccountModalShown(state)).toBe(true)
+  })
+
+  it("falls back to the custodial slot when activeAccountId is undefined", () => {
+    const state: PersistentState = {
+      ...baseState,
+      defaultAccountModalShownByAccountId: {
+        [DefaultAccountId.Custodial]: true,
+      },
+    }
+
+    expect(getDefaultAccountModalShown(state)).toBe(true)
+  })
+
+  it("isolates the flag per active account", () => {
+    const map = {
+      "self-custodial-1": true,
+      "self-custodial-2": false,
+    }
+
+    expect(
+      getDefaultAccountModalShown({
+        ...baseState,
+        activeAccountId: "self-custodial-1",
+        defaultAccountModalShownByAccountId: map,
+      }),
+    ).toBe(true)
+
+    expect(
+      getDefaultAccountModalShown({
+        ...baseState,
+        activeAccountId: "self-custodial-2",
+        defaultAccountModalShownByAccountId: map,
+      }),
+    ).toBe(false)
+  })
+
+  it("returns false when the map exists but has no entry for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-3",
+      defaultAccountModalShownByAccountId: {
+        "self-custodial-1": true,
+      },
+    }
+
+    expect(getDefaultAccountModalShown(state)).toBe(false)
+  })
+})
+
+describe("markDefaultAccountModalShown", () => {
+  it("creates the per-account map when absent and sets the flag for the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+    }
+
+    const next = markDefaultAccountModalShown(state)
+
+    expect(next.defaultAccountModalShownByAccountId).toEqual({
+      "self-custodial-1": true,
+    })
+  })
+
+  it("preserves entries for other accounts and updates only the active id", () => {
+    const state: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-2",
+      defaultAccountModalShownByAccountId: {
+        "self-custodial-1": true,
+        "self-custodial-2": false,
+      },
+    }
+
+    const next = markDefaultAccountModalShown(state)
+
+    expect(next.defaultAccountModalShownByAccountId).toEqual({
+      "self-custodial-1": true,
+      "self-custodial-2": true,
+    })
+  })
+
+  it("uses the custodial slot when activeAccountId is undefined", () => {
+    const next = markDefaultAccountModalShown(baseState)
+
+    expect(next.defaultAccountModalShownByAccountId).toEqual({
+      [DefaultAccountId.Custodial]: true,
+    })
+  })
+
+  it("does not mutate the input state", () => {
+    const original: PersistentState = {
+      ...baseState,
+      activeAccountId: "self-custodial-1",
+      defaultAccountModalShownByAccountId: {
+        "self-custodial-1": false,
+      },
+    }
+    const snapshot = JSON.parse(JSON.stringify(original))
+
+    markDefaultAccountModalShown(original)
+
+    expect(original).toEqual(snapshot)
+  })
+})

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -84,7 +84,7 @@ describe("PersistentStateProvider", () => {
     })
 
     expect(screen.getByTestId("token").props.children).toBe("saved-token")
-    expect(screen.getByTestId("schema").props.children).toBe(12)
+    expect(screen.getByTestId("schema").props.children).toBe(13)
   })
 
   it("falls back to default state when no persisted data exists", async () => {

--- a/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 12,
+  schemaVersion: 13,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 12,
+  schemaVersion: 13,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-language.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-language.spec.ts
@@ -6,7 +6,7 @@ import { PersistentState } from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 12,
+  schemaVersion: 13,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -23,7 +23,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state6)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.galoyAuthToken).toBe("test-token")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -39,7 +39,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state7)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.activeAccountId).toBe("custodial-default")
   })
 
@@ -52,7 +52,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state5)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.galoyAuthToken).toBe("old-token")
     expect(result.activeAccountId).toBeUndefined()
   })
@@ -68,7 +68,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -89,7 +89,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "USD",
       "self-custodial-id-2": "BTC",
@@ -105,7 +105,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toBeUndefined()
     expect(result.selfCustodialLanguageByAccountId).toBeUndefined()
   })
@@ -128,7 +128,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state11)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "EUR",
       "self-custodial-id-2": "JPY",
@@ -174,7 +174,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state4)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.galoyAuthToken).toBe("token-v4")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -203,14 +203,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state3)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.galoyAuthToken).toBe("token-v3")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
   })
 
-  it("default state has schema version 11", () => {
-    expect(defaultPersistentState.schemaVersion).toBe(12)
+  it("default state has the current schema version", () => {
+    expect(defaultPersistentState.schemaVersion).toBe(13)
     expect(defaultPersistentState.activeAccountId).toBeUndefined()
     expect(
       defaultPersistentState.selfCustodialDefaultWalletCurrencyByAccountId,
@@ -228,7 +228,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -247,7 +247,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "BTC",
@@ -263,7 +263,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -278,7 +278,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -294,7 +294,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -314,7 +314,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(12)
+    expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "BTC",

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -110,8 +110,8 @@ describe("state-migrations schema 10", () => {
     expect(result.selfCustodialLanguageByAccountId).toBeUndefined()
   })
 
-  it("preserves schema 11 per-account display currency and language maps as-is", async () => {
-    const state11 = {
+  it("preserves per-account display currency and language maps when migrating v12 to v13", async () => {
+    const state12 = {
       schemaVersion: 12,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "token",
@@ -126,7 +126,7 @@ describe("state-migrations schema 10", () => {
       },
     }
 
-    const result = await migrateAndGetPersistentState(state11)
+    const result = await migrateAndGetPersistentState(state12)
 
     expect(result.schemaVersion).toBe(13)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toEqual({
@@ -136,6 +136,48 @@ describe("state-migrations schema 10", () => {
     expect(result.selfCustodialLanguageByAccountId).toEqual({
       "self-custodial-id-1": "es",
       "self-custodial-id-2": "fr",
+    })
+  })
+
+  it("migrates a v12 state to v13 preserving themeByAccountId", async () => {
+    const state12 = {
+      schemaVersion: 12,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "token",
+      activeAccountId: "self-custodial-id-1",
+      themeByAccountId: {
+        "self-custodial-id-1": "dark" as const,
+        "self-custodial-id-2": "light" as const,
+      },
+    }
+
+    const result = await migrateAndGetPersistentState(state12)
+
+    expect(result.schemaVersion).toBe(13)
+    expect(result.themeByAccountId).toEqual({
+      "self-custodial-id-1": "dark",
+      "self-custodial-id-2": "light",
+    })
+  })
+
+  it("v13 identity migration preserves defaultAccountModalShownByAccountId untouched", async () => {
+    const state13 = {
+      schemaVersion: 13,
+      galoyInstance: { id: "Main" },
+      galoyAuthToken: "token",
+      activeAccountId: "self-custodial-id-1",
+      defaultAccountModalShownByAccountId: {
+        "self-custodial-id-1": true,
+        "self-custodial-id-2": false,
+      },
+    }
+
+    const result = await migrateAndGetPersistentState(state13)
+
+    expect(result.schemaVersion).toBe(13)
+    expect(result.defaultAccountModalShownByAccountId).toEqual({
+      "self-custodial-id-1": true,
+      "self-custodial-id-2": false,
     })
   })
 

--- a/__tests__/store/persistent-state/theme-preference.spec.ts
+++ b/__tests__/store/persistent-state/theme-preference.spec.ts
@@ -6,7 +6,7 @@ import {
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 12,
+  schemaVersion: 13,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/app/components/set-default-account-modal/set-default-account-modal.tsx
+++ b/app/components/set-default-account-modal/set-default-account-modal.tsx
@@ -3,14 +3,14 @@ import { View, TouchableOpacity, ActivityIndicator } from "react-native"
 import { ScrollView } from "react-native-gesture-handler"
 import Modal from "react-native-modal"
 
-import { gql, useApolloClient } from "@apollo/client"
-import { setHasPromptedSetDefaultAccount } from "@app/graphql/client-only-query"
+import { gql } from "@apollo/client"
 import {
   WalletCurrency,
   useAccountUpdateDefaultWalletIdMutation,
   useSetDefaultAccountModalQuery,
 } from "@app/graphql/generated"
 import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"
+import { useDefaultAccountModalShown } from "@app/hooks/use-default-account-modal-shown"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import crashlytics from "@react-native-firebase/crashlytics"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
@@ -53,7 +53,7 @@ export const SetDefaultAccountModal = ({
     fetchPolicy: "cache-only",
   })
 
-  const client = useApolloClient()
+  const { markDefaultAccountModalShown } = useDefaultAccountModalShown()
 
   const usdWallet = getUsdWallet(data?.me?.defaultAccount?.wallets)
   const btcWallet = getBtcWallet(data?.me?.defaultAccount?.wallets)
@@ -77,7 +77,7 @@ export const SetDefaultAccountModal = ({
     }
     setUsdLoading(false)
 
-    setHasPromptedSetDefaultAccount(client)
+    markDefaultAccountModalShown()
     toggleModal()
   }
 
@@ -100,7 +100,7 @@ export const SetDefaultAccountModal = ({
     }
     setBtcLoading(false)
 
-    setHasPromptedSetDefaultAccount(client)
+    markDefaultAccountModalShown()
     toggleModal()
   }
 

--- a/app/components/set-default-account-modal/set-default-account-modal.tsx
+++ b/app/components/set-default-account-modal/set-default-account-modal.tsx
@@ -58,6 +58,11 @@ export const SetDefaultAccountModal = ({
   const usdWallet = getUsdWallet(data?.me?.defaultAccount?.wallets)
   const btcWallet = getBtcWallet(data?.me?.defaultAccount?.wallets)
 
+  const closeAsAcknowledged = () => {
+    markDefaultAccountModalShown()
+    toggleModal()
+  }
+
   const onPressUsdAccount = async () => {
     setUsdLoading(true)
     if (usdWallet) {
@@ -77,8 +82,7 @@ export const SetDefaultAccountModal = ({
     }
     setUsdLoading(false)
 
-    markDefaultAccountModalShown()
-    toggleModal()
+    closeAsAcknowledged()
   }
 
   const onPressBtcAccount = async () => {
@@ -100,8 +104,7 @@ export const SetDefaultAccountModal = ({
     }
     setBtcLoading(false)
 
-    markDefaultAccountModalShown()
-    toggleModal()
+    closeAsAcknowledged()
   }
 
   return (

--- a/app/graphql/cache.ts
+++ b/app/graphql/cache.ts
@@ -104,9 +104,6 @@ export const createCache = () =>
           feedbackModalShown: {
             read: (value) => value ?? false,
           },
-          hasPromptedSetDefaultAccount: {
-            read: (value) => value ?? false,
-          },
           introducingCirclesModalShown: {
             read: (value) => value ?? false,
           },

--- a/app/graphql/client-only-query.ts
+++ b/app/graphql/client-only-query.ts
@@ -10,7 +10,6 @@ import {
   CountryCodeQuery,
   FeedbackModalShownDocument,
   FeedbackModalShownQuery,
-  HasPromptedSetDefaultAccountDocument,
   HiddenBalanceToolTipDocument,
   HiddenBalanceToolTipQuery,
   HideBalanceDocument,
@@ -60,10 +59,6 @@ export default gql`
 
   query feedbackModalShown {
     feedbackModalShown @client
-  }
-
-  query hasPromptedSetDefaultAccount {
-    hasPromptedSetDefaultAccount @client
   }
 
   query introducingCirclesModalShown {
@@ -190,20 +185,6 @@ export const setFeedbackModalShown = (client: ApolloClient<unknown>, shown: bool
     })
   } catch {
     console.warn("unable to update feedbackModalShown")
-  }
-}
-
-export const setHasPromptedSetDefaultAccount = (client: ApolloClient<unknown>) => {
-  try {
-    client.writeQuery({
-      query: HasPromptedSetDefaultAccountDocument,
-      data: {
-        __typename: "Query",
-        hasPromptedSetDefaultAccount: true,
-      },
-    })
-  } catch {
-    console.warn("impossible to update hasPromptedSetDefaultAccount")
   }
 }
 

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -2198,7 +2198,6 @@ export type Query = {
   readonly deviceSessionCount: Scalars['Int']['output'];
   readonly feedbackModalShown: Scalars['Boolean']['output'];
   readonly globals?: Maybe<Globals>;
-  readonly hasPromptedSetDefaultAccount: Scalars['Boolean']['output'];
   readonly hiddenBalanceToolTip: Scalars['Boolean']['output'];
   readonly hideBalance: Scalars['Boolean']['output'];
   readonly innerCircleValue: Scalars['Int']['output'];
@@ -3192,11 +3191,6 @@ export type FeedbackModalShownQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type FeedbackModalShownQuery = { readonly __typename: 'Query', readonly feedbackModalShown: boolean };
-
-export type HasPromptedSetDefaultAccountQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type HasPromptedSetDefaultAccountQuery = { readonly __typename: 'Query', readonly hasPromptedSetDefaultAccount: boolean };
 
 export type IntroducingCirclesModalShownQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -4620,43 +4614,6 @@ export type FeedbackModalShownQueryHookResult = ReturnType<typeof useFeedbackMod
 export type FeedbackModalShownLazyQueryHookResult = ReturnType<typeof useFeedbackModalShownLazyQuery>;
 export type FeedbackModalShownSuspenseQueryHookResult = ReturnType<typeof useFeedbackModalShownSuspenseQuery>;
 export type FeedbackModalShownQueryResult = Apollo.QueryResult<FeedbackModalShownQuery, FeedbackModalShownQueryVariables>;
-export const HasPromptedSetDefaultAccountDocument = gql`
-    query hasPromptedSetDefaultAccount {
-  hasPromptedSetDefaultAccount @client
-}
-    `;
-
-/**
- * __useHasPromptedSetDefaultAccountQuery__
- *
- * To run a query within a React component, call `useHasPromptedSetDefaultAccountQuery` and pass it any options that fit your needs.
- * When your component renders, `useHasPromptedSetDefaultAccountQuery` returns an object from Apollo Client that contains loading, error, and data properties
- * you can use to render your UI.
- *
- * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
- *
- * @example
- * const { data, loading, error } = useHasPromptedSetDefaultAccountQuery({
- *   variables: {
- *   },
- * });
- */
-export function useHasPromptedSetDefaultAccountQuery(baseOptions?: Apollo.QueryHookOptions<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>(HasPromptedSetDefaultAccountDocument, options);
-      }
-export function useHasPromptedSetDefaultAccountLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>(HasPromptedSetDefaultAccountDocument, options);
-        }
-export function useHasPromptedSetDefaultAccountSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useSuspenseQuery<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>(HasPromptedSetDefaultAccountDocument, options);
-        }
-export type HasPromptedSetDefaultAccountQueryHookResult = ReturnType<typeof useHasPromptedSetDefaultAccountQuery>;
-export type HasPromptedSetDefaultAccountLazyQueryHookResult = ReturnType<typeof useHasPromptedSetDefaultAccountLazyQuery>;
-export type HasPromptedSetDefaultAccountSuspenseQueryHookResult = ReturnType<typeof useHasPromptedSetDefaultAccountSuspenseQuery>;
-export type HasPromptedSetDefaultAccountQueryResult = Apollo.QueryResult<HasPromptedSetDefaultAccountQuery, HasPromptedSetDefaultAccountQueryVariables>;
 export const IntroducingCirclesModalShownDocument = gql`
     query introducingCirclesModalShown {
   introducingCirclesModalShown @client
@@ -10899,7 +10856,6 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   deviceSessionCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   feedbackModalShown?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   globals?: Resolver<Maybe<ResolversTypes['Globals']>, ParentType, ContextType>;
-  hasPromptedSetDefaultAccount?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   hiddenBalanceToolTip?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   hideBalance?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   innerCircleValue?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;

--- a/app/graphql/local-schema.gql
+++ b/app/graphql/local-schema.gql
@@ -10,7 +10,6 @@ extend type Query {
   countryCode: String!
   region: Region
   feedbackModalShown: Boolean!
-  hasPromptedSetDefaultAccount: Boolean!
   introducingCirclesModalShown: Boolean!
   innerCircleValue: Int!
   upgradeModalLastShownAt: String

--- a/app/hooks/use-default-account-modal-shown.ts
+++ b/app/hooks/use-default-account-modal-shown.ts
@@ -3,19 +3,19 @@ import { useCallback } from "react"
 import { usePersistentStateContext } from "@app/store/persistent-state"
 import {
   getDefaultAccountModalShown,
-  markDefaultAccountModalShown,
+  withDefaultAccountModalShown,
 } from "@app/store/persistent-state/default-account-modal-shown"
 
-type UseDefaultAccountModalShownReturn = {
+type DefaultAccountModalShownReturn = {
   defaultAccountModalShown: boolean
   markDefaultAccountModalShown: () => void
 }
 
-export const useDefaultAccountModalShown = (): UseDefaultAccountModalShownReturn => {
+export const useDefaultAccountModalShown = (): DefaultAccountModalShownReturn => {
   const { persistentState, updateState } = usePersistentStateContext()
 
   const markShown = useCallback(() => {
-    updateState((prev) => prev && markDefaultAccountModalShown(prev))
+    updateState((prev) => prev && withDefaultAccountModalShown(prev))
   }, [updateState])
 
   return {

--- a/app/hooks/use-default-account-modal-shown.ts
+++ b/app/hooks/use-default-account-modal-shown.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react"
+
+import { usePersistentStateContext } from "@app/store/persistent-state"
+import {
+  getDefaultAccountModalShown,
+  markDefaultAccountModalShown,
+} from "@app/store/persistent-state/default-account-modal-shown"
+
+type UseDefaultAccountModalShownReturn = {
+  defaultAccountModalShown: boolean
+  markDefaultAccountModalShown: () => void
+}
+
+export const useDefaultAccountModalShown = (): UseDefaultAccountModalShownReturn => {
+  const { persistentState, updateState } = usePersistentStateContext()
+
+  const markShown = useCallback(() => {
+    updateState((prev) => prev && markDefaultAccountModalShown(prev))
+  }, [updateState])
+
+  return {
+    defaultAccountModalShown: getDefaultAccountModalShown(persistentState),
+    markDefaultAccountModalShown: markShown,
+  }
+}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -39,6 +39,7 @@ import { NetworkStatusBanner } from "@app/components/network-status-banner"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
+import { useDefaultAccountModalShown } from "@app/hooks/use-default-account-modal-shown"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
 import { getErrorMessages } from "@app/graphql/utils"
@@ -58,7 +59,6 @@ import {
   TxDirection,
   TxStatus,
   useBulletinsQuery,
-  useHasPromptedSetDefaultAccountQuery,
   useHomeAuthedQuery,
   useHomeUnauthedQuery,
   useRealtimePriceQuery,
@@ -163,8 +163,7 @@ export const HomeScreen: React.FC = () => {
   const { balanceLimitToTriggerUpgradeModal, upgradeModalCooldownDays } =
     useRemoteConfig()
 
-  const { data: { hasPromptedSetDefaultAccount } = {} } =
-    useHasPromptedSetDefaultAccountQuery()
+  const { defaultAccountModalShown } = useDefaultAccountModalShown()
   const [setDefaultAccountModalVisible, setSetDefaultAccountModalVisible] =
     React.useState(false)
   const reopenUpgradeModal = React.useRef(false)
@@ -408,7 +407,7 @@ export const HomeScreen: React.FC = () => {
     if (
       !isSelfCustodial &&
       target === "receiveBitcoin" &&
-      !hasPromptedSetDefaultAccount &&
+      !defaultAccountModalShown &&
       numberOfTxs >= TransactionCountToTriggerSetDefaultAccountModal &&
       galoyInstanceId === "Main"
     ) {

--- a/app/store/persistent-state/account-key.ts
+++ b/app/store/persistent-state/account-key.ts
@@ -1,0 +1,11 @@
+import { DefaultAccountId } from "@app/types/wallet"
+
+import { PersistentState } from "./state-migrations"
+
+/**
+ * Resolves the per-account map key for features that fall back to the custodial
+ * slot when no self-custodial account is active. The write key and read key
+ * must stay identical, so both sides resolve through this single primitive.
+ */
+export const resolveAccountKey = (state: PersistentState): string =>
+  state.activeAccountId ?? DefaultAccountId.Custodial

--- a/app/store/persistent-state/default-account-modal-shown.ts
+++ b/app/store/persistent-state/default-account-modal-shown.ts
@@ -1,0 +1,22 @@
+import { DefaultAccountId } from "@app/types/wallet"
+
+import { PersistentState } from "./state-migrations"
+
+const resolveAccountKey = (state: PersistentState): string =>
+  state.activeAccountId ?? DefaultAccountId.Custodial
+
+export const getDefaultAccountModalShown = (state: PersistentState): boolean => {
+  const key = resolveAccountKey(state)
+  return state.defaultAccountModalShownByAccountId?.[key] ?? false
+}
+
+export const markDefaultAccountModalShown = (state: PersistentState): PersistentState => {
+  const key = resolveAccountKey(state)
+  return {
+    ...state,
+    defaultAccountModalShownByAccountId: {
+      ...state.defaultAccountModalShownByAccountId,
+      [key]: true,
+    },
+  }
+}

--- a/app/store/persistent-state/default-account-modal-shown.ts
+++ b/app/store/persistent-state/default-account-modal-shown.ts
@@ -1,16 +1,12 @@
-import { DefaultAccountId } from "@app/types/wallet"
-
+import { resolveAccountKey } from "./account-key"
 import { PersistentState } from "./state-migrations"
-
-const resolveAccountKey = (state: PersistentState): string =>
-  state.activeAccountId ?? DefaultAccountId.Custodial
 
 export const getDefaultAccountModalShown = (state: PersistentState): boolean => {
   const key = resolveAccountKey(state)
   return state.defaultAccountModalShownByAccountId?.[key] ?? false
 }
 
-export const markDefaultAccountModalShown = (state: PersistentState): PersistentState => {
+export const withDefaultAccountModalShown = (state: PersistentState): PersistentState => {
   const key = resolveAccountKey(state)
   return {
     ...state,

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -87,8 +87,24 @@ type PersistentState_12 = {
   themeByAccountId?: Record<string, "system" | "light" | "dark">
 }
 
-const migrate12ToCurrent = (state: PersistentState_12): Promise<PersistentState> =>
+type PersistentState_13 = {
+  schemaVersion: 13
+  galoyInstance: GaloyInstanceInput
+  galoyAuthToken: string
+  activeAccountId?: string
+  selfCustodialDefaultWalletCurrency?: "BTC" | "USD"
+  selfCustodialDefaultWalletCurrencyByAccountId?: Record<string, "BTC" | "USD">
+  selfCustodialDisplayCurrencyByAccountId?: Record<string, string>
+  selfCustodialLanguageByAccountId?: Record<string, string>
+  themeByAccountId?: Record<string, "system" | "light" | "dark">
+  defaultAccountModalShownByAccountId?: Record<string, boolean>
+}
+
+const migrate13ToCurrent = (state: PersistentState_13): Promise<PersistentState> =>
   Promise.resolve(state)
+
+const migrate12ToCurrent = (state: PersistentState_12): Promise<PersistentState> =>
+  migrate13ToCurrent({ ...state, schemaVersion: 13 })
 
 const migrate11ToCurrent = (state: PersistentState_11): Promise<PersistentState> =>
   migrate12ToCurrent({ ...state, schemaVersion: 12 })
@@ -203,6 +219,7 @@ type StateMigrations = {
   10: (state: PersistentState_10) => Promise<PersistentState>
   11: (state: PersistentState_11) => Promise<PersistentState>
   12: (state: PersistentState_12) => Promise<PersistentState>
+  13: (state: PersistentState_13) => Promise<PersistentState>
 }
 
 const stateMigrations: StateMigrations = {
@@ -216,12 +233,13 @@ const stateMigrations: StateMigrations = {
   10: migrate10ToCurrent,
   11: migrate11ToCurrent,
   12: migrate12ToCurrent,
+  13: migrate13ToCurrent,
 }
 
-export type PersistentState = PersistentState_12
+export type PersistentState = PersistentState_13
 
 export const defaultPersistentState: PersistentState = {
-  schemaVersion: 12,
+  schemaVersion: 13,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }
@@ -248,7 +266,7 @@ export const migratePersistentState = async (
   if (!data || !(data.schemaVersion in stateMigrations)) {
     return { status: MigrationStatus.NoData }
   }
-  const schemaVersion: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 = data.schemaVersion
+  const schemaVersion: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 = data.schemaVersion
   try {
     const migration = stateMigrations[schemaVersion]
     const state = await migration(data)

--- a/app/store/persistent-state/theme-preference.ts
+++ b/app/store/persistent-state/theme-preference.ts
@@ -1,11 +1,7 @@
-import { DefaultAccountId } from "@app/types/wallet"
-
+import { resolveAccountKey } from "./account-key"
 import { PersistentState } from "./state-migrations"
 
 export type ThemePreference = "system" | "light" | "dark"
-
-const resolveAccountKey = (state: PersistentState): string =>
-  state.activeAccountId ?? DefaultAccountId.Custodial
 
 export const getThemePreference = (state: PersistentState): ThemePreference => {
   const key = resolveAccountKey(state)


### PR DESCRIPTION
## Summary

Fixes #3811 — the "Select default account" modal re-appearing on every **Receive** tap.

The flag tracking whether the modal has already been shown lived in the Apollo client-only cache (`hasPromptedSetDefaultAccount`). Its restore was [token-gated in PR #3769](https://github.com/blinkbitcoin/blink-mobile/blob/main/app/graphql/client.tsx#L296-L300) and `useEffectiveAuthToken()` resolves asynchronously, so on cold start the restore is often skipped and the flag defaults to `false` — the modal re-appears.

This PR moves the flag out of Apollo cache into `persistentState`, keyed by `accountId`. Same persistence pattern used by PR #3795 (theme preference).

## Why persistentState

- Independent of Apollo client lifecycle and token-gating
- Loaded synchronously on app boot via `PersistentStateProvider`
- Per-account isolation comes for free (`defaultAccountModalShownByAccountId[id]`), which also fixes the secondary issue where the choice was lost on account switches

## Changes

**New**
- `app/store/persistent-state/default-account-modal-shown.ts` — `getDefaultAccountModalShown` / `markDefaultAccountModalShown`
- `app/hooks/use-default-account-modal-shown.ts` — `useDefaultAccountModalShown`
- `__tests__/store/persistent-state/default-account-modal-shown.spec.ts` — 9 specs covering per-account isolation, fallback, immutability

**Schema migration**
- `PersistentState_13` adds `defaultAccountModalShownByAccountId?: Record<string, boolean>`
- `migrate12ToCurrent` → bumps to 13, `migrate13ToCurrent` is identity

**Removed (Apollo client-only field)**
- `hasPromptedSetDefaultAccount` from `local-schema.gql`
- Type policy from `cache.ts`
- `setHasPromptedSetDefaultAccount` writer + query from `client-only-query.ts`
- Regenerated `generated.ts`

**Consumers migrated**
- `home-screen.tsx` — reads `defaultAccountModalShown` from the new hook
- `set-default-account-modal.tsx` — calls `markDefaultAccountModalShown()` instead of writing the Apollo cache
