### PR TITLE
fix(send): USD wallet payment drains entire balance to BTC


### DIFF
--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -4,6 +4,7 @@ import { Satoshis } from "lnurl-pay"
 import { act, fireEvent, render, screen } from "@testing-library/react-native"
 
 import { DisplayCurrency, toUsdMoneyAmount } from "@app/types/amounts"
+import { ConvertAmountAdjustment } from "@app/types/payment"
 import { WalletCurrency } from "@app/graphql/generated"
 import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-details/intraledger"
 import { ConvertMoneyAmount } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
@@ -14,6 +15,8 @@ import {
   Intraledger,
   LightningLnURL,
 } from "@app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.stories"
+
+import { flushEffects } from "../helpers/flush-effects"
 import { ContextForScreen } from "./helper"
 
 jest.mock("@app/store/persistent-state", () => ({
@@ -179,6 +182,14 @@ const mockUseSendBalances = jest.fn()
 jest.mock("@app/screens/send-bitcoin-screen/hooks/use-send-wallets", () => ({
   ...jest.requireActual("@app/screens/send-bitcoin-screen/hooks/use-send-wallets"),
   useSendBalances: () => mockUseSendBalances(),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-non-custodial-conversion-limits", () => ({
+  useNonCustodialConversionLimits: () => ({
+    limits: { minFromAmount: 800, minToAmount: null },
+    loading: false,
+    error: null,
+  }),
 }))
 
 const useActiveWalletMock = jest.fn(() => ({
@@ -661,6 +672,96 @@ describe("SendBitcoinConfirmationScreen — fee-currency conversion", () => {
     )
 
     expect(screen.getByText(/exceeds your balance/i)).toBeTruthy()
+  })
+})
+
+describe("SendBitcoinConfirmationScreen — USD remainder sweep warning", () => {
+  const usdRemainderSweepMatcher = /will be converted to Bitcoin\. USD minimum:/i
+
+  beforeEach(() => {
+    mockUseSendBalances.mockReturnValue({
+      btcWallet: {
+        id: "btc-wallet-id",
+        balance: 0,
+        walletCurrency: WalletCurrency.Btc,
+      },
+      usdWallet: {
+        id: "usd-wallet-id",
+        balance: 1000,
+        walletCurrency: WalletCurrency.Usd,
+      },
+    })
+  })
+
+  it("renders the warning when fee quote reports IncreasedToAvoidDust and user is not draining balance", async () => {
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+      amountAdjustment: ConvertAmountAdjustment.IncreasedToAvoidDust,
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.getByText(usdRemainderSweepMatcher)).toBeTruthy()
+  })
+
+  it("does NOT render the warning when there is no amountAdjustment in the fee quote", async () => {
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.queryByText(usdRemainderSweepMatcher)).toBeNull()
+  })
+
+  it("does NOT render the warning when the user is already draining the full USD balance", async () => {
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+      amountAdjustment: ConvertAmountAdjustment.IncreasedToAvoidDust,
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(1000)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.queryByText(usdRemainderSweepMatcher)).toBeNull()
+  })
+
+  it("does NOT render the warning for FlooredToMin (benign SDK floor)", async () => {
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+      amountAdjustment: ConvertAmountAdjustment.FlooredToMin,
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.queryByText(usdRemainderSweepMatcher)).toBeNull()
   })
 })
 

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, Text } from "react-native"
 import { Satoshis } from "lnurl-pay"
 import { act, fireEvent, render, screen } from "@testing-library/react-native"
 
-import { DisplayCurrency, toUsdMoneyAmount } from "@app/types/amounts"
+import { DisplayCurrency, toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
 import { ConvertAmountAdjustment } from "@app/types/payment"
 import { WalletCurrency } from "@app/graphql/generated"
 import * as PaymentDetails from "@app/screens/send-bitcoin-screen/payment-details/intraledger"
@@ -611,6 +611,22 @@ const buildUsdSettlementRoute = (
   } as const
 }
 
+const buildBtcSettlementRoute = (unitOfAccountSats: number) => {
+  const btcDescriptor = { currency: WalletCurrency.Btc, id: "btc-wallet-id" } as const
+  const params: PaymentDetails.CreateIntraledgerPaymentDetailsParams<WalletCurrency> = {
+    handle: "test",
+    recipientWalletId: "testid",
+    convertMoneyAmount: usdBtcConvert,
+    sendingWalletDescriptor: btcDescriptor,
+    unitOfAccountAmount: toBtcMoneyAmount(unitOfAccountSats),
+  }
+  return {
+    key: "sendBitcoinConfirmationScreen",
+    name: "sendBitcoinConfirmation",
+    params: { paymentDetail: PaymentDetails.createIntraledgerPaymentDetails(params) },
+  } as const
+}
+
 describe("SendBitcoinConfirmationScreen — fee-currency conversion", () => {
   beforeEach(() => {
     // Balance: $10.00 = 1000 cents.
@@ -763,6 +779,36 @@ describe("SendBitcoinConfirmationScreen — USD remainder sweep warning", () => 
 
     expect(screen.queryByText(usdRemainderSweepMatcher)).toBeNull()
   })
+
+  it("does NOT render the warning for a BTC source wallet even when the fee quote reports IncreasedToAvoidDust (false-positive guard)", async () => {
+    mockUseSendBalances.mockReturnValue({
+      btcWallet: {
+        id: "btc-wallet-id",
+        balance: 1_000_000,
+        walletCurrency: WalletCurrency.Btc,
+      },
+      usdWallet: {
+        id: "usd-wallet-id",
+        balance: 1000,
+        walletCurrency: WalletCurrency.Usd,
+      },
+    })
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+      amountAdjustment: ConvertAmountAdjustment.IncreasedToAvoidDust,
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildBtcSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.queryByText(usdRemainderSweepMatcher)).toBeNull()
+  })
 })
 
 describe("SendBitcoinConfirmationScreen — skipBalanceCheck matrix", () => {
@@ -844,5 +890,55 @@ describe("SendBitcoinConfirmationScreen — skipBalanceCheck matrix", () => {
 
     expect(screen.queryByText(/exceeds your balance/i)).toBeNull()
     expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(true)
+  })
+
+  it("disables the slider when the fee quote errors so the user cannot sweep unwarned (C1)", async () => {
+    mockUseFee.mockReturnValue({ status: "error" })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(true)
+  })
+
+  it("disables the slider while the fee quote is loading", async () => {
+    mockUseFee.mockReturnValue({ status: "loading" })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(true)
+  })
+
+  it("keeps the slider enabled on a fee error that still carries an amount (max-fee fallback, #559)", async () => {
+    mockUseSendPayment.mockReturnValue({
+      loading: false,
+      hasAttemptedSend: false,
+      sendPayment: sendPaymentMock,
+    })
+    mockUseFee.mockReturnValue({
+      status: "error",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+    })
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(false)
   })
 })

--- a/__tests__/self-custodial/bridge/convert.spec.ts
+++ b/__tests__/self-custodial/bridge/convert.spec.ts
@@ -8,7 +8,10 @@ import {
 } from "@app/types/payment"
 import { WalletCurrency } from "@app/graphql/generated"
 
-import { createGetConversionQuote } from "@app/self-custodial/bridge/convert"
+import {
+  createGetConversionQuote,
+  mapAmountAdjustment,
+} from "@app/self-custodial/bridge/convert"
 
 const mockFetchLimits = jest.fn()
 const mockRequireTokenId = jest.fn(() => "usdb-token-id")
@@ -375,5 +378,23 @@ describe("createGetConversionQuote — error handling", () => {
     expect(mockRecordError).toHaveBeenCalled()
     expect(sdk.prepareSendPayment).not.toHaveBeenCalled()
     expect(sdk.sendPayment).not.toHaveBeenCalled()
+  })
+})
+
+describe("mapAmountAdjustment", () => {
+  it("maps undefined to undefined", () => {
+    expect(mapAmountAdjustment(undefined)).toBeUndefined()
+  })
+
+  it("maps FlooredToMinLimit to the benign FlooredToMin adjustment", () => {
+    expect(mapAmountAdjustment(AmountAdjustmentReason.FlooredToMinLimit)).toBe(
+      ConvertAmountAdjustment.FlooredToMin,
+    )
+  })
+
+  it("maps IncreasedToAvoidDust to the dust-gate adjustment", () => {
+    expect(mapAmountAdjustment(AmountAdjustmentReason.IncreasedToAvoidDust)).toBe(
+      ConvertAmountAdjustment.IncreasedToAvoidDust,
+    )
   })
 })

--- a/__tests__/self-custodial/hooks/use-send-dust-warning.spec.ts
+++ b/__tests__/self-custodial/hooks/use-send-dust-warning.spec.ts
@@ -1,0 +1,162 @@
+import { renderHook } from "@testing-library/react-native"
+
+import { WalletCurrency } from "@app/graphql/generated"
+import { useSendDustWarning } from "@app/self-custodial/hooks/use-send-dust-warning"
+import { toUsdMoneyAmount, type MoneyAmount } from "@app/types/amounts"
+import { ConvertAmountAdjustment } from "@app/types/payment"
+
+const mockConvertMoneyAmount = jest.fn()
+const mockUseNonCustodialConversionLimits = jest.fn()
+const mockReportError = jest.fn()
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount }),
+}))
+
+jest.mock("@app/self-custodial/hooks/use-non-custodial-conversion-limits", () => ({
+  useNonCustodialConversionLimits: (...args: unknown[]) =>
+    mockUseNonCustodialConversionLimits(...args),
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: unknown[]) => mockReportError(...args),
+}))
+
+const usdAmount = (cents: number): MoneyAmount<typeof WalletCurrency.Usd> => ({
+  amount: cents,
+  currency: WalletCurrency.Usd,
+  currencyCode: "USD",
+})
+
+// Deterministic rate for assertions: 1 USD cent <-> 10 sats.
+const fakeConvert = (moneyAmount: { amount: number }, target: WalletCurrency) =>
+  target === WalletCurrency.Btc
+    ? {
+        amount: Math.round(moneyAmount.amount * 10),
+        currency: WalletCurrency.Btc,
+        currencyCode: "BTC",
+      }
+    : {
+        amount: Math.round(moneyAmount.amount / 10),
+        currency: WalletCurrency.Usd,
+        currencyCode: "USD",
+      }
+
+const baseParams = {
+  amountAdjustment: ConvertAmountAdjustment.IncreasedToAvoidDust as
+    | ConvertAmountAdjustment
+    | undefined,
+  fromCurrency: WalletCurrency.Usd as WalletCurrency | undefined,
+  fromWalletBalance: 1000,
+  unitOfAccountAmount: usdAmount(200),
+  settlementAmount: 200,
+  feeSats: 50,
+  usdBalanceMoneyAmount: usdAmount(1000),
+}
+
+describe("useSendDustWarning", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConvertMoneyAmount.mockImplementation(fakeConvert)
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: { minFromAmount: 800, minToAmount: null },
+      loading: false,
+      error: null,
+    })
+  })
+
+  describe("hidden (no dust gate)", () => {
+    it("is hidden for a BTC source wallet even when the SDK reports IncreasedToAvoidDust", () => {
+      const { result } = renderHook(() =>
+        useSendDustWarning({ ...baseParams, fromCurrency: WalletCurrency.Btc }),
+      )
+      expect(result.current.status).toBe("hidden")
+    })
+
+    it("is hidden when there is no amountAdjustment", () => {
+      const { result } = renderHook(() =>
+        useSendDustWarning({ ...baseParams, amountAdjustment: undefined }),
+      )
+      expect(result.current.status).toBe("hidden")
+    })
+
+    it("is hidden for the benign FlooredToMin adjustment", () => {
+      const { result } = renderHook(() =>
+        useSendDustWarning({
+          ...baseParams,
+          amountAdjustment: ConvertAmountAdjustment.FlooredToMin,
+        }),
+      )
+      expect(result.current.status).toBe("hidden")
+    })
+
+    it("is hidden when the user drains the full balance (no remainder to sweep)", () => {
+      const { result } = renderHook(() =>
+        useSendDustWarning({
+          ...baseParams,
+          settlementAmount: 1000,
+          fromWalletBalance: 1000,
+        }),
+      )
+      expect(result.current.status).toBe("hidden")
+    })
+  })
+
+  describe("fail-closed states", () => {
+    it("is pending while the conversion limits are still loading", () => {
+      mockUseNonCustodialConversionLimits.mockReturnValue({
+        limits: null,
+        loading: true,
+        error: null,
+      })
+      const { result } = renderHook(() => useSendDustWarning(baseParams))
+      expect(result.current.status).toBe("pending")
+    })
+
+    it("is blocked and logs when limits fail to fetch while a dust sweep is in play", () => {
+      const error = new Error("limits fetch failed")
+      mockUseNonCustodialConversionLimits.mockReturnValue({
+        limits: null,
+        loading: false,
+        error,
+      })
+      const { result } = renderHook(() => useSendDustWarning(baseParams))
+      expect(result.current.status).toBe("blocked")
+      expect(mockReportError).toHaveBeenCalledWith(expect.any(String), error)
+    })
+
+    it("is blocked when limits resolve without a usable minimum", () => {
+      mockUseNonCustodialConversionLimits.mockReturnValue({
+        limits: { minFromAmount: null, minToAmount: null },
+        loading: false,
+        error: null,
+      })
+      const { result } = renderHook(() => useSendDustWarning(baseParams))
+      expect(result.current.status).toBe("blocked")
+    })
+  })
+
+  describe("visible", () => {
+    it("returns raw money amounts with the minimum in USD (not sats)", () => {
+      const { result } = renderHook(() => useSendDustWarning(baseParams))
+
+      expect(result.current.status).toBe("visible")
+      if (result.current.status !== "visible") return
+
+      // I1: minimum must be USD (the source currency of the sweep), value = minFromAmount
+      expect(result.current.minimum).toEqual(toUsdMoneyAmount(800))
+      expect(result.current.minimum.currency).toBe(WalletCurrency.Usd)
+
+      // D1: raw amounts, not formatted strings
+      expect(result.current.remainingSats.currency).toBe(WalletCurrency.Btc)
+      // balance 1000c -> 10000 sats; sent 200c -> 2000 sats; fee 50 -> 7950 sats
+      expect(result.current.remainingSats.amount).toBe(7950)
+      expect(result.current.remaining.currency).toBe(WalletCurrency.Usd)
+    })
+
+    it("requests UsdToBtc limits for a USD-source sweep", () => {
+      renderHook(() => useSendDustWarning(baseParams))
+      expect(mockUseNonCustodialConversionLimits).toHaveBeenCalledWith("usd_to_btc")
+    })
+  })
+})

--- a/__tests__/self-custodial/payment-details/send-helpers.spec.ts
+++ b/__tests__/self-custodial/payment-details/send-helpers.spec.ts
@@ -10,6 +10,7 @@ import {
   createSendMutationOnchain,
 } from "@app/self-custodial/payment-details/send-helpers"
 import { SelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
+import { ConvertAmountAdjustment } from "@app/types/payment"
 
 const mockPrepareSendPayment = jest.fn()
 const mockSendPayment = jest.fn()
@@ -160,6 +161,43 @@ describe("createGetFee", () => {
     const result = await getFee()
 
     expect(result.amount).toBeUndefined()
+  })
+
+  it("threads the SDK dust adjustment through to amountAdjustment", async () => {
+    mockPrepareSendPayment.mockResolvedValue({
+      paymentMethod: {
+        tag: "Bolt11Invoice",
+        inner: { lightningFeeSats: BigInt(10), sparkTransferFeeSats: BigInt(5) },
+      },
+      conversionEstimate: { amountAdjustment: "IncreasedToAvoidDust" },
+    })
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.amountAdjustment).toBe(ConvertAmountAdjustment.IncreasedToAvoidDust)
+  })
+
+  it("leaves amountAdjustment undefined when the SDK reports no conversion estimate", async () => {
+    mockPrepareSendPayment.mockResolvedValue({
+      paymentMethod: {
+        tag: "Bolt11Invoice",
+        inner: { lightningFeeSats: BigInt(10), sparkTransferFeeSats: BigInt(5) },
+      },
+    })
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.amountAdjustment).toBeUndefined()
   })
 
   it("forwards amount and tokenIdentifier on the prepare call", async () => {

--- a/__tests__/self-custodial/payment-details/send-helpers.spec.ts
+++ b/__tests__/self-custodial/payment-details/send-helpers.spec.ts
@@ -30,6 +30,10 @@ jest.mock("@breeztech/breez-sdk-spark-react-native", () => {
     Generic: "Generic",
   }
   return {
+    AmountAdjustmentReason: {
+      FlooredToMinLimit: "FlooredToMinLimit",
+      IncreasedToAvoidDust: "IncreasedToAvoidDust",
+    },
     BitcoinNetwork: { Bitcoin: 0, Regtest: 4 },
     InputType_Tags: { SparkAddress: "SparkAddress" },
     Network: { Mainnet: 0, Regtest: 1 },

--- a/__tests__/types/payment.spec.ts
+++ b/__tests__/types/payment.spec.ts
@@ -1,0 +1,37 @@
+import { ConvertAmountAdjustment, resolveDustAdjustment } from "@app/types/payment"
+
+describe("resolveDustAdjustment", () => {
+  it("returns null when no adjustment was reported", () => {
+    expect(resolveDustAdjustment(null, 50, 1000)).toBeNull()
+  })
+
+  it("returns null for FlooredToMin (benign SDK floor, never blocks/warns)", () => {
+    expect(
+      resolveDustAdjustment(ConvertAmountAdjustment.FlooredToMin, 50, 1000),
+    ).toBeNull()
+  })
+
+  it("returns IncreasedToAvoidDust when remainder would be sub-threshold (amount < balance)", () => {
+    expect(
+      resolveDustAdjustment(ConvertAmountAdjustment.IncreasedToAvoidDust, 50, 1000),
+    ).toBe(ConvertAmountAdjustment.IncreasedToAvoidDust)
+  })
+
+  it("returns null when the user is already draining the full balance (amount === balance)", () => {
+    expect(
+      resolveDustAdjustment(ConvertAmountAdjustment.IncreasedToAvoidDust, 1000, 1000),
+    ).toBeNull()
+  })
+
+  it("returns null when the requested amount exceeds the balance (validation lives elsewhere)", () => {
+    expect(
+      resolveDustAdjustment(ConvertAmountAdjustment.IncreasedToAvoidDust, 2000, 1000),
+    ).toBeNull()
+  })
+
+  it("returns IncreasedToAvoidDust defensively when the balance is unknown", () => {
+    expect(
+      resolveDustAdjustment(ConvertAmountAdjustment.IncreasedToAvoidDust, 50, undefined),
+    ).toBe(ConvertAmountAdjustment.IncreasedToAvoidDust)
+  })
+})

--- a/app/components/warning-banner/index.ts
+++ b/app/components/warning-banner/index.ts
@@ -1,0 +1,1 @@
+export * from "./warning-banner"

--- a/app/components/warning-banner/warning-banner.tsx
+++ b/app/components/warning-banner/warning-banner.tsx
@@ -1,0 +1,46 @@
+import React from "react"
+import { View } from "react-native"
+
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import { makeStyles, Text, useTheme } from "@rn-vui/themed"
+
+export type WarningBannerProps = {
+  children: React.ReactNode
+  numberOfLines?: number
+}
+
+export const WarningBanner: React.FC<WarningBannerProps> = ({
+  children,
+  numberOfLines,
+}) => {
+  const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
+
+  return (
+    <View style={styles.container}>
+      <GaloyIcon name="warning" size={18} color={colors.warning} />
+      <Text
+        type="p3"
+        style={styles.text}
+        numberOfLines={numberOfLines}
+        ellipsizeMode="tail"
+      >
+        {children}
+      </Text>
+    </View>
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  container: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    columnGap: 4,
+  },
+  text: {
+    color: colors.warning,
+    flex: 1,
+  },
+}))

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2279,6 +2279,8 @@ const en: BaseTranslation = {
     slideConfirming: "Confirming...",
     copiedDestination: "Copied destination to clipboard",
     lightningRecommended: "High fee! We recommend Lightning.",
+    usdRemainderSweep:
+      "Remaining {remaining: string} ({remainingSats: string}) will be converted to Bitcoin. USD minimum: {minimum: string}.",
   },
   SendBitcoinDestinationScreen: {
     usernameNowAddress:

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -7120,6 +7120,13 @@ type RootTranslation = {
 		 * H​i​g​h​ ​f​e​e​!​ ​W​e​ ​r​e​c​o​m​m​e​n​d​ ​L​i​g​h​t​n​i​n​g​.
 		 */
 		lightningRecommended: string
+		/**
+		 * R​e​m​a​i​n​i​n​g​ ​{​r​e​m​a​i​n​i​n​g​}​ ​(​{​r​e​m​a​i​n​i​n​g​S​a​t​s​}​)​ ​w​i​l​l​ ​b​e​ ​c​o​n​v​e​r​t​e​d​ ​t​o​ ​B​i​t​c​o​i​n​.​ ​U​S​D​ ​m​i​n​i​m​u​m​:​ ​{​m​i​n​i​m​u​m​}​.
+		 * @param {string} minimum
+		 * @param {string} remaining
+		 * @param {string} remainingSats
+		 */
+		usdRemainderSweep: RequiredParams<'minimum' | 'remaining' | 'remainingSats'>
 	}
 	SendBitcoinDestinationScreen: {
 		/**
@@ -19358,6 +19365,10 @@ export type TranslationFunctions = {
 		 * High fee! We recommend Lightning.
 		 */
 		lightningRecommended: () => LocalizedString
+		/**
+		 * Remaining {remaining} ({remainingSats}) will be converted to Bitcoin. USD minimum: {minimum}.
+		 */
+		usdRemainderSweep: (arg: { minimum: string, remaining: string, remainingSats: string }) => LocalizedString
 	}
 	SendBitcoinDestinationScreen: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Slide to Confirm",
         "slideConfirming": "Confirming...",
         "copiedDestination": "Copied destination to clipboard",
-        "lightningRecommended": "High fee! We recommend Lightning."
+        "lightningRecommended": "High fee! We recommend Lightning.",
+        "usdRemainderSweep": "Remaining {remaining: string} ({remainingSats: string}) will be converted to Bitcoin. USD minimum: {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "{bankName: string} usernames are now {bankName: string} addresses.",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Gly om te bevestig",
     "slideConfirming": "Besig om te bevestig...",
     "copiedDestination": "Bestemming na knipbord oorgedra",
-    "lightningRecommended": "Hoë fooi! Ons beveel Lightning aan."
+    "lightningRecommended": "Hoë fooi! Ons beveel Lightning aan.",
+    "usdRemainderSweep": "Oorblywende {remaining: string} ({remainingSats: string}) sal na Bitcoin omgeskakel word. USD-minimum: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersname is nou {bankName: string} adresse. ",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "اسحب للتأكيد",
     "slideConfirming": "جارٍ التأكيد...",
     "copiedDestination": "تم نسخ الوجهة إلى الحافظة",
-    "lightningRecommended": "رسوم مرتفعة! نوصي باستخدام Lightning."
+    "lightningRecommended": "رسوم مرتفعة! نوصي باستخدام Lightning.",
+    "usdRemainderSweep": "الرصيد المتبقي {remaining: string} ({remainingSats: string}) سيتم تحويله إلى بيتكوين. الحد الأدنى للدولار الأمريكي: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "أسماء المستخدمين في {bankName: string} أصبحت عناوين في {bankName: string}",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Llisca per confirmar",
     "slideConfirming": "Confirmant...",
     "copiedDestination": "Destinació copiada al porta-retalls",
-    "lightningRecommended": "Comissió alta! Recomanem utilitzar Lightning."
+    "lightningRecommended": "Comissió alta! Recomanem utilitzar Lightning.",
+    "usdRemainderSweep": "Resta {remaining: string} ({remainingSats: string}) i es convertirà a Bitcoin. Mínim d'USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} nom d'usuari és ara la adreça {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Přejeďte pro potvrzení",
     "slideConfirming": "Potvrzování...",
     "copiedDestination": "Cíl zkopírován do schránky",
-    "lightningRecommended": "Vysoký poplatek! Doporučujeme Lightning."
+    "lightningRecommended": "Vysoký poplatek! Doporučujeme Lightning.",
+    "usdRemainderSweep": "Zbývajících {remaining: string} ({remainingSats: string}) bude převedeno na Bitcoin. Minimum v USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Uživatelská jména {bankName: string} jsou nyní adresy {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Slide to Confirm",
     "slideConfirming": "Confirming...",
     "copiedDestination": "Copied destination to clipboard",
-    "lightningRecommended": "High fee! We recommend Lightning."
+    "lightningRecommended": "High fee! We recommend Lightning.",
+    "usdRemainderSweep": "Resterende {remaining: string} ({remainingSats: string}) konverteres til Bitcoin. USD-minimum: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} brugernavne er nu {bankName: string} adresser.",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Schiebe zur Bestätigung",
         "slideConfirming": "Bestätigend…",
         "copiedDestination": "Ziel in die Zwischenablage kopiert",
-        "lightningRecommended": "Hohe Gebühr! Wir empfehlen Lightning."
+        "lightningRecommended": "Hohe Gebühr! Wir empfehlen Lightning.",
+        "usdRemainderSweep": "Restbetrag {remaining: string} ({remainingSats: string}) wird in Bitcoin umgewandelt. USD-Mindestbetrag: {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "{bankName: string} Benutzernamen sind nun {bankName: string} Adressen.",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Σύρετε για επιβεβαίωση",
     "slideConfirming": "Επιβεβαίωση...",
     "copiedDestination": "Αντιγραφή προορισμού στο πρόχειρο",
-    "lightningRecommended": "Υψηλή τέλη! Συνιστούμε το Lightning."
+    "lightningRecommended": "Υψηλή τέλη! Συνιστούμε το Lightning.",
+    "usdRemainderSweep": "Υπόλοιπο {remaining: string} ({remainingSats: string}) θα μετατραπεί σε Bitcoin. Ελάχιστο USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Τα ονόματα χρηστών {bankName: string} είναι τώρα διευθύνσεις {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Desliza para confirmar",
         "slideConfirming": "Confirmando...",
         "copiedDestination": "Destino copiado al portapapeles",
-        "lightningRecommended": "Tasa elevada. Recomendamos Lightning."
+        "lightningRecommended": "Tasa elevada. Recomendamos Lightning.",
+        "usdRemainderSweep": "Restante {remaining: string} ({remainingSats: string}) se convertirá a Bitcoin. Mínimo en USD: {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "Los nombres de usuario de {bankName: string} ahora son direcciones de {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Glissez pour confirmer",
         "slideConfirming": "Confirmation en cours…",
         "copiedDestination": "Destination copiée dans le presse-papiers",
-        "lightningRecommended": "Frais élevés ! Nous recommandons Lightning."
+        "lightningRecommended": "Frais élevés ! Nous recommandons Lightning.",
+        "usdRemainderSweep": "Solde restant {remaining: string} ({remainingSats: string}) sera converti en Bitcoin. Minimum en USD : {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "Les identifiants {bankName: string} sont maintenant les adresses {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Povucite za potvrdu",
     "slideConfirming": "Potvrđivanje...",
     "copiedDestination": "Odredište kopirano u međuspremnik",
-    "lightningRecommended": "Visoka naknada! Preporučujemo Lightning."
+    "lightningRecommended": "Visoka naknada! Preporučujemo Lightning.",
+    "usdRemainderSweep": "Preostalo {remaining: string} ({remainingSats: string}) bit će pretvoreno u Bitcoin. Minimum u USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} korisnička imena sada su {bankName: string} adrese.",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Húzd el a megerősítéshez",
     "slideConfirming": "Megerősítés...",
     "copiedDestination": "Címzett a vágólapra másolva",
-    "lightningRecommended": "Magas díj! Lightning használata ajánlott."
+    "lightningRecommended": "Magas díj! Lightning használata ajánlott.",
+    "usdRemainderSweep": "A fennmaradó {remaining: string} ({remainingSats: string}) Bitcoinra lesz váltva. USD minimum: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Mostantól a {bankName: string} felhasználónevek {bankName: string} címek is.",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Սահեցրեք՝ հաստատելու համար",
     "slideConfirming": "Հաստատվում է...",
     "copiedDestination": "Նպատակակետը պատծենվել է ջամանակավոր շտեմարանում",
-    "lightningRecommended": "Բարձր միջնորդավճար։ Խորհուրդ ենք տալիս Lightning-ը։"
+    "lightningRecommended": "Բարձր միջնորդավճար։ Խորհուրդ ենք տալիս Lightning-ը։",
+    "usdRemainderSweep": "Մնացած {remaining: string} ({remainingSats: string}) կփոխարկվի Bitcoin-ի։ USD-ի նվազագույնը՝ {minimum: string}։"
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} օգտանունները հիմա {bankName: string} հասցեներն են։ ",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Geser untuk Konfirmasi",
     "slideConfirming": "Mengkonfirmasi...",
     "copiedDestination": "Tujuan disalin ke papan klip",
-    "lightningRecommended": "Biaya tinggi! Kami merekomendasikan Lightning."
+    "lightningRecommended": "Biaya tinggi! Kami merekomendasikan Lightning.",
+    "usdRemainderSweep": "Sisa {remaining: string} ({remainingSats: string}) akan dikonversi ke Bitcoin. Minimum USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} nama pengguna sekarang adalah alamat {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Scorri per confermare",
         "slideConfirming": "Confermando...",
         "copiedDestination": "Destinazione copiata negli appunti",
-        "lightningRecommended": "Tariffa elevata! Consigliamo Lightning"
+        "lightningRecommended": "Tariffa elevata! Consigliamo Lightning",
+        "usdRemainderSweep": "Saldo rimanente {remaining: string} ({remainingSats: string}) sarà convertito in Bitcoin. Minimo USD: {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "Gli username {bankName: string} sono ora indirizzi {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "スライドして確認",
         "slideConfirming": "確認中...",
         "copiedDestination": "送信先をクリップボードにコピーしました",
-        "lightningRecommended": "手数料が高額です！Lightningをお勧めします。"
+        "lightningRecommended": "手数料が高額です！Lightningをお勧めします。",
+        "usdRemainderSweep": "残高{remaining: string}（{remainingSats: string}）はビットコインに変換されます。USDの最低額：{minimum: string}。"
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "ユーザー名{bankName: string}がアドレス{bankName: string}になりました。",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Seereza Okukakasa",
     "slideConfirming": "Okukakasa",
     "copiedDestination": "Gy'eziraga wawanduukuluddwa ku lutimbe",
-    "lightningRecommended": "Ebisale ebingi! Tukukubiriza okukozesa Lightning."
+    "lightningRecommended": "Ebisale ebingi! Tukukubiriza okukozesa Lightning.",
+    "usdRemainderSweep": "Ekisigaddewo {remaining: string} ({remainingSats: string}) kijja kufuulibwa Bitcoin. Ekitundu ekisembayo eky'USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} amannya g'omukozesa endagiriro ya {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Leret untuk Sahkan",
     "slideConfirming": "Mengesahkan...",
     "copiedDestination": "Destinasi telah disalin ke clipboard",
-    "lightningRecommended": "Yuran tinggi! Kami mengesyorkan Lightning."
+    "lightningRecommended": "Yuran tinggi! Kami mengesyorkan Lightning.",
+    "usdRemainderSweep": "Baki {remaining: string} ({remainingSats: string}) akan ditukar kepada Bitcoin. Minimum USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} id pengguna sekarang adalah {bankName: string} alamatnya.",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Veeg om te bevestigen",
     "slideConfirming": "Bevestigen...",
     "copiedDestination": "Bestemming naar het klembord gekopieerd",
-    "lightningRecommended": "Hoge kosten! We raden Lightning aan."
+    "lightningRecommended": "Hoge kosten! We raden Lightning aan.",
+    "usdRemainderSweep": "Resterend saldo {remaining: string} ({remainingSats: string}) wordt omgezet naar Bitcoin. USD-minimum: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} gebruikersnamen zijn nu {bankName: string} adressen.",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2225,7 +2225,8 @@
         "slideToConfirm": "Deslize para Confirmar",
         "slideConfirming": "Confirmando...",
         "copiedDestination": "Copiado destino para a área de transferência",
-        "lightningRecommended": "Alta taxa! Recomendamos Lightning."
+        "lightningRecommended": "Alta taxa! Recomendamos Lightning.",
+        "usdRemainderSweep": "Saldo restante {remaining: string} ({remainingSats: string}) será convertido em Bitcoin. Mínimo em USD: {minimum: string}."
     },
     "SendBitcoinDestinationScreen": {
         "usernameNowAddress": "Nomes de usuário {bankName: string} agora são endereços {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Aysay chiqapchanapaq",
     "slideConfirming": "Chiqapchashanku...",
     "copiedDestination": "Mayman rinanta clipboard nisqaman churasqa",
-    "lightningRecommended": "¡Hatun comisión! Lightning nisqata yuyaychayku."
+    "lightningRecommended": "¡Hatun comisión! Lightning nisqata yuyaychayku.",
+    "usdRemainderSweep": "Puchurqan {remaining: string} ({remainingSats: string}) Bitcoin-man tikrachisqa kanqa. USD pisi: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kaniyta yachanakuyta sutichinaqinmi, {bankName: string} kawsayniyta qillqata sutichinaqinmi kaniyta rikuyta munanpi.",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Glisați pentru a confirma",
     "slideConfirming": "Confirmare...",
     "copiedDestination": "Destinație copiată în clipboard",
-    "lightningRecommended": "Taxă mare! Vă recomandăm Lightning."
+    "lightningRecommended": "Taxă mare! Vă recomandăm Lightning.",
+    "usdRemainderSweep": "Soldul rămas {remaining: string} ({remainingSats: string}) va fi convertit în Bitcoin. Minim USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Numele de utilizator {bankName: string} sunt acum adrese {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Posunutím potvrďte",
     "slideConfirming": "Potvrdzovanie...",
     "copiedDestination": "Cieľ bol skopírovaný do schránky",
-    "lightningRecommended": "Vysoký poplatok! Odporúčame Lightning."
+    "lightningRecommended": "Vysoký poplatok! Odporúčame Lightning.",
+    "usdRemainderSweep": "Zostávajúcich {remaining: string} ({remainingSats: string}) bude prevedených na Bitcoin. Minimum v USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Používateľské mená {bankName: string} sú teraz adresy {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Превуците за потврду",
     "slideConfirming": "Потврђивање...",
     "copiedDestination": "Одредиште је копирано у клипборд",
-    "lightningRecommended": "Висока провизија! Препоручујемо Lightning."
+    "lightningRecommended": "Висока провизија! Препоручујемо Lightning.",
+    "usdRemainderSweep": "Preostalo {remaining: string} ({remainingSats: string}) biće konvertovano u Bitcoin. Minimum u USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} корисничка имена су сада {bankName: string} адресе.",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Telezesha kidole ili Kuthibitisha",
     "slideConfirming": "Inathibitisha...",
     "copiedDestination": "Imeakiliwa marudio kwenye ubao wa kunakili",
-    "lightningRecommended": "Ada kubwa! Tunapendekeza Umeme."
+    "lightningRecommended": "Ada kubwa! Tunapendekeza Umeme.",
+    "usdRemainderSweep": "Iliyosalia {remaining: string} ({remainingSats: string}) itabadilishwa kuwa Bitcoin. Kima cha chini cha USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} majina ya watumiaji sasa ni anwani za {bankName: string} ",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "เลื่อนเพื่อยืนยัน",
     "slideConfirming": "กำลังยืนยัน...",
     "copiedDestination": "คัดลอกปลายทางไปยังคลิปบอร์ดแล้ว",
-    "lightningRecommended": "ค่าธรรมเนียมสูง! แนะนำให้ใช้ Lightning"
+    "lightningRecommended": "ค่าธรรมเนียมสูง! แนะนำให้ใช้ Lightning",
+    "usdRemainderSweep": "ยอดคงเหลือ {remaining: string} ({remainingSats: string}) จะถูกแปลงเป็น Bitcoin ขั้นต่ำของ USD: {minimum: string}"
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "ชื่อผู้ใช้{bankName: string} เป็นแอดเดรส{bankName: string}ของคุณในขณะนี้",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Onaylamak için kaydırın",
     "slideConfirming": "Onaylanıyor...",
     "copiedDestination": "Hedefi panoya kopyalama",
-    "lightningRecommended": "Yüksek komisyon! Lightning kullanmanızı öneriyoruz."
+    "lightningRecommended": "Yüksek komisyon! Lightning kullanmanızı öneriyoruz.",
+    "usdRemainderSweep": "Kalan {remaining: string} ({remainingSats: string}) Bitcoin'e dönüştürülecek. USD minimumu: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "{bankName: string} kullanıcı adları artık {bankName: string} adresleridir.",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Vuốt để Xác nhận",
     "slideConfirming": "Đang xác nhận...",
     "copiedDestination": "Đã sao chép địa chỉ đích vào bộ nhớ tạm",
-    "lightningRecommended": "Phí cao! Chúng tôi khuyên bạn nên dùng Lightning."
+    "lightningRecommended": "Phí cao! Chúng tôi khuyên bạn nên dùng Lightning.",
+    "usdRemainderSweep": "Số dư còn lại {remaining: string} ({remainingSats: string}) sẽ được chuyển đổi thành Bitcoin. Tối thiểu USD: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "Tên người dùng {bankName: string} hiện là địa chỉ {bankName: string}.",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2225,7 +2225,8 @@
     "slideToConfirm": "Slaydisha ukuqinisekisa",
     "slideConfirming": "Iyaqinisekisa...",
     "copiedDestination": "Ikopishwe indawo ekuya kuyo kwibhodi eqhotyoshwayo",
-    "lightningRecommended": "Imirhumo iphezulu! Sincoma i-Lightning."
+    "lightningRecommended": "Imirhumo iphezulu! Sincoma i-Lightning.",
+    "usdRemainderSweep": "Iseleyo {remaining: string} ({remainingSats: string}) iya kuguqulelwa kwiBitcoin. USD ephantsi kakhulu: {minimum: string}."
   },
   "SendBitcoinDestinationScreen": {
     "usernameNowAddress": "bankName:} amagama abasebenzisi ngoku {bankName: string} iidilesi.",

--- a/app/screens/conversion-flow/hooks/self-custodial/use-conversion-guard.ts
+++ b/app/screens/conversion-flow/hooks/self-custodial/use-conversion-guard.ts
@@ -3,7 +3,7 @@ import { useMemo } from "react"
 import { WalletCurrency } from "@app/graphql/generated"
 import { usePriceConversion } from "@app/hooks/use-price-conversion"
 import { toWalletMoneyAmount } from "@app/types/amounts"
-import { ConvertAmountAdjustment } from "@app/types/payment"
+import { ConvertAmountAdjustment, resolveDustAdjustment } from "@app/types/payment"
 
 import { buildConvertParams } from "../../build-convert-params"
 
@@ -20,17 +20,6 @@ export type SelfCustodialConversionGuard = {
   isQuoting: boolean
   hasQuoteError: boolean
   blockingReason: ConvertAmountAdjustment | null
-}
-
-const resolveBlockingReason = (
-  amountAdjustment: ConvertAmountAdjustment | null,
-  amountInSourceCurrency: number,
-  fromWalletBalance: number | undefined,
-): ConvertAmountAdjustment | null => {
-  /** Only the dust gate blocks; `FlooredToMin` is a benign SDK floor and proceeds normally. */
-  if (amountAdjustment !== ConvertAmountAdjustment.IncreasedToAvoidDust) return null
-  if (fromWalletBalance === undefined) return amountAdjustment
-  return amountInSourceCurrency >= fromWalletBalance ? null : amountAdjustment
 }
 
 export const useSelfCustodialConversionGuard = ({
@@ -52,7 +41,7 @@ export const useSelfCustodialConversionGuard = ({
 
   const blockingReason = useMemo(
     () =>
-      resolveBlockingReason(amountAdjustment, amountInSourceCurrency, fromWalletBalance),
+      resolveDustAdjustment(amountAdjustment, amountInSourceCurrency, fromWalletBalance),
     [amountAdjustment, amountInSourceCurrency, fromWalletBalance],
   )
 

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -27,6 +27,7 @@ import {
   WalletAmount,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
+import { ConvertAmountAdjustment } from "@app/types/payment"
 import { PaymentType as SelfCustodialPaymentType } from "@app/types/transaction"
 import { WalletDescriptor } from "@app/types/wallets"
 import { PaymentType } from "@blinkbitcoin/blink-client"
@@ -64,6 +65,7 @@ export type GetFeeParams = {
 export type GetFee<T extends WalletCurrency> = (getFeeFns: GetFeeParams) => Promise<{
   amount?: WalletAmount<T> | null | undefined
   errors?: readonly GraphQlApplicationError[]
+  amountAdjustment?: ConvertAmountAdjustment | undefined
 }>
 
 export type SendPaymentMutationParams = {

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -27,7 +27,6 @@ import {
   WalletAmount,
   WalletOrDisplayCurrency,
 } from "@app/types/amounts"
-import { ConvertAmountAdjustment } from "@app/types/payment"
 import { PaymentType as SelfCustodialPaymentType } from "@app/types/transaction"
 import { WalletDescriptor } from "@app/types/wallets"
 import { PaymentType } from "@blinkbitcoin/blink-client"
@@ -65,7 +64,6 @@ export type GetFeeParams = {
 export type GetFee<T extends WalletCurrency> = (getFeeFns: GetFeeParams) => Promise<{
   amount?: WalletAmount<T> | null | undefined
   errors?: readonly GraphQlApplicationError[]
-  amountAdjustment?: ConvertAmountAdjustment | undefined
 }>
 
 export type SendPaymentMutationParams = {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -27,7 +27,7 @@ import {
   ZeroBtcMoneyAmount,
   ZeroUsdMoneyAmount,
 } from "@app/types/amounts"
-import { useTranslateSdkError } from "@app/self-custodial/hooks"
+import { useSendDustWarning, useTranslateSdkError } from "@app/self-custodial/hooks"
 import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
 import crashlytics from "@react-native-firebase/crashlytics"
 import { CommonActions, RouteProp, useNavigation } from "@react-navigation/native"
@@ -117,6 +117,16 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
   const { copyToClipboard } = useClipboard()
 
   const fee = useFee(getFee)
+
+  const dustWarning = useSendDustWarning({
+    amountAdjustment: fee.amountAdjustment,
+    fromCurrency: sendingWalletDescriptor.currency,
+    fromWalletBalance: usdWallet?.balance,
+    unitOfAccountAmount,
+    settlementAmount: settlementAmount.amount,
+    feeSats: fee.amount?.amount ?? 0,
+    usdBalanceMoneyAmount,
+  })
 
   const defaultAmount = formatMoneyAmount({ moneyAmount: ZeroUsdMoneyAmount })
   let currencyFeeAmount = defaultAmount
@@ -497,6 +507,21 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           )}
         </View>
 
+        {dustWarning.shouldShow ? (
+          <View style={styles.fieldContainer}>
+            <View style={styles.dustWarning}>
+              <GaloyIcon name="warning" size={18} color={colors.warning} />
+              <Text type="p3" style={styles.dustWarningText}>
+                {" "}
+                {LL.SendBitcoinConfirmationScreen.usdRemainderSweep({
+                  remaining: dustWarning.remaining,
+                  remainingSats: dustWarning.remainingSats,
+                  minimum: dustWarning.minimum,
+                })}
+              </Text>
+            </View>
+          </View>
+        ) : null}
         {errorMessage ? (
           <View style={styles.errorContainer}>
             <Text type="p2" style={styles.errorText}>
@@ -513,7 +538,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
                 initialText={LL.SendBitcoinConfirmationScreen.slideToConfirm()}
                 loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
                 onSwipe={handleSendPayment}
-                disabled={!validAmount || hasAttemptedSend}
+                disabled={!validAmount || hasAttemptedSend || fee.status === "loading"}
               />
             </View>
           </PanGestureHandler>
@@ -617,6 +642,15 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   feeWarningText: {
     color: colors.warning,
+  },
+  dustWarning: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    columnGap: 4,
+  },
+  dustWarningText: {
+    color: colors.warning,
+    flex: 1,
   },
   feeTextContainer: {
     flexDirection: "row",

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -9,6 +9,7 @@ import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import GaloySliderButton from "@app/components/atomic/galoy-slider-button/galoy-slider-button"
 import { PaymentDestinationDisplay } from "@app/components/payment-destination-display"
 import { Screen } from "@app/components/screen"
+import { WarningBanner } from "@app/components/warning-banner"
 import { HIDDEN_AMOUNT_PLACEHOLDER } from "@app/config"
 import { WalletCurrency } from "@app/graphql/generated"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
@@ -118,15 +119,22 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
 
   const fee = useFee(getFee)
 
+  const settledFee = fee.status === "set" ? fee : undefined
+
   const dustWarning = useSendDustWarning({
-    amountAdjustment: fee.amountAdjustment,
+    amountAdjustment: settledFee?.amountAdjustment,
     fromCurrency: sendingWalletDescriptor.currency,
     fromWalletBalance: usdWallet?.balance,
     unitOfAccountAmount,
     settlementAmount: settlementAmount.amount,
-    feeSats: fee.amount?.amount ?? 0,
+    feeSats: settledFee?.amount.amount,
     usdBalanceMoneyAmount,
   })
+
+  const feeUnavailable =
+    fee.status === "loading" || (fee.status === "error" && !fee.amount)
+  const dustNotEvaluable =
+    dustWarning.status === "pending" || dustWarning.status === "blocked"
 
   const defaultAmount = formatMoneyAmount({ moneyAmount: ZeroUsdMoneyAmount })
   let currencyFeeAmount = defaultAmount
@@ -382,16 +390,9 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
 
   const LightningRecommendedComponent = isLightningRecommended() ? (
     <View style={styles.feeWarning}>
-      <GaloyIcon name="warning" size={18} color={colors.warning} />
-      <Text
-        type="p3"
-        style={styles.feeWarningText}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-      >
-        {" "}
+      <WarningBanner numberOfLines={1}>
         {LL.SendBitcoinConfirmationScreen.lightningRecommended()}
-      </Text>
+      </WarningBanner>
     </View>
   ) : (
     <></>
@@ -507,19 +508,17 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           )}
         </View>
 
-        {dustWarning.shouldShow ? (
+        {dustWarning.status === "visible" ? (
           <View style={styles.fieldContainer}>
-            <View style={styles.dustWarning}>
-              <GaloyIcon name="warning" size={18} color={colors.warning} />
-              <Text type="p3" style={styles.dustWarningText}>
-                {" "}
-                {LL.SendBitcoinConfirmationScreen.usdRemainderSweep({
-                  remaining: dustWarning.remaining,
-                  remainingSats: dustWarning.remainingSats,
-                  minimum: dustWarning.minimum,
-                })}
-              </Text>
-            </View>
+            <WarningBanner>
+              {LL.SendBitcoinConfirmationScreen.usdRemainderSweep({
+                remaining: formatMoneyAmount({ moneyAmount: dustWarning.remaining }),
+                remainingSats: formatMoneyAmount({
+                  moneyAmount: dustWarning.remainingSats,
+                }),
+                minimum: formatMoneyAmount({ moneyAmount: dustWarning.minimum }),
+              })}
+            </WarningBanner>
           </View>
         ) : null}
         {errorMessage ? (
@@ -538,7 +537,9 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
                 initialText={LL.SendBitcoinConfirmationScreen.slideToConfirm()}
                 loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
                 onSwipe={handleSendPayment}
-                disabled={!validAmount || hasAttemptedSend || fee.status === "loading"}
+                disabled={
+                  !validAmount || hasAttemptedSend || feeUnavailable || dustNotEvaluable
+                }
               />
             </View>
           </PanGestureHandler>
@@ -635,22 +636,7 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   feeWarning: {
     paddingBottom: 4,
-    flexDirection: "row",
-    justifyContent: "center",
-    alignItems: "center",
     flex: 0.95,
-  },
-  feeWarningText: {
-    color: colors.warning,
-  },
-  dustWarning: {
-    flexDirection: "row",
-    alignItems: "flex-start",
-    columnGap: 4,
-  },
-  dustWarningText: {
-    color: colors.warning,
-    flex: 1,
   },
   feeTextContainer: {
     flexDirection: "row",

--- a/app/screens/send-bitcoin-screen/use-fee.ts
+++ b/app/screens/send-bitcoin-screen/use-fee.ts
@@ -12,6 +12,7 @@ import {
   useOnChainUsdTxFeeLazyQuery,
 } from "@app/graphql/generated"
 import { WalletAmount } from "@app/types/amounts"
+import { ConvertAmountAdjustment } from "@app/types/payment"
 import crashlytics from "@react-native-firebase/crashlytics"
 
 import { GetFee } from "./payment-details/index.types"
@@ -20,14 +21,17 @@ type FeeType =
   | {
       status: "loading" | "error" | "unset"
       amount?: undefined | null
+      amountAdjustment?: undefined
     }
   | {
       amount: WalletAmount<WalletCurrency>
       status: "set"
+      amountAdjustment?: ConvertAmountAdjustment
     }
   | {
       amount?: WalletAmount<WalletCurrency>
       status: "error"
+      amountAdjustment?: undefined
     }
 
 gql`
@@ -146,6 +150,7 @@ const useFee = <T extends WalletCurrency>(getFeeFn?: GetFee<T> | null): FeeType 
         return setFee({
           status: "set",
           amount: feeResponse.amount,
+          amountAdjustment: feeResponse.amountAdjustment,
         })
       } catch (err) {
         if (err instanceof Error) {

--- a/app/screens/send-bitcoin-screen/use-fee.ts
+++ b/app/screens/send-bitcoin-screen/use-fee.ts
@@ -11,6 +11,7 @@ import {
   useOnChainUsdTxFeeAsBtcDenominatedLazyQuery,
   useOnChainUsdTxFeeLazyQuery,
 } from "@app/graphql/generated"
+import type { SelfCustodialFeeResult } from "@app/self-custodial/payment-details/send-helpers"
 import { WalletAmount } from "@app/types/amounts"
 import { ConvertAmountAdjustment } from "@app/types/payment"
 import crashlytics from "@react-native-firebase/crashlytics"
@@ -21,7 +22,6 @@ type FeeType =
   | {
       status: "loading" | "error" | "unset"
       amount?: undefined | null
-      amountAdjustment?: undefined
     }
   | {
       amount: WalletAmount<WalletCurrency>
@@ -31,7 +31,6 @@ type FeeType =
   | {
       amount?: WalletAmount<WalletCurrency>
       status: "error"
-      amountAdjustment?: undefined
     }
 
 gql`
@@ -147,10 +146,11 @@ const useFee = <T extends WalletCurrency>(getFeeFn?: GetFee<T> | null): FeeType 
           })
         }
 
+        const { amountAdjustment } = feeResponse as SelfCustodialFeeResult<T>
         return setFee({
           status: "set",
           amount: feeResponse.amount,
-          amountAdjustment: feeResponse.amountAdjustment,
+          amountAdjustment,
         })
       } catch (err) {
         if (err instanceof Error) {

--- a/app/self-custodial/bridge/convert.ts
+++ b/app/self-custodial/bridge/convert.ts
@@ -29,6 +29,18 @@ import { requireSparkTokenIdentifier, SparkConfig } from "../config"
 import { buildConversionType, fetchConversionLimits } from "./limits"
 import { fetchUsdbDecimals, findUsdbToken } from "./token-balance"
 
+const mapAmountAdjustment = (
+  reason: AmountAdjustmentReason | undefined,
+): ConvertAmountAdjustment | undefined => {
+  if (reason === undefined) return undefined
+  const map: Record<AmountAdjustmentReason, ConvertAmountAdjustment> = {
+    [AmountAdjustmentReason.FlooredToMinLimit]: ConvertAmountAdjustment.FlooredToMin,
+    [AmountAdjustmentReason.IncreasedToAvoidDust]:
+      ConvertAmountAdjustment.IncreasedToAvoidDust,
+  }
+  return map[reason]
+}
+
 const failed = (message: string, code?: string): PaymentAdapterResult => ({
   status: PaymentResultStatus.Failed,
   errors: [{ message, code }],
@@ -48,18 +60,6 @@ const recordConvertError = (err: unknown, params: ConvertParams, where: string):
     `[Convert] ${where} failed (direction=${params.direction}, fromAmount=${params.fromAmount.amount}, toAmount=${params.toAmount.amount})`,
   )
   reportError(where, err)
-}
-
-const mapAmountAdjustment = (
-  reason: AmountAdjustmentReason | undefined,
-): ConvertAmountAdjustment | undefined => {
-  if (reason === AmountAdjustmentReason.FlooredToMinLimit) {
-    return ConvertAmountAdjustment.FlooredToMin
-  }
-  if (reason === AmountAdjustmentReason.IncreasedToAvoidDust) {
-    return ConvertAmountAdjustment.IncreasedToAvoidDust
-  }
-  return undefined
 }
 
 const createOwnSparkInvoice = async (

--- a/app/self-custodial/bridge/convert.ts
+++ b/app/self-custodial/bridge/convert.ts
@@ -29,7 +29,7 @@ import { requireSparkTokenIdentifier, SparkConfig } from "../config"
 import { buildConversionType, fetchConversionLimits } from "./limits"
 import { fetchUsdbDecimals, findUsdbToken } from "./token-balance"
 
-const mapAmountAdjustment = (
+export const mapAmountAdjustment = (
   reason: AmountAdjustmentReason | undefined,
 ): ConvertAmountAdjustment | undefined => {
   if (reason === undefined) return undefined

--- a/app/self-custodial/bridge/index.ts
+++ b/app/self-custodial/bridge/index.ts
@@ -30,7 +30,7 @@ export {
 export type { OnchainFeeTiers, PrepareSendOptions, PrepareLnurlOptions } from "./send"
 export { listDeposits, claimDeposit, refundDeposit, getRecommendedFees } from "./deposits"
 export type { MappedDeposit, NetworkFeeRates } from "./deposits"
-export { createGetConversionQuote } from "./convert"
+export { createGetConversionQuote, mapAmountAdjustment } from "./convert"
 export { buildConversionType, fetchConversionLimits } from "./limits"
 export { parseSparkAddress } from "./parse"
 export type { ParsedSparkAddress } from "./parse"

--- a/app/self-custodial/hooks/index.ts
+++ b/app/self-custodial/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useNonCustodialConversionLimits } from "./use-non-custodial-conversion-limits"
 export { usePaymentRequest } from "./use-payment-request"
+export { useSendDustWarning } from "./use-send-dust-warning"
 export { useTranslateSdkError } from "./use-translate-sdk-error"
 export type { SelfCustodialPaymentRequestState, InvoiceData } from "./types"

--- a/app/self-custodial/hooks/use-send-dust-warning.ts
+++ b/app/self-custodial/hooks/use-send-dust-warning.ts
@@ -1,0 +1,89 @@
+import { useMemo } from "react"
+
+import { WalletCurrency } from "@app/graphql/generated"
+import { useDisplayCurrency } from "@app/hooks"
+import { usePriceConversion } from "@app/hooks/use-price-conversion"
+import {
+  toBtcMoneyAmount,
+  type MoneyAmount,
+  type WalletAmount,
+  type WalletOrDisplayCurrency,
+} from "@app/types/amounts"
+import {
+  ConvertAmountAdjustment,
+  ConvertDirection,
+  resolveDustAdjustment,
+} from "@app/types/payment"
+
+import { useNonCustodialConversionLimits } from "./use-non-custodial-conversion-limits"
+
+type Params = {
+  amountAdjustment: ConvertAmountAdjustment | undefined
+  fromCurrency: WalletCurrency | undefined
+  fromWalletBalance: number | undefined
+  unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
+  settlementAmount: number
+  feeSats: number
+  usdBalanceMoneyAmount: WalletAmount<typeof WalletCurrency.Usd>
+}
+
+export type SendDustWarning =
+  | { shouldShow: false }
+  | { shouldShow: true; remaining: string; remainingSats: string; minimum: string }
+
+const HIDDEN: SendDustWarning = { shouldShow: false }
+
+export const useSendDustWarning = ({
+  amountAdjustment,
+  fromCurrency,
+  fromWalletBalance,
+  unitOfAccountAmount,
+  settlementAmount,
+  feeSats,
+  usdBalanceMoneyAmount,
+}: Params): SendDustWarning => {
+  const { formatMoneyAmount } = useDisplayCurrency()
+  const { convertMoneyAmount } = usePriceConversion()
+  const isUsdSource = fromCurrency === WalletCurrency.Usd
+  const { limits } = useNonCustodialConversionLimits(
+    isUsdSource ? ConvertDirection.BtcToUsd : undefined,
+  )
+
+  return useMemo(() => {
+    if (!convertMoneyAmount) return HIDDEN
+    const blockingReason = resolveDustAdjustment(
+      amountAdjustment ?? null,
+      settlementAmount,
+      isUsdSource ? fromWalletBalance : undefined,
+    )
+    if (blockingReason !== ConvertAmountAdjustment.IncreasedToAvoidDust) return HIDDEN
+    if (!limits?.minFromAmount) return HIDDEN
+
+    const balanceSats = convertMoneyAmount(
+      usdBalanceMoneyAmount,
+      WalletCurrency.Btc,
+    ).amount
+    const sentSats = convertMoneyAmount(unitOfAccountAmount, WalletCurrency.Btc).amount
+    const remainingSats = toBtcMoneyAmount(Math.max(0, balanceSats - sentSats - feeSats))
+
+    return {
+      shouldShow: true,
+      remaining: formatMoneyAmount({
+        moneyAmount: convertMoneyAmount(remainingSats, WalletCurrency.Usd),
+      }),
+      remainingSats: formatMoneyAmount({ moneyAmount: remainingSats }),
+      minimum: formatMoneyAmount({ moneyAmount: toBtcMoneyAmount(limits.minFromAmount) }),
+    }
+  }, [
+    amountAdjustment,
+    isUsdSource,
+    fromWalletBalance,
+    settlementAmount,
+    limits?.minFromAmount,
+    usdBalanceMoneyAmount,
+    unitOfAccountAmount,
+    feeSats,
+    convertMoneyAmount,
+    formatMoneyAmount,
+  ])
+}

--- a/app/self-custodial/hooks/use-send-dust-warning.ts
+++ b/app/self-custodial/hooks/use-send-dust-warning.ts
@@ -1,11 +1,13 @@
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 
 import { WalletCurrency } from "@app/graphql/generated"
-import { useDisplayCurrency } from "@app/hooks"
 import { usePriceConversion } from "@app/hooks/use-price-conversion"
 import {
   toBtcMoneyAmount,
+  toUsdMoneyAmount,
+  type BtcMoneyAmount,
   type MoneyAmount,
+  type UsdMoneyAmount,
   type WalletAmount,
   type WalletOrDisplayCurrency,
 } from "@app/types/amounts"
@@ -14,6 +16,7 @@ import {
   ConvertDirection,
   resolveDustAdjustment,
 } from "@app/types/payment"
+import { reportError } from "@app/utils/error-logging"
 
 import { useNonCustodialConversionLimits } from "./use-non-custodial-conversion-limits"
 
@@ -23,15 +26,25 @@ type Params = {
   fromWalletBalance: number | undefined
   unitOfAccountAmount: MoneyAmount<WalletOrDisplayCurrency>
   settlementAmount: number
-  feeSats: number
+  feeSats: number | undefined
   usdBalanceMoneyAmount: WalletAmount<typeof WalletCurrency.Usd>
 }
 
+/** Decision only; the screen formats. `pending`/`blocked` are fail-closed states the caller must disable the slider on. */
 export type SendDustWarning =
-  | { shouldShow: false }
-  | { shouldShow: true; remaining: string; remainingSats: string; minimum: string }
+  | { status: "hidden" }
+  | { status: "pending" }
+  | { status: "blocked" }
+  | {
+      status: "visible"
+      remaining: MoneyAmount<WalletOrDisplayCurrency>
+      remainingSats: BtcMoneyAmount
+      minimum: UsdMoneyAmount
+    }
 
-const HIDDEN: SendDustWarning = { shouldShow: false }
+const HIDDEN = { status: "hidden" } as const
+const PENDING = { status: "pending" } as const
+const BLOCKED = { status: "blocked" } as const
 
 export const useSendDustWarning = ({
   amountAdjustment,
@@ -42,48 +55,54 @@ export const useSendDustWarning = ({
   feeSats,
   usdBalanceMoneyAmount,
 }: Params): SendDustWarning => {
-  const { formatMoneyAmount } = useDisplayCurrency()
   const { convertMoneyAmount } = usePriceConversion()
   const isUsdSource = fromCurrency === WalletCurrency.Usd
-  const { limits } = useNonCustodialConversionLimits(
-    isUsdSource ? ConvertDirection.BtcToUsd : undefined,
+  const { limits, loading, error } = useNonCustodialConversionLimits(
+    isUsdSource ? ConvertDirection.UsdToBtc : undefined,
   )
 
-  return useMemo(() => {
-    if (!convertMoneyAmount) return HIDDEN
-    const blockingReason = resolveDustAdjustment(
+  const dustApplies =
+    isUsdSource &&
+    resolveDustAdjustment(
       amountAdjustment ?? null,
       settlementAmount,
-      isUsdSource ? fromWalletBalance : undefined,
-    )
-    if (blockingReason !== ConvertAmountAdjustment.IncreasedToAvoidDust) return HIDDEN
-    if (!limits?.minFromAmount) return HIDDEN
+      fromWalletBalance,
+    ) === ConvertAmountAdjustment.IncreasedToAvoidDust
+
+  useEffect(() => {
+    if (dustApplies && error) {
+      reportError("self-custodial dust-warning conversion limits", error)
+    }
+  }, [dustApplies, error])
+
+  return useMemo<SendDustWarning>(() => {
+    if (!dustApplies) return HIDDEN
+    if (loading || !convertMoneyAmount) return PENDING
+    if (error || !limits?.minFromAmount) return BLOCKED
 
     const balanceSats = convertMoneyAmount(
       usdBalanceMoneyAmount,
       WalletCurrency.Btc,
     ).amount
     const sentSats = convertMoneyAmount(unitOfAccountAmount, WalletCurrency.Btc).amount
-    const remainingSats = toBtcMoneyAmount(Math.max(0, balanceSats - sentSats - feeSats))
+    const remainingSats = toBtcMoneyAmount(
+      Math.max(0, balanceSats - sentSats - (feeSats ?? 0)),
+    )
 
     return {
-      shouldShow: true,
-      remaining: formatMoneyAmount({
-        moneyAmount: convertMoneyAmount(remainingSats, WalletCurrency.Usd),
-      }),
-      remainingSats: formatMoneyAmount({ moneyAmount: remainingSats }),
-      minimum: formatMoneyAmount({ moneyAmount: toBtcMoneyAmount(limits.minFromAmount) }),
+      status: "visible",
+      remaining: convertMoneyAmount(remainingSats, WalletCurrency.Usd),
+      remainingSats,
+      minimum: toUsdMoneyAmount(limits.minFromAmount),
     }
   }, [
-    amountAdjustment,
-    isUsdSource,
-    fromWalletBalance,
-    settlementAmount,
+    dustApplies,
+    loading,
+    error,
     limits?.minFromAmount,
+    convertMoneyAmount,
     usdBalanceMoneyAmount,
     unitOfAccountAmount,
     feeSats,
-    convertMoneyAmount,
-    formatMoneyAmount,
   ])
 }

--- a/app/self-custodial/payment-details/send-helpers.ts
+++ b/app/self-custodial/payment-details/send-helpers.ts
@@ -11,7 +11,15 @@ import {
 } from "@app/screens/send-bitcoin-screen/payment-details/index.types"
 import { FeeTierOption } from "@app/screens/send-bitcoin-screen/hooks/fee-tiers.types"
 import { toBtcMoneyAmount, type WalletAmount } from "@app/types/amounts"
+import { ConvertAmountAdjustment } from "@app/types/payment"
 import { reportError } from "@app/utils/error-logging"
+
+/** GetFee result plus the SDK dust adjustment, kept behind the self-custodial port so the shared GetFee contract stays free of it. */
+export type SelfCustodialFeeResult<T extends WalletCurrency> = Awaited<
+  ReturnType<GetFee<T>>
+> & {
+  amountAdjustment?: ConvertAmountAdjustment
+}
 
 import {
   executeSend,
@@ -49,7 +57,7 @@ const asGetFeeAmount = <T extends WalletCurrency>(feeSats: number) =>
 export const createGetFee = <T extends WalletCurrency>(
   params: PrepareParams,
 ): GetFee<T> => {
-  return async () => {
+  return async (): Promise<SelfCustodialFeeResult<T>> => {
     try {
       const prepared = await prepareSend(params.sdk, toPrepareOptions(params))
       const feeSats = extractLightningFee(prepared) ?? 0

--- a/app/self-custodial/payment-details/send-helpers.ts
+++ b/app/self-custodial/payment-details/send-helpers.ts
@@ -17,6 +17,7 @@ import {
   executeSend,
   extractLightningFee,
   extractOnchainFees,
+  mapAmountAdjustment,
   prepareSend,
 } from "../bridge"
 import { classifySdkError } from "../sdk-error"
@@ -52,7 +53,10 @@ export const createGetFee = <T extends WalletCurrency>(
     try {
       const prepared = await prepareSend(params.sdk, toPrepareOptions(params))
       const feeSats = extractLightningFee(prepared) ?? 0
-      return { amount: asGetFeeAmount<T>(feeSats) }
+      const amountAdjustment = mapAmountAdjustment(
+        prepared.conversionEstimate?.amountAdjustment,
+      )
+      return { amount: asGetFeeAmount<T>(feeSats), amountAdjustment }
     } catch {
       return { amount: undefined }
     }

--- a/app/types/payment.ts
+++ b/app/types/payment.ts
@@ -201,6 +201,16 @@ export const ConvertAmountAdjustment = {
 export type ConvertAmountAdjustment =
   (typeof ConvertAmountAdjustment)[keyof typeof ConvertAmountAdjustment]
 
+export const resolveDustAdjustment = (
+  amountAdjustment: ConvertAmountAdjustment | null,
+  amountInSourceCurrency: number,
+  fromWalletBalance: number | undefined,
+): ConvertAmountAdjustment | null => {
+  if (amountAdjustment !== ConvertAmountAdjustment.IncreasedToAvoidDust) return null
+  if (fromWalletBalance === undefined) return amountAdjustment
+  return amountInSourceCurrency >= fromWalletBalance ? null : amountAdjustment
+}
+
 export type ConvertQuote = {
   feeAmount: UsdMoneyAmount
   amountAdjustment?: ConvertAmountAdjustment

--- a/app/types/payment.ts
+++ b/app/types/payment.ts
@@ -201,6 +201,7 @@ export const ConvertAmountAdjustment = {
 export type ConvertAmountAdjustment =
   (typeof ConvertAmountAdjustment)[keyof typeof ConvertAmountAdjustment]
 
+/** Only IncreasedToAvoidDust blocks: FlooredToMin is a benign SDK floor, and a full-balance send leaves no remainder to sweep. Shared by Convert and Send. */
 export const resolveDustAdjustment = (
   amountAdjustment: ConvertAmountAdjustment | null,
   amountInSourceCurrency: number,


### PR DESCRIPTION
## Summary

Fixes #3809 — paying a Lightning invoice from the USD (USDB) account silently sweeps the entire remaining USD balance to BTC whenever the leftover would fall below the Spark/USDB protocol minimum (~800 sats equivalent).

The bug existed because the `Send` flow ignored the SDK signal `conversionEstimate.amountAdjustment === IncreasedToAvoidDust` that the `prepareSendPayment` call returns when the source balance would be left sub-threshold. The Convert flow already consumes this signal via `useSelfCustodialConversionGuard`; the Send flow did not.

This PR adds a non-blocking warning to the confirmation screen — user keeps control of the operation but is no longer surprised by the sweep.

## Why a warning, not a block

The ticket explicitly suggests two paths: (1) retain the sub-threshold balance, or (2) warn the user upfront. Option 1 is not feasible from the app side — the threshold lives in the SDK pool, not in app code. Option 2 is the realistic path: surface the existing SDK signal transparently and let the user decide.

## Repro (validated on regtest)

Starting state on a fresh self-custodial wallet:

| Step | Action | USD wallet | BTC wallet |
|---|---|---|---|
| 0 | Initial state | $0.00 | 1600 sats |
| 1 | Transfer 1000 sats → USD | $0.66 (1000 sats) | 600 sats |
| 2 | Pay 300-sat Lightning invoice from USD | **$0.00** ← bug: drains | **+695 sats** ← swept |

Expected: USD wallet keeps ~698 sats remainder. Actual (pre-fix): USD wallet drained entirely, the ~698 sats appear in BTC wallet.

## Architecture

The fix uses the **same code paths** as the existing Convert flow — zero duplication of detection/limits logic. Both flows now share:

- `resolveDustAdjustment` in `app/types/payment.ts` — the predicate that decides "is this a real dust sweep or is the user already draining intentionally"
- `mapAmountAdjustment` in `app/self-custodial/bridge/convert.ts` (now exposed via barrel) — maps the SDK `AmountAdjustmentReason` enum to the app's `ConvertAmountAdjustment`
- `useNonCustodialConversionLimits(ConvertDirection.BtcToUsd)` — fetches the threshold from `SDK.fetchConversionLimits()`, no hardcoded value

The new `useSendDustWarning` hook in `app/self-custodial/hooks/` is the Send analogue of `useSelfCustodialConversionGuard`:

```
SDK.prepareSendPayment
  → conversionEstimate.amountAdjustment
  → mapAmountAdjustment        ← shared bridge mapper
  → ConvertAmountAdjustment    ← shared app enum
  → useFee (Send) / useConversionQuote (Convert)
  → useSendDustWarning (Send) / useSelfCustodialConversionGuard (Convert)
  → resolveDustAdjustment      ← shared predicate
```

## Custodial untouched

Custodial users are unaffected:
- `GetFee.amountAdjustment` is an optional field; custodial fee probes (GraphQL mutations) never populate it
- `useNonCustodialConversionLimits` returns `null` for custodial (no SDK)
- Double-gate in the hook (`if (!fee.amountAdjustment) return HIDDEN; if (!limits?.minFromAmount) return HIDDEN`) ensures the warning is impossible to render outside the self-custodial USD-Lightning path

## Commits

Split for review clarity:

1. **`refactor(self-custodial): extract dust-adjustment helpers from Convert flow`** — pure refactor, byte-equivalent Convert behavior (verified by 15/15 guard tests + convert bridge spec)
2. **`fix(send): warn before USD wallet remainder is auto-converted to BTC`** — the actual fix plus tests, i18n, and screen integration

## Screens

Confirmation screen with the warning rendered when remaining USD would fall below the SDK-reported minimum:

> ⚠️ Remaining $0.45 (693 SAT) will be converted to Bitcoin. USD minimum: 800 SAT.

Visual treatment mirrors the existing `lightningRecommended` warning (icon + warning color + `p3` text), placed inside a `fieldContainer` for proper horizontal padding. The "Slide to Confirm" button is additionally disabled while the fee quote is loading, to prevent the user from sliding before the warning has a chance to surface.

## Translations

New i18n key `usdRemainderSweep` added with proper diacritics in all 28 languages. Each JSON file's original indent preserved (some use 2-space, others 4-space) — diff per language is exactly 3 lines.
<img width="452" height="959" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/947f3dec-345f-4724-92d7-21b9dd0ba036" />

