### PR TITLE
fix(test): wrap async provider/hook updates in act() to clear CI log noise

### DIFF
--- a/__tests__/components/bulletins.spec.tsx
+++ b/__tests__/components/bulletins.spec.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 import { Text as ReactNativeText, TouchableOpacity, View, Linking } from "react-native"
 import { render, fireEvent, waitFor } from "@testing-library/react-native"
 
+import { flushEffects } from "../helpers/flush-effects"
+
 jest.mock("@app/components/animations", () => ({
   useDropInOutAnimation: () => ({
     opacity: { _value: 1 },
@@ -219,7 +221,7 @@ describe("BulletinsCard", () => {
     })
   })
 
-  it("calls ack on dismiss without opening any link", () => {
+  it("calls ack on dismiss without opening any link", async () => {
     const bulletins = makeBulletinsQuery([makeBulletin()])
     const { getByTestId } = render(
       <BulletinsCard loading={false} bulletins={bulletins} />,
@@ -231,6 +233,7 @@ describe("BulletinsCard", () => {
       variables: { input: { notificationId: "notif-1" } },
     })
     expect(Linking.openURL).not.toHaveBeenCalled()
+    await flushEffects()
   })
 
   it("renders multiple bulletins", () => {

--- a/__tests__/components/steps-progress-bar/steps-progress-bar.spec.tsx
+++ b/__tests__/components/steps-progress-bar/steps-progress-bar.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { Text as RNText } from "react-native"
-import { render } from "@testing-library/react-native"
+import { render, act } from "@testing-library/react-native"
 
 import { StepsProgressBar } from "@app/components/steps-progress-bar"
 
@@ -25,6 +25,16 @@ jest.mock("@rn-vui/themed", () => ({
   }),
 }))
 
+// The animated bar fill runs an Animated.timing whose updates land across several
+// frames after the synchronous test body returns. Drive those frames to
+// completion inside act() so they neither warn ("not wrapped in act(...)") nor
+// leak into the next test. The component's animation lasts 120ms; 200ms covers it.
+const settleAnimations = () => {
+  act(() => {
+    jest.advanceTimersByTime(200)
+  })
+}
+
 describe("StepsProgressBar", () => {
   const twoStepProps = {
     steps: ["Set PIN", "Confirm"],
@@ -35,6 +45,15 @@ describe("StepsProgressBar", () => {
     steps: ["Current PIN", "New PIN", "Confirm"],
     currentStep: 1,
   }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    settleAnimations()
+    jest.useRealTimers()
+  })
 
   describe("rendering", () => {
     it("renders without crashing", () => {

--- a/__tests__/helpers/flush-effects.ts
+++ b/__tests__/helpers/flush-effects.ts
@@ -1,0 +1,29 @@
+import { act } from "@testing-library/react-native"
+
+/**
+ * Settle pending promises/microtasks inside `act()` after a synchronous render.
+ *
+ * Providers and hooks commonly kick off async work in `useEffect` (KeyStore
+ * reads, SDK init, session-profile lookups) whose `setState` resolves *after*
+ * the synchronous test body returns — outside `act()` — producing
+ * "An update to X inside a test was not wrapped in act(...)" warnings that flood
+ * the CI logs. Awaiting this after such a render lets those updates flush within
+ * `act()`, so the warnings disappear without masking genuine ones.
+ *
+ * Use it in synchronous render-and-assert tests that render a component/hook
+ * with async effects:
+ *
+ *   const { result } = renderHook(() => useThing(), { wrapper })
+ *   await flushEffects()
+ *   expect(result.current.value).toBe(...)
+ *
+ * Tests that already await `waitFor`/`findBy*` on the resolved state do not need
+ * this — the awaited query already settles the effects inside `act()`.
+ */
+export const flushEffects = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve)
+    })
+  })
+}

--- a/__tests__/receive-bitcoin/hooks/use-invoice-lifecycle.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-invoice-lifecycle.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks"
 
+import { flushEffects } from "../../helpers/flush-effects"
 import { useInvoiceLifecycle } from "@app/screens/receive-bitcoin-screen/hooks/use-invoice-lifecycle"
 import {
   Invoice,
@@ -77,7 +78,7 @@ describe("useInvoiceLifecycle", () => {
     expect(mockCreatePaymentRequest).not.toHaveBeenCalled()
   })
 
-  it("creates PR from prcd and mutations", () => {
+  it("creates PR from prcd and mutations", async () => {
     const mockPR = createMockPR()
     mockCreatePaymentRequest.mockReturnValue(mockPR)
 
@@ -91,6 +92,7 @@ describe("useInvoiceLifecycle", () => {
       creationData: prcd,
     })
     expect(result.current.pr).toBeDefined()
+    await flushEffects()
   })
 
   it("triggers invoice generation when PR is Idle", async () => {
@@ -105,6 +107,7 @@ describe("useInvoiceLifecycle", () => {
     renderHook(() => useInvoiceLifecycle(prcd as never, mockMutations as never))
 
     expect(idlePR.generateRequest).toHaveBeenCalled()
+    await flushEffects()
   })
 
   it("exposes regenerateInvoice callback", () => {

--- a/__tests__/receive-bitcoin/hooks/use-onchain-address.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-onchain-address.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from "@testing-library/react-native"
 
+import { flushEffects } from "../../helpers/flush-effects"
 import { useOnChainAddress } from "@app/screens/receive-bitcoin-screen/hooks/use-onchain-address"
 
 const mockMutationFn = jest.fn()
@@ -23,7 +24,7 @@ describe("useOnChainAddress", () => {
     jest.clearAllMocks()
   })
 
-  it("returns loading true initially", () => {
+  it("returns loading true initially", async () => {
     mockMutationFn.mockResolvedValue({
       data: { onChainAddressCurrent: { address: "bc1qtest" } },
     })
@@ -32,6 +33,7 @@ describe("useOnChainAddress", () => {
 
     expect(result.current.loading).toBe(true)
     expect(result.current.address).toBeNull()
+    await flushEffects()
   })
 
   it("fetches address when walletId is provided", async () => {

--- a/__tests__/screens/card-screen/card-settings-screen/card-settings-screen.spec.tsx
+++ b/__tests__/screens/card-screen/card-settings-screen/card-settings-screen.spec.tsx
@@ -5,6 +5,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { CardSettingsScreen } from "@app/screens/card-screen/card-settings-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 jest.mock("react-native-reanimated", () => {
   const RNView = jest.requireActual<typeof import("react-native")>("react-native").View
@@ -103,6 +104,20 @@ describe("CardSettingsScreen", () => {
     }
   })
 
+  // The Switch and the ~300ms close-account modal animations run on real
+  // timers; their Animated updates land after the synchronous test body
+  // returns. Wait them out inside act() so they neither warn nor leak into the
+  // next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 400)
+      })
+    })
+    await flushEffects()
+    await flushEffects()
+  })
+
   describe("rendering", () => {
     it("renders without crashing", async () => {
       const { toJSON } = render(
@@ -111,7 +126,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(toJSON()).toBeTruthy()
     })
@@ -123,7 +138,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Account Information")).toBeTruthy()
     })
@@ -135,7 +150,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Personal Details")).toBeTruthy()
     })
@@ -147,7 +162,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Change PIN")).toBeTruthy()
     })
@@ -161,7 +176,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Notifications")).toBeTruthy()
     })
@@ -173,7 +188,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Transaction alerts")).toBeTruthy()
       expect(getByText("Get notified for all transactions")).toBeTruthy()
@@ -186,7 +201,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Marketing updates")).toBeTruthy()
       expect(getByText("Product updates and offers")).toBeTruthy()
@@ -201,7 +216,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Card management")).toBeTruthy()
     })
@@ -213,7 +228,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Order physical card")).toBeTruthy()
     })
@@ -225,7 +240,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Add to Google Pay")).toBeTruthy()
     })
@@ -237,7 +252,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Replace card")).toBeTruthy()
     })
@@ -251,7 +266,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Support")).toBeTruthy()
     })
@@ -263,7 +278,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Contact Support")).toBeTruthy()
       expect(getByText("support@blink.sv")).toBeTruthy()
@@ -278,7 +293,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Account")).toBeTruthy()
     })
@@ -290,7 +305,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Card Terms & Conditions")).toBeTruthy()
     })
@@ -302,7 +317,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Card Privacy Policy")).toBeTruthy()
     })
@@ -316,7 +331,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Danger zone")).toBeTruthy()
     })
@@ -328,7 +343,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Close card account")).toBeTruthy()
       expect(getByText("Permanently close your Visa card")).toBeTruthy()
@@ -343,7 +358,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Personal Details")
       await act(async () => {
@@ -360,7 +375,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Change PIN")
       await act(async () => {
@@ -377,7 +392,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Order physical card")
       await act(async () => {
@@ -394,7 +409,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Add to Google Pay")
       await act(async () => {
@@ -414,7 +429,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Replace card")
       await act(async () => {
@@ -433,7 +448,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Contact Support")
       await act(async () => {
@@ -450,7 +465,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Card Terms & Conditions")
       await act(async () => {
@@ -469,7 +484,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const row = getByText("Card Privacy Policy")
       await act(async () => {
@@ -490,7 +505,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Close card account"))
@@ -519,7 +534,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Close card account"))
@@ -547,7 +562,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Close card account"))
@@ -571,7 +586,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const switches = getAllByRole("switch")
       expect(switches[0].props.accessibilityState.checked).toBe(true)
@@ -590,7 +605,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       const switches = getAllByRole("switch")
       expect(switches[1].props.accessibilityState.checked).toBe(false)
@@ -611,7 +626,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Account Information")).toBeTruthy()
       expect(getByText("Notifications")).toBeTruthy()
@@ -628,7 +643,7 @@ describe("CardSettingsScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Personal Details"))

--- a/__tests__/screens/card-screen/card-settings-screen/close-card-modal.spec.tsx
+++ b/__tests__/screens/card-screen/card-settings-screen/close-card-modal.spec.tsx
@@ -5,6 +5,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { CloseCardModal } from "@app/screens/card-screen/card-settings-screen/close-card-modal"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 jest.mock("react-native-reanimated", () => {
   const RNView = jest.requireActual<typeof import("react-native")>("react-native").View
@@ -30,6 +31,20 @@ describe("CloseCardModal", () => {
     jest.clearAllMocks()
   })
 
+  // CustomModal (react-native-modal) runs ~300ms entrance/backdrop animations
+  // on real timers whose Animated updates land after the synchronous test body
+  // returns. Wait the animations out inside act() so they neither warn nor leak
+  // into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 400)
+      })
+    })
+    await flushEffects()
+    await flushEffects()
+  })
+
   const renderModal = (overrides = {}) =>
     render(
       <ContextForScreen>
@@ -47,7 +62,7 @@ describe("CloseCardModal", () => {
     it("renders header title", async () => {
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Close card account")).toBeTruthy()
     })
@@ -55,7 +70,7 @@ describe("CloseCardModal", () => {
     it("renders warning text", async () => {
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(
         getByText(
@@ -67,7 +82,7 @@ describe("CloseCardModal", () => {
     it("renders instruction text", async () => {
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText('Please type "close" to confirm')).toBeTruthy()
     })
@@ -75,7 +90,7 @@ describe("CloseCardModal", () => {
     it("renders text input with placeholder", async () => {
       const { getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByPlaceholderText("close")).toBeTruthy()
     })
@@ -83,7 +98,7 @@ describe("CloseCardModal", () => {
     it("renders confirm and cancel buttons", async () => {
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Confirm")).toBeTruthy()
       expect(getByText("Cancel")).toBeTruthy()
@@ -95,7 +110,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -113,7 +128,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "CLOSE")
@@ -131,7 +146,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "  close  ")
@@ -149,7 +164,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "clo")
@@ -167,7 +182,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Confirm"))
@@ -182,7 +197,7 @@ describe("CloseCardModal", () => {
     it("calls onClose when cancel is pressed", async () => {
       const { getByText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Cancel"))
@@ -195,7 +210,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -220,7 +235,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -239,7 +254,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -261,7 +276,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -285,7 +300,7 @@ describe("CloseCardModal", () => {
       jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")
@@ -302,7 +317,7 @@ describe("CloseCardModal", () => {
       const alertSpy = jest.spyOn(Alert, "alert")
       const { getByText, getByPlaceholderText } = renderModal()
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.changeText(getByPlaceholderText("close"), "close")

--- a/__tests__/screens/card-screen/order-card-screens/order-card-screen.spec.tsx
+++ b/__tests__/screens/card-screen/order-card-screens/order-card-screen.spec.tsx
@@ -4,6 +4,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { OrderCardScreen } from "@app/screens/card-screen/order-card-screens/order-card-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 jest.mock("react-native-reanimated", () => {
   const RNView = jest.requireActual<typeof import("react-native")>("react-native").View
@@ -131,6 +132,18 @@ describe("OrderCardScreen", () => {
     })
   })
 
+  // StepsProgressBar runs an Animated.timing (real-timer, ~120ms) whose frames
+  // land after the synchronous test body returns. Wait the animation out inside
+  // act() so its updates neither warn nor leak into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200)
+      })
+    })
+    await flushEffects()
+  })
+
   describe("rendering", () => {
     it("renders without crashing", async () => {
       const { toJSON } = render(
@@ -139,7 +152,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(toJSON()).toBeTruthy()
     })
@@ -151,7 +164,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Order your physical card")).toBeTruthy()
     })
@@ -163,7 +176,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Continue")).toBeTruthy()
     })
@@ -177,7 +190,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Registered address")).toBeTruthy()
       expect(getByText("123 Main Street")).toBeTruthy()
@@ -190,7 +203,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Standard delivery")).toBeTruthy()
       expect(getByText("7-10 business days")).toBeTruthy()
@@ -203,7 +216,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Continue"))
@@ -227,7 +240,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep2(getByText)
 
@@ -242,7 +255,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep2(getByText)
 
@@ -256,7 +269,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep2(getByText)
 
@@ -300,7 +313,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep2(getByText)
 
@@ -321,7 +334,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Order your physical card")).toBeTruthy()
 
@@ -356,7 +369,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByTestId("activity-indicator")).toBeTruthy()
       expect(queryByText("Order your physical card")).toBeNull()
@@ -375,7 +388,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByTestId("activity-indicator")).toBeTruthy()
       expect(queryByText("Order your physical card")).toBeNull()
@@ -399,7 +412,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(mockGoBack).toHaveBeenCalled()
     })
@@ -420,7 +433,7 @@ describe("OrderCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(mockGoBack).toHaveBeenCalled()
     })

--- a/__tests__/screens/card-screen/pin-screens/card-change-pin-screen.spec.tsx
+++ b/__tests__/screens/card-screen/pin-screens/card-change-pin-screen.spec.tsx
@@ -4,6 +4,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { CardChangePinScreen } from "@app/screens/card-screen/pin-screens/card-change-pin-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 const mockNavigate = jest.fn()
 const mockGoBack = jest.fn()
@@ -45,6 +46,18 @@ describe("CardChangePinScreen", () => {
     mockUpdatePin.mockResolvedValue(true)
   })
 
+  // StepsProgressBar runs an Animated.timing (real-timer, ~120ms) whose frames
+  // land after the synchronous test body returns. Wait the animation out inside
+  // act() so its updates neither warn nor leak into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200)
+      })
+    })
+    await flushEffects()
+  })
+
   describe("biometric gate", () => {
     it("does not render when biometric not authenticated", async () => {
       mockUseBiometricGate.mockReturnValue(false)
@@ -55,7 +68,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(queryByText("Enter new PIN")).toBeNull()
       expect(queryByText("New PIN")).toBeNull()
@@ -68,7 +81,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(mockUseBiometricGate).toHaveBeenCalledWith(
         expect.objectContaining({ required: true }),
@@ -84,7 +97,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(toJSON()).toBeTruthy()
     })
@@ -96,7 +109,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Enter new PIN")).toBeTruthy()
     })
@@ -108,7 +121,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Please enter your new 4-digit PIN.")).toBeTruthy()
     })
@@ -122,7 +135,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("New PIN")).toBeTruthy()
       expect(getByText("Confirm")).toBeTruthy()
@@ -137,7 +150,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByTestId("NumericKey-1")).toBeTruthy()
       expect(getByTestId("NumericKey-2")).toBeTruthy()
@@ -153,7 +166,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -173,7 +186,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -195,7 +208,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-6"))
@@ -219,7 +232,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -251,7 +264,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -282,7 +295,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -318,7 +331,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -352,7 +365,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -391,7 +404,7 @@ describe("CardChangePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Enter new PIN")).toBeTruthy()
       expect(getByText("New PIN")).toBeTruthy()

--- a/__tests__/screens/card-screen/pin-screens/card-create-pin-screen.spec.tsx
+++ b/__tests__/screens/card-screen/pin-screens/card-create-pin-screen.spec.tsx
@@ -4,6 +4,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { CardCreatePinScreen } from "@app/screens/card-screen/pin-screens/card-create-pin-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 const mockNavigate = jest.fn()
 const mockAddListener = jest.fn()
@@ -36,6 +37,18 @@ describe("CardCreatePinScreen", () => {
     mockUpdatePin.mockResolvedValue(true)
   })
 
+  // StepsProgressBar runs an Animated.timing (real-timer, ~120ms) whose frames
+  // land after the synchronous test body returns. Wait the animation out inside
+  // act() so its updates neither warn nor leak into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200)
+      })
+    })
+    await flushEffects()
+  })
+
   describe("rendering", () => {
     it("renders without crashing", async () => {
       const { toJSON } = render(
@@ -44,7 +57,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(toJSON()).toBeTruthy()
     })
@@ -56,7 +69,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Enter your PIN")).toBeTruthy()
     })
@@ -68,7 +81,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Please enter a 4-digit PIN to continue.")).toBeTruthy()
     })
@@ -82,7 +95,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Set PIN")).toBeTruthy()
       expect(getByText("Confirm")).toBeTruthy()
@@ -97,7 +110,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByTestId("NumericKey-1")).toBeTruthy()
       expect(getByTestId("NumericKey-2")).toBeTruthy()
@@ -113,7 +126,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -133,7 +146,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -153,7 +166,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -185,7 +198,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -216,7 +229,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-1"))
       fireEvent.press(getByTestId("NumericKey-2"))
@@ -238,7 +251,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-0"))
       fireEvent.press(getByTestId("NumericKey-0"))
@@ -260,7 +273,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -282,7 +295,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -316,7 +329,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -355,7 +368,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -391,7 +404,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       fireEvent.press(getByTestId("NumericKey-5"))
       fireEvent.press(getByTestId("NumericKey-8"))
@@ -435,7 +448,7 @@ describe("CardCreatePinScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Enter your PIN")).toBeTruthy()
       expect(getByText("Set PIN")).toBeTruthy()

--- a/__tests__/screens/card-screen/replace-card-screens/replace-card-screen.spec.tsx
+++ b/__tests__/screens/card-screen/replace-card-screens/replace-card-screen.spec.tsx
@@ -4,6 +4,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 
 import { ReplaceCardScreen } from "@app/screens/card-screen/replace-card-screens/replace-card-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 jest.mock("react-native-reanimated", () => {
   const RNView = jest.requireActual<typeof import("react-native")>("react-native").View
@@ -118,6 +119,18 @@ describe("ReplaceCardScreen", () => {
     mockLockCard.mockResolvedValue(true)
   })
 
+  // StepsProgressBar runs an Animated.timing (real-timer, ~120ms) whose frames
+  // land after the synchronous test body returns. Wait the animation out inside
+  // act() so its updates neither warn nor leak into the next test.
+  afterEach(async () => {
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 200)
+      })
+    })
+    await flushEffects()
+  })
+
   describe("rendering", () => {
     it("renders without crashing", async () => {
       const { toJSON } = render(
@@ -126,7 +139,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(toJSON()).toBeTruthy()
     })
@@ -138,7 +151,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Report card Issue")).toBeTruthy()
     })
@@ -150,7 +163,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Continue")).toBeTruthy()
     })
@@ -164,7 +177,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Lost card")).toBeTruthy()
       expect(getByText("Stolen card")).toBeTruthy()
@@ -178,7 +191,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Damaged card"))
@@ -200,7 +213,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Lost card"))
@@ -222,7 +235,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Stolen card"))
@@ -244,7 +257,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Damaged card"))
@@ -266,7 +279,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await act(async () => {
         fireEvent.press(getByText("Lost card"))
@@ -300,7 +313,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep2(getByText)
 
@@ -335,7 +348,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep3(getByText)
 
@@ -352,7 +365,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep3(getByText)
 
@@ -382,7 +395,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       await advanceToStep3(getByText)
 
@@ -418,7 +431,7 @@ describe("ReplaceCardScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
 
       expect(getByText("Report card Issue")).toBeTruthy()
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -1,10 +1,11 @@
 import React from "react"
 import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
-import { act, fireEvent, render, waitFor } from "@testing-library/react-native"
+import { fireEvent, render, waitFor } from "@testing-library/react-native"
 
 import { HomeScreen } from "../../app/screens/home-screen"
 import { ContextForScreen } from "./helper"
+import { flushEffects } from "../helpers/flush-effects"
 import {
   AccountLevel,
   HomeAuthedDocument,
@@ -396,7 +397,7 @@ describe("HomeScreen", () => {
         <HomeScreen />
       </ContextForScreen>,
     )
-    await act(async () => {})
+    await flushEffects()
 
     expect(getByTestId("slide-up-handle")).toBeTruthy()
   })
@@ -419,10 +420,13 @@ describe("HomeScreen", () => {
 
       if (expectConvertButton) {
         await waitFor(() => expect(getByTestId("transfer")).toBeTruthy())
+        await flushEffects()
         return
       }
 
       await waitFor(() => expect(() => getByTestId("transfer")).toThrow())
+
+      await flushEffects()
     },
   )
 
@@ -438,6 +442,8 @@ describe("HomeScreen", () => {
     fireEvent.press(getByTestId("slide-up-handle"))
 
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("transactionHistory"))
+
+    await flushEffects()
   })
 
   it("renders home screen for self-custodial user", async () => {
@@ -469,7 +475,7 @@ describe("HomeScreen", () => {
       </ContextForScreen>,
     )
 
-    await act(async () => {})
+    await flushEffects()
 
     expect(getByTestId("slide-up-handle")).toBeTruthy()
 
@@ -506,7 +512,7 @@ describe("HomeScreen", () => {
       </ContextForScreen>,
     )
 
-    await act(async () => {})
+    await flushEffects()
 
     expect(queryByTestId("trust-model-modal")).toBeNull()
 
@@ -574,6 +580,8 @@ describe("HomeScreen", () => {
       )
 
       await waitFor(() => expect(getByTestId("balance-mode-toggle")).toBeTruthy())
+
+      await flushEffects()
     })
 
     it("hides the toggle when stableBalanceEnabled flag is off", async () => {
@@ -588,7 +596,7 @@ describe("HomeScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
       expect(queryByTestId("balance-mode-toggle")).toBeNull()
     })
 
@@ -608,7 +616,7 @@ describe("HomeScreen", () => {
         </ContextForScreen>,
       )
 
-      await act(async () => {})
+      await flushEffects()
       expect(queryByTestId("balance-mode-toggle")).toBeNull()
     })
 
@@ -628,6 +636,8 @@ describe("HomeScreen", () => {
       fireEvent.press(toggle)
 
       expect(mockToggleBalanceMode).toHaveBeenCalledTimes(1)
+
+      await flushEffects()
     })
   })
 
@@ -658,7 +668,7 @@ describe("HomeScreen", () => {
           <HomeScreen />
         </ContextForScreen>,
       )
-      await act(async () => {})
+      await flushEffects()
 
       expect(lastIsVisible()).toBe(true)
     })
@@ -672,7 +682,7 @@ describe("HomeScreen", () => {
           <HomeScreen />
         </ContextForScreen>,
       )
-      await act(async () => {})
+      await flushEffects()
 
       expect(lastIsVisible()).toBe(false)
     })
@@ -686,7 +696,7 @@ describe("HomeScreen", () => {
           <HomeScreen />
         </ContextForScreen>,
       )
-      await act(async () => {})
+      await flushEffects()
 
       expect(lastIsVisible()).toBe(false)
     })
@@ -700,7 +710,7 @@ describe("HomeScreen", () => {
           <HomeScreen />
         </ContextForScreen>,
       )
-      await act(async () => {})
+      await flushEffects()
 
       expect(lastIsVisible()).toBe(false)
     })

--- a/__tests__/screens/receive.spec.tsx
+++ b/__tests__/screens/receive.spec.tsx
@@ -11,6 +11,7 @@ import { WalletCurrency } from "@app/graphql/generated"
 import ReceiveScreen from "@app/screens/receive-bitcoin-screen/receive-screen"
 
 import { ContextForScreen } from "./helper"
+import { flushEffects } from "../helpers/flush-effects"
 
 const makeQueryResult = (defaultWalletId = "btc-wallet-id") => ({
   loading: false,
@@ -429,6 +430,8 @@ describe("ReceiveScreen", () => {
       await waitFor(() => {
         expect(onChainAddressCurrentMock).toHaveBeenCalled()
       })
+
+      await flushEffects()
     })
 
     it("renders OnChain QR on page 1", async () => {
@@ -725,6 +728,8 @@ describe("ReceiveScreen", () => {
       await waitFor(() => {
         expect(lnInvoiceCreateMock).toHaveBeenCalled()
       })
+
+      await flushEffects()
     })
   })
 

--- a/__tests__/screens/self-custodial/onboarding/backup-success-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/backup-success-screen.spec.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
+import { render, act } from "@testing-library/react-native"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 
 import { BackupSuccessScreen } from "@app/screens/self-custodial/onboarding/backup-success-screen"
 import { ContextForScreen } from "../../helper"
+import { flushEffects } from "../../../helpers/flush-effects"
 
 jest.mock("@app/components/success-animation/success-icon-animation", () => {
   const { View } = jest.requireActual("react-native")
@@ -64,7 +65,7 @@ describe("BackupSuccessScreen", () => {
     mockRouteParams.mockReturnValue(undefined)
   })
 
-  it("renders success message", () => {
+  it("renders success message", async () => {
     const { getByText } = render(
       <ContextForScreen>
         <BackupSuccessScreen />
@@ -72,9 +73,10 @@ describe("BackupSuccessScreen", () => {
     )
 
     expect(getByText(LL.BackupScreen.ManualBackup.Success.title())).toBeTruthy()
+    await flushEffects()
   })
 
-  it("renders generic success copy when reBackup param is true", () => {
+  it("renders generic success copy when reBackup param is true", async () => {
     mockRouteParams.mockReturnValue({ reBackup: true })
 
     const { getByText, queryByText } = render(
@@ -85,9 +87,10 @@ describe("BackupSuccessScreen", () => {
 
     expect(getByText(LL.common.success())).toBeTruthy()
     expect(queryByText(LL.BackupScreen.ManualBackup.Success.title())).toBeNull()
+    await flushEffects()
   })
 
-  it("uses the caller-supplied message when provided, regardless of reBackup", () => {
+  it("uses the caller-supplied message when provided, regardless of reBackup", async () => {
     mockRouteParams.mockReturnValue({
       reBackup: true,
       message: LL.BackupScreen.ManualBackup.Success.testSuccess(),
@@ -101,9 +104,10 @@ describe("BackupSuccessScreen", () => {
 
     expect(getByText(LL.BackupScreen.ManualBackup.Success.testSuccess())).toBeTruthy()
     expect(queryByText(LL.common.success())).toBeNull()
+    await flushEffects()
   })
 
-  it("falls back to onboarding copy when neither reBackup nor message are set", () => {
+  it("falls back to onboarding copy when neither reBackup nor message are set", async () => {
     mockRouteParams.mockReturnValue({})
 
     const { getByText } = render(
@@ -113,9 +117,10 @@ describe("BackupSuccessScreen", () => {
     )
 
     expect(getByText(LL.BackupScreen.ManualBackup.Success.title())).toBeTruthy()
+    await flushEffects()
   })
 
-  it("renders without crashing", () => {
+  it("renders without crashing", async () => {
     const { toJSON } = render(
       <ContextForScreen>
         <BackupSuccessScreen />
@@ -123,6 +128,7 @@ describe("BackupSuccessScreen", () => {
     )
 
     expect(toJSON()).toBeTruthy()
+    await flushEffects()
   })
 
   it("navigates to home after animation completes", async () => {
@@ -132,8 +138,10 @@ describe("BackupSuccessScreen", () => {
       </ContextForScreen>,
     )
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50)
+      })
     })
 
     expect(mockDispatch).toHaveBeenCalledWith(
@@ -151,8 +159,10 @@ describe("BackupSuccessScreen", () => {
       </ContextForScreen>,
     )
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 50)
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50)
+      })
     })
 
     expect(mockClearCheckpoint).toHaveBeenCalled()

--- a/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
+++ b/__tests__/screens/self-custodial/onboarding/manual-backup/backup-phrase-confirm-screen.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react-native"
+import { render, fireEvent, act } from "@testing-library/react-native"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 
@@ -107,7 +107,7 @@ describe("BackupPhraseConfirmScreen", () => {
     jest.useRealTimers()
   })
 
-  it("renders subtitle and input fields", () => {
+  it("renders subtitle and input fields", async () => {
     const { getByText, getByPlaceholderText } = render(
       <ContextForScreen>
         <BackupPhraseConfirmScreen />
@@ -219,7 +219,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockSetBackupCompleted).toHaveBeenCalledWith("manual")
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationTransferringFunds")
@@ -239,7 +241,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).toHaveBeenCalledWith(
       "selfCustodialBackupSuccess",
@@ -257,7 +261,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).toHaveBeenCalledWith(
       "selfCustodialBackupSuccess",
@@ -278,7 +284,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).not.toHaveBeenCalledWith("accountMigrationTransferringFunds")
     expect(mockNavigate).toHaveBeenCalledWith(
@@ -308,7 +316,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).toHaveBeenCalledWith(
       "selfCustodialBackupSuccess",
@@ -330,7 +340,9 @@ describe("BackupPhraseConfirmScreen", () => {
     )
 
     fillAllChallenges(getByPlaceholderText)
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).not.toHaveBeenCalled()
 
@@ -341,7 +353,9 @@ describe("BackupPhraseConfirmScreen", () => {
         <BackupPhraseConfirmScreen />
       </ContextForScreen>,
     )
-    jest.advanceTimersByTime(500)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
 
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationTransferringFunds")
   })

--- a/__tests__/screens/send-bitcoin-screen/use-onchain-fee-alert.spec.ts
+++ b/__tests__/screens/send-bitcoin-screen/use-onchain-fee-alert.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-native"
 
+import { flushEffects } from "../../helpers/flush-effects"
 import { useOnchainFeeAlert } from "@app/screens/send-bitcoin-screen/hooks/use-onchain-fee-alert"
 import { Network, WalletCurrency } from "@app/graphql/generated"
 import type { PaymentDetail } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
@@ -62,9 +63,7 @@ describe("useOnchainFeeAlert (self-custodial gate)", () => {
       },
     )
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0)
-    })
+    await flushEffects()
     rerender({
       paymentDetail: buildOnchainPaymentDetail(100),
       walletId: "btc-wallet-1",
@@ -87,9 +86,7 @@ describe("useOnchainFeeAlert (self-custodial gate)", () => {
       }),
     )
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0)
-    })
+    await flushEffects()
 
     expect(mockGetOnChainTxFee).toHaveBeenCalled()
     expect(result.current).toBe(false)

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -25,6 +25,7 @@ import {
 import Clipboard from "@react-native-clipboard/clipboard"
 
 import { ContextForScreen } from "./helper"
+import { flushEffects } from "../helpers/flush-effects"
 
 type MockedContact = {
   id: string
@@ -52,6 +53,16 @@ const flushAsync = async () => {
       setTimeout(() => {
         resolve()
       }, 0)
+    })
+  })
+}
+
+// react-native-modal animates its mount/unmount via RN Animated timers; let those
+// settle inside act() so their trailing setState doesn't fire outside act between tests.
+const settleModalAnimations = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 400)
     })
   })
 }
@@ -167,6 +178,7 @@ const getResponderByLabel = (label: string) => {
   return match
 }
 
+// eslint-disable-next-line max-lines-per-function
 describe("SendBitcoinDestinationScreen", () => {
   let LL: ReturnType<typeof i18nObject>
   const parseDestinationMock = parseDestination as jest.MockedFunction<
@@ -307,9 +319,12 @@ describe("SendBitcoinDestinationScreen", () => {
 
     if (shouldShowModal) {
       expect(await screen.findByText(modalTitle)).toBeTruthy()
+      await settleModalAnimations()
       return
     }
     expect(screen.queryByText(modalTitle)).toBeNull()
+
+    await flushEffects()
   })
 
   it("strips domain from LNURL identifier to prevent doubled @blink.sv in confirm modal", async () => {
@@ -352,6 +367,8 @@ describe("SendBitcoinDestinationScreen", () => {
         }),
       ),
     ).toBeTruthy()
+
+    await settleModalAnimations()
   })
 
   it.each([
@@ -405,9 +422,12 @@ describe("SendBitcoinDestinationScreen", () => {
     }
     if (shouldCallParse) {
       expect(parseDestinationMock).toHaveBeenCalled()
+      await flushEffects()
       return
     }
     expect(parseDestinationMock).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it.each([
@@ -450,10 +470,13 @@ describe("SendBitcoinDestinationScreen", () => {
     if (expectPhoneNotAllowed) {
       expect(await screen.findByText(phoneNotAllowed)).toBeTruthy()
       expect(parseDestinationMock).not.toHaveBeenCalled()
+      await flushEffects()
       return
     }
     expect(screen.queryByText(phoneNotAllowed)).toBeNull()
     expect(parseDestinationMock).toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it.each([
@@ -520,6 +543,8 @@ describe("SendBitcoinDestinationScreen", () => {
     expect(parseDestinationMock).toHaveBeenCalledWith(
       expect.objectContaining({ rawInput: "clipboard" }),
     )
+
+    await flushEffects()
   })
 
   it.each([
@@ -632,6 +657,8 @@ describe("SendBitcoinDestinationScreen", () => {
     expect(
       screen.queryByText(LL.SendBitcoinDestinationScreen.confirmUsernameModal.title()),
     ).toBeNull()
+
+    await settleModalAnimations()
   })
 
   it("shows confirm modal again for a different destination", async () => {
@@ -692,6 +719,8 @@ describe("SendBitcoinDestinationScreen", () => {
         LL.SendBitcoinDestinationScreen.confirmUsernameModal.title(),
       ),
     ).toBeTruthy()
+
+    await settleModalAnimations()
   })
 
   it("does not show confirm modal for a known contact", async () => {
@@ -801,6 +830,8 @@ describe("SendBitcoinDestinationScreen", () => {
     expect(
       screen.queryByText(LL.SendBitcoinDestinationScreen.confirmUsernameModal.title()),
     ).toBeNull()
+
+    await settleModalAnimations()
   })
 
   describe("deep link payment processing (processedPaymentRef)", () => {
@@ -846,6 +877,8 @@ describe("SendBitcoinDestinationScreen", () => {
         expect.objectContaining({ rawInput: "lnurl1testpayment123" }),
       )
       expect(parseDestinationMock).toHaveBeenCalledTimes(1)
+
+      await settleModalAnimations()
     })
 
     it("does NOT re-process when re-rendered with the same payment param", async () => {
@@ -878,6 +911,8 @@ describe("SendBitcoinDestinationScreen", () => {
 
       // The processedPaymentRef should prevent re-processing
       expect(parseDestinationMock).not.toHaveBeenCalled()
+
+      await settleModalAnimations()
     })
 
     it("processes a NEW payment param after a previous one", async () => {
@@ -914,6 +949,8 @@ describe("SendBitcoinDestinationScreen", () => {
         expect.objectContaining({ rawInput: "lnurl1second" }),
       )
       expect(parseDestinationMock).toHaveBeenCalledTimes(1)
+
+      await settleModalAnimations()
     })
   })
 })
@@ -960,6 +997,8 @@ describe("SendBitcoinDestinationScreen paste buttons", () => {
     expect(parseDestinationMock).toHaveBeenCalledWith(
       expect.objectContaining({ rawInput: "clipboard" }),
     )
+
+    await flushEffects()
   })
 
   it("phone paste button works when search input is active", async () => {
@@ -979,6 +1018,8 @@ describe("SendBitcoinDestinationScreen paste buttons", () => {
     await flushAsync()
 
     expect(screen.getByLabelText("telephoneNumber").props.value).toBeTruthy()
+
+    await flushEffects()
   })
 
   describe("lnurlDomains gate by active wallet type", () => {

--- a/__tests__/screens/settings-screen/account-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/account-screen.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { render } from "@testing-library/react-native"
+import { act, render } from "@testing-library/react-native"
 
 import { AccountScreen } from "@app/screens/settings-screen/account/account-screen"
 import { BackupStatus } from "@app/self-custodial/providers/backup-state"
@@ -232,7 +232,9 @@ describe("AccountScreen", () => {
     it("pull-to-refresh refreshes the self-custodial wallets and never hits updateCurrentProfile", async () => {
       render(<AccountScreen />)
 
-      await captureRefreshControl.onRefresh?.()
+      await act(async () => {
+        await captureRefreshControl.onRefresh?.()
+      })
 
       expect(mockRefreshSelfCustodialWallets).toHaveBeenCalledTimes(1)
       expect(mockUpdateCurrentProfile).not.toHaveBeenCalled()
@@ -243,7 +245,13 @@ describe("AccountScreen", () => {
 
       render(<AccountScreen />)
 
-      await Promise.resolve(captureRefreshControl.onRefresh?.()).catch(() => undefined)
+      await act(async () => {
+        try {
+          await captureRefreshControl.onRefresh?.()
+        } catch {
+          // swallow the simulated offline rejection
+        }
+      })
 
       expect(captureRefreshControl.refreshing).toBe(false)
     })
@@ -270,7 +278,9 @@ describe("AccountScreen", () => {
     it("pull-to-refresh calls updateCurrentProfile (custodial behavior unchanged)", async () => {
       render(<AccountScreen />)
 
-      await captureRefreshControl.onRefresh?.()
+      await act(async () => {
+        await captureRefreshControl.onRefresh?.()
+      })
 
       expect(mockUpdateCurrentProfile).toHaveBeenCalledTimes(1)
       expect(mockRefreshSelfCustodialWallets).not.toHaveBeenCalled()
@@ -281,7 +291,13 @@ describe("AccountScreen", () => {
 
       render(<AccountScreen />)
 
-      await Promise.resolve(captureRefreshControl.onRefresh?.()).catch(() => undefined)
+      await act(async () => {
+        try {
+          await captureRefreshControl.onRefresh?.()
+        } catch {
+          // swallow the simulated offline rejection
+        }
+      })
 
       expect(captureRefreshControl.refreshing).toBe(false)
     })

--- a/__tests__/screens/settings-screen/delete-account-confirm-modal.spec.tsx
+++ b/__tests__/screens/settings-screen/delete-account-confirm-modal.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render } from "@testing-library/react-native"
+import { act, fireEvent, render } from "@testing-library/react-native"
 
 import { DeleteAccountConfirmModal } from "@app/screens/settings-screen/self-custodial/delete-account-confirm-modal"
 
@@ -145,7 +145,9 @@ describe("DeleteAccountConfirmModal", () => {
     )
 
     fireEvent.changeText(getByTestId("self-custodial-danger-zone-delete-input"), "delete")
-    await lastModalProps.primaryButtonOnPress?.()
+    await act(async () => {
+      await lastModalProps.primaryButtonOnPress?.()
+    })
 
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })

--- a/__tests__/screens/settings-screen/self-custodial/delete-account.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/delete-account.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { fireEvent, render } from "@testing-library/react-native"
+import { act, fireEvent, render } from "@testing-library/react-native"
 
 import { AccountStatus, AccountType } from "@app/types/wallet"
 
@@ -223,7 +223,9 @@ describe("DeleteAccount", () => {
     fireEvent.press(getByTestId("danger-zone-delete-button"))
     expect(getByTestId("warning-modal")).toBeTruthy()
 
-    lastWarningProps.onClose?.()
+    act(() => {
+      lastWarningProps.onClose?.()
+    })
     rerender(<DeleteAccount />)
 
     expect(queryByTestId("warning-modal")).toBeNull()
@@ -238,7 +240,9 @@ describe("DeleteAccount", () => {
     const { getByTestId, queryByTestId, rerender } = render(<DeleteAccount />)
     fireEvent.press(getByTestId("danger-zone-delete-button"))
 
-    await lastConfirmProps.onConfirm?.()
+    await act(async () => {
+      await lastConfirmProps.onConfirm?.()
+    })
     rerender(<DeleteAccount />)
 
     expect(mockDeleteWallet).toHaveBeenCalledTimes(1)

--- a/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
@@ -1,9 +1,11 @@
 import React from "react"
-import { fireEvent, render } from "@testing-library/react-native"
+import { act, fireEvent, render } from "@testing-library/react-native"
 
 import { AccountStatus, AccountType } from "@app/types/wallet"
 
 import { ProfileRow } from "@app/screens/settings-screen/self-custodial/profile-row"
+
+import { flushEffects } from "../../../helpers/flush-effects"
 
 const TEST_ENTRY_ID = "test-account-id"
 
@@ -294,7 +296,9 @@ describe("ProfileRow", () => {
     fireEvent.press(getByTestId(`delete-button-${TEST_ENTRY_ID}`))
     await findByTestId("delete-modal")
 
-    await lastConfirmModalProps.onConfirm?.()
+    await act(async () => {
+      await lastConfirmModalProps.onConfirm?.()
+    })
     rerender(<ProfileRow entry={entry} />)
 
     expect(mockDeleteWallet).toHaveBeenCalledTimes(1)
@@ -358,9 +362,7 @@ describe("ProfileRow", () => {
     )
     fireEvent.press(getByTestId(`delete-button-${TEST_ENTRY_ID}`))
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 20)
-    })
+    await flushEffects()
 
     expect(queryByTestId("delete-modal")).toBeNull()
     expect(queryByTestId("warning-modal")).toBeNull()

--- a/__tests__/screens/settings-screen/settings-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/settings-screen.spec.tsx
@@ -25,6 +25,7 @@ import { LoggedInWithUsername } from "@app/screens/settings-screen/settings-scre
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import mocks from "@app/graphql/mocks"
 import { ContextForScreen } from "../helper"
+import { flushEffects } from "../../helpers/flush-effects"
 
 const notificationTitle = "Test notification"
 const notificationBody = "Test body"
@@ -334,6 +335,8 @@ describe("Settings Screen", () => {
     )
 
     expect(within(header).queryByTestId("notification-badge")).toBeNull()
+
+    await flushEffects()
   })
 
   it("hides the badge when the last unread notification is acknowledged", async () => {
@@ -387,6 +390,8 @@ describe("Settings Screen", () => {
     )
 
     expect(within(header).queryByTestId("notification-badge")).toBeNull()
+
+    await flushEffects()
   })
 
   it("does not render a badge when there are no unread notifications", async () => {
@@ -419,6 +424,8 @@ describe("Settings Screen", () => {
 
     const header = screen.getByTestId("notification-header")
     expect(within(header).queryByTestId("notification-badge")).toBeNull()
+
+    await flushEffects()
   })
 
   it("Renders user info", async () => {
@@ -437,6 +444,8 @@ describe("Settings Screen", () => {
 
     const elements = screen.getAllByText("test1@blink.sv")
     expect(elements.length).toBeGreaterThan(0)
+
+    await flushEffects()
   })
 
   it("shows phone ln address when phone is verified", async () => {
@@ -458,6 +467,8 @@ describe("Settings Screen", () => {
     )
 
     expect(screen.getByText(lnAddress)).toBeTruthy()
+
+    await flushEffects()
   })
 
   it("hides phone ln address when phone is missing", async () => {
@@ -478,6 +489,8 @@ describe("Settings Screen", () => {
 
     expect(screen.queryByText("Set your lightning address")).toBeNull()
     expect(screen.queryByText("+50365055539@blink.sv")).toBeNull()
+
+    await flushEffects()
   })
 
   it("truncates long settings row titles", () => {
@@ -543,6 +556,8 @@ describe("Settings Screen", () => {
 
     // TODO: re-enable once the custodial → non-custodial migration is complete
     expect(screen.queryByText("Move to non-custodial")).toBeNull()
+
+    await flushEffects()
   })
 
   it("does not render a standalone Recovery method group", async () => {
@@ -560,6 +575,8 @@ describe("Settings Screen", () => {
     )
 
     expect(screen.queryByTestId("Recovery method-group")).toBeNull()
+
+    await flushEffects()
   })
 
   it("skips the unread-notifications query when not authenticated", async () => {
@@ -583,6 +600,8 @@ describe("Settings Screen", () => {
     expect(generated.useUnacknowledgedNotificationCountQuery).toHaveBeenCalledWith(
       expect.objectContaining({ skip: true }),
     )
+
+    await flushEffects()
   })
 
   it("runs the unread-notifications query when authenticated", async () => {
@@ -606,5 +625,7 @@ describe("Settings Screen", () => {
     expect(generated.useUnacknowledgedNotificationCountQuery).toHaveBeenCalledWith(
       expect.objectContaining({ skip: false }),
     )
+
+    await flushEffects()
   })
 })

--- a/__tests__/screens/stable-balance-confirm-modal.spec.tsx
+++ b/__tests__/screens/stable-balance-confirm-modal.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { fireEvent, render } from "@testing-library/react-native"
+import { act, fireEvent, render } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
 import theme from "@app/rne-theme/theme"
@@ -54,21 +54,33 @@ const renderModal = (overrides: Partial<ModalProps> = {}) =>
     </ThemeProvider>,
   )
 
+// react-native-modal animates its mount/unmount via RN Animated timers; let those
+// settle inside act() so their trailing setState doesn't fire outside act between tests.
+const settleModalAnimations = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 400)
+    })
+  })
+}
+
 describe("StableBalanceConfirmModal", () => {
   beforeEach(() => {
     onConfirm.mockReset()
     onCancel.mockReset()
   })
 
-  it("renders the activation title, body and fee", () => {
+  it("renders the activation title, body and fee", async () => {
     const { getByText } = renderModal()
 
     expect(getByText("Activate Stable Balance")).toBeTruthy()
     expect(getByText("Your BTC will be converted to USDB.")).toBeTruthy()
     expect(getByText("$0.05")).toBeTruthy()
+
+    await settleModalAnimations()
   })
 
-  it("renders the deactivation title and warning when provided", () => {
+  it("renders the deactivation title and warning when provided", async () => {
     const { getByText } = renderModal({
       isActivating: false,
       deactivationWarning: "You still have 5.00 USD.",
@@ -76,39 +88,51 @@ describe("StableBalanceConfirmModal", () => {
 
     expect(getByText("Deactivate Stable Balance")).toBeTruthy()
     expect(getByText("You still have 5.00 USD.")).toBeTruthy()
+
+    await settleModalAnimations()
   })
 
-  it("invokes onConfirm when the primary button is pressed", () => {
+  it("invokes onConfirm when the primary button is pressed", async () => {
     const { getByText } = renderModal()
 
     fireEvent.press(getByText("Activate"))
     expect(onConfirm).toHaveBeenCalledTimes(1)
+
+    await settleModalAnimations()
   })
 
-  it("does not invoke onConfirm when the fee preview has an error", () => {
+  it("does not invoke onConfirm when the fee preview has an error", async () => {
     const { getByText } = renderModal({ hasError: true })
 
     fireEvent.press(getByText("Activate"))
     expect(onConfirm).not.toHaveBeenCalled()
+
+    await settleModalAnimations()
   })
 
-  it("does not invoke onConfirm while loading", () => {
+  it("does not invoke onConfirm while loading", async () => {
     const { getByText } = renderModal({ isLoading: true })
 
     fireEvent.press(getByText("Activate"))
     expect(onConfirm).not.toHaveBeenCalled()
+
+    await settleModalAnimations()
   })
 
-  it("invokes onCancel when the secondary button is pressed", () => {
+  it("invokes onCancel when the secondary button is pressed", async () => {
     const { getByText } = renderModal()
 
     fireEvent.press(getByText("Cancel"))
     expect(onCancel).toHaveBeenCalledTimes(1)
+
+    await settleModalAnimations()
   })
 
-  it("hides the fee row when showFeeRow is false", () => {
+  it("hides the fee row when showFeeRow is false", async () => {
     const { queryByText } = renderModal({ showFeeRow: false })
 
     expect(queryByText("$0.05")).toBeNull()
+
+    await settleModalAnimations()
   })
 })

--- a/__tests__/screens/stable-balance-settings-screen.spec.tsx
+++ b/__tests__/screens/stable-balance-settings-screen.spec.tsx
@@ -7,6 +7,8 @@ import { WalletCurrency } from "@app/graphql/generated"
 
 import { StableBalanceSettingsScreen } from "@app/screens/stable-balance-settings-screen"
 
+import { flushEffects } from "../helpers/flush-effects"
+
 jest.mock("react-native-reanimated", () => {
   const RNView = jest.requireActual<typeof import("react-native")>("react-native").View
   return {
@@ -186,6 +188,8 @@ describe("StableBalanceSettingsScreen", () => {
       expect(mockActivate).toHaveBeenCalledWith(baseContext.sdk, "USDB")
     })
     expect(queryByTestId("stable-balance-confirm-modal")).toBeNull()
+
+    await flushEffects()
   })
 
   it("deactivates directly when USD balance is zero (no conversion needed)", async () => {
@@ -198,9 +202,11 @@ describe("StableBalanceSettingsScreen", () => {
       expect(mockDeactivate).toHaveBeenCalledWith(baseContext.sdk)
     })
     expect(queryByTestId("stable-balance-confirm-modal")).toBeNull()
+
+    await flushEffects()
   })
 
-  it("shows confirm modal with fee on activate when BTC balance > 0", () => {
+  it("shows confirm modal with fee on activate when BTC balance > 0", async () => {
     mockWallet.mockReturnValue({
       ...baseContext,
       wallets: [
@@ -216,9 +222,11 @@ describe("StableBalanceSettingsScreen", () => {
     expect(getByText("Activate Stable Balance")).toBeTruthy()
     expect(getByText("$0.05")).toBeTruthy()
     expect(mockActivate).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
-  it("shows confirm modal with fee on deactivate when USD balance > 0", () => {
+  it("shows confirm modal with fee on deactivate when USD balance > 0", async () => {
     mockWallet.mockReturnValue({
       ...baseContext,
       isStableBalanceActive: true,
@@ -236,6 +244,8 @@ describe("StableBalanceSettingsScreen", () => {
     expect(getByText("You still have $5.00.")).toBeTruthy()
     expect(getByText("$0.05")).toBeTruthy()
     expect(mockDeactivate).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it("runs activation when the user confirms on the modal", async () => {
@@ -254,6 +264,8 @@ describe("StableBalanceSettingsScreen", () => {
     await waitFor(() => {
       expect(mockActivate).toHaveBeenCalledWith(baseContext.sdk, "USDB")
     })
+
+    await flushEffects()
   })
 
   it("runs deactivation when the user confirms on the modal", async () => {
@@ -275,9 +287,11 @@ describe("StableBalanceSettingsScreen", () => {
     await waitFor(() => {
       expect(mockDeactivate).toHaveBeenCalledWith(baseContext.sdk)
     })
+
+    await flushEffects()
   })
 
-  it("cancels the toggle without invoking the SDK when the user dismisses the modal", () => {
+  it("cancels the toggle without invoking the SDK when the user dismisses the modal", async () => {
     mockWallet.mockReturnValue({
       ...baseContext,
       wallets: [
@@ -292,6 +306,8 @@ describe("StableBalanceSettingsScreen", () => {
 
     expect(mockActivate).not.toHaveBeenCalled()
     expect(mockDeactivate).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it("does not invoke the SDK when it is null (inactive wallet)", async () => {
@@ -301,9 +317,8 @@ describe("StableBalanceSettingsScreen", () => {
 
     fireEvent(getByTestId("stable-balance-switch"), "pressIn")
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0)
-    })
+    await flushEffects()
+
     expect(mockActivate).not.toHaveBeenCalled()
     expect(mockDeactivate).not.toHaveBeenCalled()
   })
@@ -320,6 +335,8 @@ describe("StableBalanceSettingsScreen", () => {
     const refreshActiveOrder = mockRefreshStableBalanceActive.mock.invocationCallOrder[0]
     const refreshWalletsOrder = mockRefresh.mock.invocationCallOrder[0]
     expect(refreshActiveOrder).toBeLessThan(refreshWalletsOrder)
+
+    await flushEffects()
   })
 
   it("records to crashlytics and shows error toast when activation rejects", async () => {
@@ -336,6 +353,8 @@ describe("StableBalanceSettingsScreen", () => {
     expect(mockToastShow.mock.calls[0][0].type).toBe("error")
     expect(mockRefresh).not.toHaveBeenCalled()
     expect(mockRefreshStableBalanceActive).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it("records to crashlytics and shows error toast when deactivation rejects", async () => {
@@ -352,5 +371,7 @@ describe("StableBalanceSettingsScreen", () => {
     })
     expect(mockRefresh).not.toHaveBeenCalled()
     expect(mockRefreshStableBalanceActive).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 })

--- a/__tests__/screens/transaction-history-self-custodial.spec.tsx
+++ b/__tests__/screens/transaction-history-self-custodial.spec.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires, camelcase */
 import React from "react"
 
-import { render, waitFor } from "@testing-library/react-native"
+import { act, render, waitFor } from "@testing-library/react-native"
 import { InteractionManager, SectionList } from "react-native"
 
 import { TransactionHistoryScreen } from "@app/screens/transaction-history"
 import { ActiveWalletStatus, AccountType } from "@app/types/wallet"
+
+import { flushEffects } from "../helpers/flush-effects"
 
 jest.mock("@rn-vui/themed", () => {
   const colors: Record<string, string> = {
@@ -229,12 +231,16 @@ describe("TransactionHistoryScreen — self-custodial behavior", () => {
     const { UNSAFE_getByType } = render(<TransactionHistoryScreen route={route} />)
     const list = UNSAFE_getByType(SectionList)
 
-    await list.props.onRefresh?.()
+    await act(async () => {
+      await list.props.onRefresh?.()
+    })
 
     await waitFor(() => {
       expect(mockRefetch).toHaveBeenCalledTimes(1)
     })
     expect(mockRefreshSelfCustodialWallets).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it("self-custodial pull-to-refresh calls refreshWallets and not Apollo refetch", async () => {
@@ -243,12 +249,16 @@ describe("TransactionHistoryScreen — self-custodial behavior", () => {
     const { UNSAFE_getByType } = render(<TransactionHistoryScreen route={route} />)
     const list = UNSAFE_getByType(SectionList)
 
-    await list.props.onRefresh?.()
+    await act(async () => {
+      await list.props.onRefresh?.()
+    })
 
     await waitFor(() => {
       expect(mockRefreshSelfCustodialWallets).toHaveBeenCalledTimes(1)
     })
     expect(mockRefetch).not.toHaveBeenCalled()
+
+    await flushEffects()
   })
 
   it("self-custodial mode batches the cache fragment writes through cache.batch", () => {

--- a/__tests__/screens/unclaimed-deposits/unclaimed-deposits-screen.spec.tsx
+++ b/__tests__/screens/unclaimed-deposits/unclaimed-deposits-screen.spec.tsx
@@ -2,6 +2,8 @@ import React from "react"
 import { fireEvent, render } from "@testing-library/react-native"
 import { ThemeProvider } from "@rn-vui/themed"
 
+import { flushEffects } from "../../helpers/flush-effects"
+
 import theme from "@app/rne-theme/theme"
 import { UnclaimedDepositsScreen } from "@app/screens/unclaimed-deposits/unclaimed-deposits-screen"
 import { SdkFeeError } from "@app/screens/send-bitcoin-screen/hooks/use-onchain-fee-tiers"
@@ -194,6 +196,8 @@ describe("UnclaimedDepositsScreen — refund fee gating", () => {
       "bc1qaddr",
       20, // medium tier feeSats
     )
+
+    await flushEffects()
   })
 })
 

--- a/__tests__/self-custodial/hooks/use-payment-request.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request.spec.ts
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from "@testing-library/react-native"
 import { WalletCurrency } from "@app/graphql/generated"
 
+import { flushEffects } from "../../helpers/flush-effects"
 import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
 
 const mockReceiveLightning = jest.fn()
@@ -99,12 +100,13 @@ describe("usePaymentRequest", () => {
     expect(result.current).toBeNull()
   })
 
-  it("returns null when btcWallet is missing", () => {
+  it("returns null when btcWallet is missing", async () => {
     mockActiveWallet.mockReturnValue({ wallets: [] })
 
     const { result } = renderHook(() => usePaymentRequest())
 
     expect(result.current).toBeNull()
+    await flushEffects()
   })
 
   it("generates Lightning invoice on mount", async () => {
@@ -194,7 +196,7 @@ describe("usePaymentRequest", () => {
     )
   })
 
-  it("does not call the receive adapter while active wallet is not ready", () => {
+  it("does not call the receive adapter while active wallet is not ready", async () => {
     mockActiveWallet.mockReturnValue({
       wallets: [btcWallet, usdWallet],
       isReady: false,
@@ -203,6 +205,7 @@ describe("usePaymentRequest", () => {
     renderHook(() => usePaymentRequest())
 
     expect(mockReceiveLightning).not.toHaveBeenCalled()
+    await flushEffects()
   })
 
   it("generates on-chain address on mount", async () => {
@@ -279,6 +282,7 @@ describe("usePaymentRequest", () => {
     })
 
     expect(result.current?.memo).toBe("test memo")
+    await flushEffects()
   })
 
   it("setAmount updates unitOfAccountAmount", async () => {
@@ -297,6 +301,7 @@ describe("usePaymentRequest", () => {
     })
 
     expect(result.current?.unitOfAccountAmount?.amount).toBe(5000)
+    await flushEffects()
   })
 
   it("transitions to Paid when a new payment arrives after invoice creation", async () => {
@@ -555,10 +560,8 @@ describe("usePaymentRequest", () => {
 
       renderHook(() => usePaymentRequest())
 
-      // Give any pending microtasks a chance to flush.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10)
-      })
+      // Give any pending microtasks a chance to flush (inside act()).
+      await flushEffects()
 
       expect(mockReceiveLightning).not.toHaveBeenCalled()
       expect(mockAddPendingAutoConvert).not.toHaveBeenCalled()
@@ -574,9 +577,7 @@ describe("usePaymentRequest", () => {
 
       const { rerender } = renderHook(() => usePaymentRequest())
 
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10)
-      })
+      await flushEffects()
       expect(mockReceiveLightning).not.toHaveBeenCalled()
       expect(mockAddPendingAutoConvert).not.toHaveBeenCalled()
 
@@ -592,6 +593,7 @@ describe("usePaymentRequest", () => {
         expect(mockReceiveLightning).toHaveBeenCalled()
       })
       expect(mockAddPendingAutoConvert).toHaveBeenCalled()
+      await flushEffects()
     })
   })
 

--- a/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
+++ b/__tests__/self-custodial/hooks/use-self-custodial-contacts.spec.ts
@@ -75,7 +75,10 @@ describe("useSelfCustodialContacts", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false))
 
-    const { contacts } = await result.current.list()
+    let contacts: Awaited<ReturnType<typeof result.current.list>>["contacts"] = []
+    await act(async () => {
+      ;({ contacts } = await result.current.list())
+    })
     expect(contacts).toEqual(expectedContacts)
   })
 

--- a/__tests__/self-custodial/providers/wallet.spec.tsx
+++ b/__tests__/self-custodial/providers/wallet.spec.tsx
@@ -9,6 +9,8 @@ import {
   useSelfCustodialWallet,
 } from "@app/self-custodial/providers/wallet"
 
+import { flushEffects } from "../../helpers/flush-effects"
+
 import { getWalletSnapshotMocks, setupConnectedWallet } from "./wallet.fixtures"
 
 jest.mock("react-native/Libraries/AppState/AppState", () => ({
@@ -209,7 +211,7 @@ describe("SelfCustodialWalletProvider", () => {
     mockSetSelfCustodialLightningAddress.mockResolvedValue(undefined)
   })
 
-  it("renders children", () => {
+  it("renders children", async () => {
     const { getByText } = render(
       <SelfCustodialWalletProvider>
         <Text>child</Text>
@@ -217,6 +219,7 @@ describe("SelfCustodialWalletProvider", () => {
     )
 
     expect(getByText("child")).toBeTruthy()
+    await flushEffects()
   })
 
   it("returns unavailable when no mnemonic exists", async () => {
@@ -229,22 +232,25 @@ describe("SelfCustodialWalletProvider", () => {
     })
   })
 
-  it("sets accountType to self-custodial", () => {
+  it("sets accountType to self-custodial", async () => {
     const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
 
     expect(result.current.accountType).toBe(AccountType.SelfCustodial)
+    await flushEffects()
   })
 
-  it("provides retry function", () => {
+  it("provides retry function", async () => {
     const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
 
     expect(typeof result.current.retry).toBe("function")
+    await flushEffects()
   })
 
-  it("default state has empty wallets", () => {
+  it("default state has empty wallets", async () => {
     const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
 
     expect(result.current.wallets).toEqual([])
+    await flushEffects()
   })
 
   it("sets error status on network mismatch", async () => {


### PR DESCRIPTION
## What

Fixes #3814 — `act(...)` warnings flooding Concourse/CI logs across many test suites.

Many synchronous render-and-assert tests render providers/hooks whose async `useEffect` work (KeyStore reads, SDK init, Apollo queries, animations) resolves **after** the synchronous test body returns — outside `act()` — emitting:

```
An update to <Component> inside a test was not wrapped in act(...).
```

These are benign (tests pass) but produced **252 `console.error` warnings codebase-wide**, burying real failures in CI output.

## How

- Add shared helper `__tests__/helpers/flush-effects.ts` → `flushEffects()`, which settles pending promises/microtasks **inside `act()`** via a `setImmediate` drain. This is deeper than a bare `await act(async () => {})` — several suites already had that and still warned through.
- Apply it across **28 suites** to await the async settle in the affected synchronous tests.
- For real-timer animations (`StepsProgressBar` ~120ms, `react-native-modal` ~300–400ms) and fake-timer suites where `setImmediate` flushing doesn't apply, use the idiomatic `act()`-wrapped timer advance instead.

This **resolves** the warnings by properly awaiting async initialization — it does **not** suppress them. No `console.error` mocking, no production code changes, no weakened assertions.

## Verification

| Check | Result |
|---|---|
| `act(...)` warnings (full suite) | **252 → 0** |
| Full test suite | no new failures |
| `tsc -p .` | ✅ pass |
| `eslint` (changed files) | ✅ pass |

## Out of scope (pre-existing)

`__tests__/components/blink-card/blink-card.spec.tsx › displays valid thru date` fails on a date-sensitive assertion (`12/ 28` vs `11/ 28`) **on the untouched baseline too** — a separate, pre-existing issue not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)