### PR TITLE
fix(deps): override shell-quote to ^1.8.4 to clear critical audit advisory


### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,7 @@
     "form-data": "^4.0.4",
     "pbkdf2": "^3.1.3",
     "sha.js": "^2.4.12",
+    "shell-quote": "^1.8.4",
     "@react-native/codegen": "0.85.3",
     "handlebars": ">=4.7.9",
     "protobufjs": ">=7.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24826,10 +24826,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.7.3:
-  version "1.8.1"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
-  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+shell-quote@^1.6.1, shell-quote@^1.7.2, shell-quote@^1.7.3, shell-quote@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel@^1.0.4, side-channel@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
## Summary

The CI `Audit` check (`make audit`) was failing on every branch due to a **critical** advisory in the transitive dependency `shell-quote` (`<=1.8.3`, patched in `1.8.4`). It is pulled in only by build/dev/test tooling, so no PR introduced it — it blocks the whole repo until pinned.

## Changes

- Added `"shell-quote": "^1.8.4"` to `resolutions` in `package.json`.
- Regenerated `yarn.lock` so every consumer resolves to `1.8.4`.

## Notes

- `shell-quote` is transitive only, via build/dev/test tooling — `npm-run-all`, `@react-native-community/cli-tools` (run-android/ios, doctor, clean), `@graphql-codegen/cli`, `detox`, `react-devtools-core`. None ship in the app bundle.
- All existing requested ranges (`^1.6.1`, `^1.7.2`, `^1.7.3`) are satisfied by `1.8.4`, so the override forces no incompatible version on any consumer.
- Patch-level bump (`1.8.1` → `1.8.4`) within `1.8.x`: security fixes only, semver-compatible.
- `make audit` now exits `0` (_No critical vulnerabilities found_).