### PR TITLE
fix(conversion): preserve chip-press amount when focused-input identity changes mid-cycle

### DIFF
--- a/__tests__/components/amount-input-screen.spec.tsx
+++ b/__tests__/components/amount-input-screen.spec.tsx
@@ -12,32 +12,40 @@ const mockFormatMoneyAmount = jest.fn()
 const mockOnAmountChange = jest.fn()
 const mockOnSetFormattedAmount = jest.fn()
 
-jest.mock("@app/hooks/use-display-currency", () => ({
-  useDisplayCurrency: () => ({
-    currencyInfo: {
-      BTC: {
-        symbol: "",
-        minorUnitToMajorUnitOffset: 0,
-        showFractionDigits: false,
-        currencyCode: "SAT",
-      },
-      USD: {
-        symbol: "$",
-        minorUnitToMajorUnitOffset: 2,
-        showFractionDigits: true,
-        currencyCode: "USD",
-      },
-      DisplayCurrency: {
-        symbol: "$",
-        minorUnitToMajorUnitOffset: 2,
-        showFractionDigits: true,
-        currencyCode: "USD",
-      },
+jest.mock("@app/hooks/use-display-currency", () => {
+  const currencyInfo = {
+    BTC: {
+      symbol: "",
+      minorUnitToMajorUnitOffset: 0,
+      showFractionDigits: false,
+      currencyCode: "SAT",
     },
-    formatMoneyAmount: mockFormatMoneyAmount,
-    zeroDisplayAmount: { amount: 0, currency: "DisplayCurrency", currencyCode: "USD" },
-  }),
-}))
+    USD: {
+      symbol: "$",
+      minorUnitToMajorUnitOffset: 2,
+      showFractionDigits: true,
+      currencyCode: "USD",
+    },
+    DisplayCurrency: {
+      symbol: "$",
+      minorUnitToMajorUnitOffset: 2,
+      showFractionDigits: true,
+      currencyCode: "USD",
+    },
+  }
+  const zeroDisplayAmount = {
+    amount: 0,
+    currency: "DisplayCurrency",
+    currencyCode: "USD",
+  }
+  return {
+    useDisplayCurrency: () => ({
+      currencyInfo,
+      formatMoneyAmount: mockFormatMoneyAmount,
+      zeroDisplayAmount,
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-debounce", () => ({
   useDebouncedEffect: (callback: () => void) => {
@@ -130,5 +138,52 @@ describe("AmountInputScreen", () => {
 
     const errorElement = getByTestId("error-message")
     expect(errorElement.props.children).toBe("")
+  })
+
+  it("propagates a fresh initialAmount even when focusedInput identity changes in the same commit", () => {
+    const initialFocusedInput = {
+      id: ConvertInputType.FROM,
+      currency: "BTC" as const,
+      formattedAmount: "",
+      isFocused: true,
+      amount: toBtcMoneyAmount(0),
+    }
+
+    const { rerender } = render(
+      <AmountInputScreen
+        inputValues={defaultInputValues}
+        onAmountChange={mockOnAmountChange}
+        convertMoneyAmount={mockConvertMoneyAmount}
+        onSetFormattedAmount={mockOnSetFormattedAmount}
+        focusedInput={initialFocusedInput}
+      />,
+    )
+
+    mockOnAmountChange.mockClear()
+
+    const chipAmount = toBtcMoneyAmount(25000)
+    const refocusedInput = {
+      ...initialFocusedInput,
+      amount: {
+        ...initialFocusedInput.amount,
+        currency: "USD" as const,
+        currencyCode: "USD",
+      },
+    }
+
+    rerender(
+      <AmountInputScreen
+        inputValues={defaultInputValues}
+        onAmountChange={mockOnAmountChange}
+        convertMoneyAmount={mockConvertMoneyAmount}
+        onSetFormattedAmount={mockOnSetFormattedAmount}
+        focusedInput={refocusedInput}
+        initialAmount={chipAmount}
+      />,
+    )
+
+    expect(mockOnAmountChange).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 25000 }),
+    )
   })
 })

--- a/__tests__/components/amount-input-screen.spec.tsx
+++ b/__tests__/components/amount-input-screen.spec.tsx
@@ -12,6 +12,8 @@ const mockFormatMoneyAmount = jest.fn()
 const mockOnAmountChange = jest.fn()
 const mockOnSetFormattedAmount = jest.fn()
 
+const CHIP_AMOUNT_SATS = 25000
+
 jest.mock("@app/hooks/use-display-currency", () => {
   const currencyInfo = {
     BTC: {
@@ -140,7 +142,7 @@ describe("AmountInputScreen", () => {
     expect(errorElement.props.children).toBe("")
   })
 
-  it("propagates a fresh initialAmount even when focusedInput identity changes in the same commit", () => {
+  it("propagates a fresh initialAmount even when focusedInput identity changes in the same render", () => {
     const initialFocusedInput = {
       id: ConvertInputType.FROM,
       currency: "BTC" as const,
@@ -161,7 +163,7 @@ describe("AmountInputScreen", () => {
 
     mockOnAmountChange.mockClear()
 
-    const chipAmount = toBtcMoneyAmount(25000)
+    const chipAmount = toBtcMoneyAmount(CHIP_AMOUNT_SATS)
     const refocusedInput = {
       ...initialFocusedInput,
       amount: {
@@ -183,7 +185,10 @@ describe("AmountInputScreen", () => {
     )
 
     expect(mockOnAmountChange).toHaveBeenCalledWith(
-      expect.objectContaining({ amount: 25000 }),
+      expect.objectContaining({ amount: CHIP_AMOUNT_SATS }),
+    )
+    expect(mockOnAmountChange.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({ amount: CHIP_AMOUNT_SATS }),
     )
   })
 })

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -1744,6 +1744,20 @@ describe("Comprehensive conversion scenarios", () => {
       actions: [{ type: "typeDigits", field: "from", digits: ["4", "5", "4", "5", "5"] }],
       expectNextEnabled: true,
     },
+
+    {
+      name: "65. Enter -> toggle -> percent 25 -> validate (USD is the from wallet)",
+      options: { btcBalance: 100000, usdBalance: 50000 },
+      actions: [{ type: "toggle" }, { type: "percent", value: 25 }],
+    },
+    {
+      name: "66. Enter -> percent 25 -> percent 100 -> validate consecutive presses",
+      options: { btcBalance: 100000, usdBalance: 50000 },
+      actions: [
+        { type: "percent", value: 25 },
+        { type: "percent", value: 100 },
+      ],
+    },
   ]
 
   beforeEach(() => {
@@ -2100,5 +2114,89 @@ describe("Self-custodial conversion limits gating", () => {
     })
 
     expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(true)
+  })
+})
+
+describe("Self-custodial percentage chip happy-path", () => {
+  const selfCustodialActiveWallet = {
+    isSelfCustodial: true,
+    isReady: true,
+    needsBackendAuth: false,
+    wallets: [
+      {
+        id: "self-custodial-btc-id",
+        walletCurrency: WalletCurrency.Btc,
+        balance: { amount: 200000, currency: WalletCurrency.Btc },
+        transactions: [],
+      },
+      {
+        id: "self-custodial-usd-id",
+        walletCurrency: WalletCurrency.Usd,
+        balance: { amount: 50000, currency: WalletCurrency.Usd },
+        transactions: [],
+      },
+    ],
+    status: "Ready",
+    accountType: "SelfCustodial",
+  }
+
+  const buildMocks = () => createGraphQLMocks({ btcBalance: 200000, usdBalance: 50000 })
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockUseActiveWallet.mockReturnValue(selfCustodialActiveWallet)
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: { minFromAmount: 0, minToAmount: null },
+      loading: false,
+      error: null,
+    })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("enables Next and carries the chip amount into nav params after a percent press", async () => {
+    const Wrapper = createTestWrapper(buildMocks())
+
+    const { getByTestId } = render(
+      <Wrapper>
+        <ConversionDetailsScreen />
+      </Wrapper>,
+    )
+
+    await waitFor(() => {
+      expect(getByTestId("convert-25%")).toBeTruthy()
+    })
+
+    await act(async () => {
+      fireEvent.press(getByTestId("convert-25%"))
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(1500)
+    })
+
+    await waitFor(
+      () => {
+        expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(false)
+      },
+      { timeout: 3000 },
+    )
+
+    await act(async () => {
+      fireEvent.press(getByTestId("next-button"))
+    })
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      "conversionConfirmation",
+      expect.objectContaining({
+        fromWalletCurrency: WalletCurrency.Btc,
+        moneyAmount: expect.objectContaining({
+          currency: expect.any(String),
+          amount: expect.any(Number),
+        }),
+      }),
+    )
   })
 })

--- a/app/components/transfer-amount-input/amount-input-screen.tsx
+++ b/app/components/transfer-amount-input/amount-input-screen.tsx
@@ -164,7 +164,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
   const typingRef = useRef(false)
   const [typingState, setTypingState] = useState(false)
   const forceDebounceRef = useRef(false)
-  const initialAmountAppliedRef = useRef(false)
+  const chipAmountAppliedRef = useRef(false)
 
   const notifyTyping = useCallback(
     (typing: boolean) => {
@@ -236,7 +236,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     if (initialAmount) {
       setNumberPadAmount(initialAmount)
       forceDebounceRef.current = true
-      initialAmountAppliedRef.current = true
+      chipAmountAppliedRef.current = true
     }
   }, [initialAmount, setNumberPadAmount])
 
@@ -248,8 +248,9 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
       return
     }
 
-    const initialAmountJustApplied = initialAmountAppliedRef.current
-    initialAmountAppliedRef.current = false
+    /** Consume-once token; the initialAmount effect must stay declared before this effect so React sets it first. */
+    const chipAmountJustApplied = chipAmountAppliedRef.current
+    chipAmountAppliedRef.current = false
 
     prevFocusSigRef.current = focusSig
     skipNextRecalcRef.current = true
@@ -265,13 +266,15 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
       currencyInfo,
     })
 
+    /** Sticky until the next debounce: set on chip-apply and focus changes, cleared only when the debounce fires. */
     forceDebounceRef.current =
-      initialAmountJustApplied ||
+      chipAmountJustApplied ||
       forceDebounceRef.current ||
       currentAmountFromNp.amount !== focusedInput.amount.amount ||
       currentAmountFromNp.currency !== focusedInput.amount.currency
 
-    if (initialAmountJustApplied) return
+    /** Number pad already holds the chip amount; bail before the focus reset and let the forced debounce re-push formatting instead of clobbering it to 0. */
+    if (chipAmountJustApplied) return
 
     setNumberPadAmount(focusedInput.amount)
 
@@ -480,7 +483,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
       onAmountChange(primaryAmount)
       notifyTyping(false)
       forceDebounceRef.current = false
-      initialAmountAppliedRef.current = false
+      chipAmountAppliedRef.current = false
       onAfterRecalc?.()
     },
     debounceMs,

--- a/app/components/transfer-amount-input/amount-input-screen.tsx
+++ b/app/components/transfer-amount-input/amount-input-screen.tsx
@@ -164,6 +164,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
   const typingRef = useRef(false)
   const [typingState, setTypingState] = useState(false)
   const forceDebounceRef = useRef(false)
+  const initialAmountAppliedRef = useRef(false)
 
   const notifyTyping = useCallback(
     (typing: boolean) => {
@@ -235,6 +236,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     if (initialAmount) {
       setNumberPadAmount(initialAmount)
       forceDebounceRef.current = true
+      initialAmountAppliedRef.current = true
     }
   }, [initialAmount, setNumberPadAmount])
 
@@ -245,6 +247,9 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     if (prevFocusSigRef.current === focusSig) {
       return
     }
+
+    const initialAmountJustApplied = initialAmountAppliedRef.current
+    initialAmountAppliedRef.current = false
 
     prevFocusSigRef.current = focusSig
     skipNextRecalcRef.current = true
@@ -261,8 +266,12 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
     })
 
     forceDebounceRef.current =
+      initialAmountJustApplied ||
+      forceDebounceRef.current ||
       currentAmountFromNp.amount !== focusedInput.amount.amount ||
       currentAmountFromNp.currency !== focusedInput.amount.currency
+
+    if (initialAmountJustApplied) return
 
     setNumberPadAmount(focusedInput.amount)
 
@@ -471,6 +480,7 @@ export const AmountInputScreen: React.FC<AmountInputScreenProps> = ({
       onAmountChange(primaryAmount)
       notifyTyping(false)
       forceDebounceRef.current = false
+      initialAmountAppliedRef.current = false
       onAfterRecalc?.()
     },
     debounceMs,


### PR DESCRIPTION
## Result

Pressing a percentage chip (25 / 50 / 75 / 100%) on the conversion screen now applies the amount and clears the loading state correctly, even on a fresh entry without any prior typing in the input. The bug affected both custodial and self-custodial accounts.

Before the fix the chip showed an indefinite spinner and the amount never reached the inputs on the fresh-entry path. After the fix the full cycle completes within the normal debounce window (~1s) and the converted value renders in the other input as expected.