### PR TITLE
feat(send): show the payment note on the success screen

### DIFF
--- a/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
@@ -314,6 +314,139 @@ describe("SendBitcoinCompletedScreen", () => {
     expect(screen.getByText(`${plaintext} ${description}`)).toBeTruthy()
   })
 
+  it("renders the sender's note for a regular payment with no success action", async () => {
+    const note = "Dinner split with Alice"
+    const regularPaymentRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        note,
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "alice",
+        paymentType: "intraledger",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <SuccessAction route={regularPaymentRoute} />
+      </ContextForScreen>,
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(2300)
+    })
+
+    expect(screen.getByText(LL.SendBitcoinScreen.noteLabel())).toBeTruthy()
+    expect(screen.getByText(note)).toBeTruthy()
+  })
+
+  it("prefers the success action over the sender's note when both are present", async () => {
+    const note = "Private memo to self"
+    const successMessage = "Thanks for your support."
+    const bothRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        successAction: {
+          tag: "message",
+          description: "",
+          url: null,
+          message: successMessage,
+          ciphertext: null,
+          iv: null,
+          decipher: () => null,
+        },
+        note,
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "moises",
+        paymentType: "lnurl",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <SuccessAction route={bothRoute} />
+      </ContextForScreen>,
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(2300)
+    })
+
+    expect(screen.getByText(successMessage)).toBeTruthy()
+    expect(screen.queryByText(note)).toBeNull()
+  })
+
+  it("hides the Note when there is neither a note nor a success action", async () => {
+    const noNoteRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "bob",
+        paymentType: "onchain",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <SuccessAction route={noNoteRoute} />
+      </ContextForScreen>,
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(2300)
+    })
+
+    expect(screen.queryByText(LL.SendBitcoinScreen.noteLabel())).toBeNull()
+  })
+
+  it("treats a whitespace-only note as empty and hides the Note", async () => {
+    const whitespaceNoteRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        note: "   ",
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "carol",
+        paymentType: "intraledger",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <SuccessAction route={whitespaceNoteRoute} />
+      </ContextForScreen>,
+    )
+
+    act(() => {
+      jest.advanceTimersByTime(2300)
+    })
+
+    expect(screen.queryByText(LL.SendBitcoinScreen.noteLabel())).toBeNull()
+  })
+
   describe("ViewShot background color for screenshot", () => {
     const successRoute = {
       key: "sendBitcoinCompleted",

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -490,7 +490,8 @@ describe("SendBitcoinConfirmationScreen", () => {
         }
         const routes = action.payload?.routes ?? action.routes ?? []
         const completed = routes.find((r) => r.name === "sendBitcoinCompleted")
-        if (completed) return completed.params as { successAction?: unknown }
+        if (completed)
+          return completed.params as { successAction?: unknown; note?: unknown }
       }
       throw new Error("sendBitcoinCompleted route was not dispatched")
     }
@@ -558,6 +559,38 @@ describe("SendBitcoinConfirmationScreen", () => {
 
       const params = findCompletedRouteParams()
       expect(params.successAction).toEqual(successActionMessageMock)
+    })
+
+    it("forwards the payment memo as the note to the completed screen", async () => {
+      const memo = "Dinner split with Alice"
+      const { createLnurlPaymentDetails } = PaymentDetailsLightning
+      const paymentDetailWithMemo = {
+        ...createLnurlPaymentDetails(defaultLightningParams),
+        memo,
+      }
+      const routeWithMemo = {
+        key: "sendBitcoinConfirmationScreen",
+        name: "sendBitcoinConfirmation",
+        params: { paymentDetail: paymentDetailWithMemo },
+      } as const
+
+      sendPaymentMock.mockResolvedValueOnce({
+        status: "SUCCESS",
+        extraInfo: { preimage: "p" },
+      })
+
+      render(
+        <ContextForScreen>
+          <LightningLnURL route={routeWithMemo} />
+        </ContextForScreen>,
+      )
+
+      await act(async () => {
+        fireEvent.press(screen.getByTestId("slider"))
+      })
+
+      const params = findCompletedRouteParams()
+      expect(params.note).toBe(memo)
     })
   })
 })

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -69,6 +69,7 @@ export type RootStackParamList = {
     status: PaymentSendCompletedStatus
     successAction?: LNURLPaySuccessAction
     preimage?: string
+    note?: string
     currencyAmount?: string
     satAmount?: string
     currencyFeeAmount?: string

--- a/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
@@ -309,6 +309,7 @@ const SendBitcoinCompletedScreen: React.FC<Props> = ({ route }) => {
     status: statusRaw,
     successAction,
     preimage,
+    note,
     currencyAmount,
     satAmount,
     currencyFeeAmount,
@@ -332,7 +333,9 @@ const SendBitcoinCompletedScreen: React.FC<Props> = ({ route }) => {
 
   const status = processStatus({ arrivalAtMempoolEstimate, status: statusRaw })
   const usernameTitle = data?.me?.username || LL.common.blinkUser()
-  const noteMessage = useSuccessMessage(successAction, preimage)
+  const successActionMessage = useSuccessMessage(successAction, preimage)
+  /** The Note shows the LNURL success action if present, otherwise the payment memo. */
+  const noteMessage = successActionMessage || note?.trim() || ""
   const Logo = mode === "dark" ? LogoDarkMode : LogoLightMode
 
   const { requestFeedback, showSuggestionModal, setShowSuggestionModal } =

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -226,6 +226,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
                 status,
                 successAction: extraInfo?.successAction ?? paymentDetail?.successAction,
                 preimage: extraInfo?.preimage,
+                note,
                 currencyAmount,
                 satAmount,
                 currencyFeeAmount,
@@ -297,6 +298,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     satAmount,
     currencyFeeAmount,
     satFeeAmount,
+    note,
     translateSdkError,
   ])
 


### PR DESCRIPTION
## Summary

Extends the send success screen so its **Note** also shows the payment memo for regular payments (Blink to Blink, Lightning invoices, on-chain), in addition to the existing LNURL success action. Works for both custodial and self-custodial. Closes blinkbitcoin/blink-wip#733.

## Changes

- Added an optional `note` to the `sendBitcoinCompleted` route params.
- The confirmation screen now forwards `note` (the payment memo) to the success screen.
- The success screen renders `noteMessage = successActionMessage || note`: the LNURL success action keeps priority, falling back to the payment memo. Reuses the existing `NoteSection`, with no custody branching.

## Notes

- **Not a regression.** The success screen only ever rendered the LNURL success action (LUD-09 message/url, LUD-10 aes) as its Note; the user's memo was never forwarded. Confirmed across the `sendBitcoinCompleted` param-type history. Showing the memo for regular payments is a new extension.
- The memo already appeared on the transaction history detail screen; this brings parity to the shareable success screen.
- Custody-agnostic: the memo is provided by each adapter's `paymentDetail.memo`; no `else`, no nested ternaries.
- Tests: 4 new cases on the success screen (note only, success-action precedence over note, neither hidden, whitespace hidden) plus one asserting the confirmation screen forwards `note`. Verified on device for both an LNURL pay and a regular Lightning invoice carrying a description.