### PR TITLE
fix(self-custodial): Not Authorized on send to a Blink Lightning Address, plus account-resolution fixes

### DIFF
--- a/__tests__/payment-destination/resolve-destination.integration.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.integration.spec.ts
@@ -1,0 +1,86 @@
+import { getParams } from "js-lnurl"
+import { requestPayServiceParams } from "lnurl-pay"
+
+import { Network } from "@app/graphql/generated"
+import { resolveDestination } from "@app/screens/send-bitcoin-screen/payment-destination/resolve-destination"
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
+// Real parser + LNURL resolution; only the network boundaries are mocked.
+jest.mock("js-lnurl", () => ({
+  ...jest.requireActual("js-lnurl"),
+  getParams: jest.fn(),
+}))
+jest.mock("lnurl-pay", () => ({
+  ...jest.requireActual("lnurl-pay"),
+  requestPayServiceParams: jest.fn(),
+}))
+
+const mockParseSparkAddress = jest.fn()
+jest.mock("@app/self-custodial/bridge", () => ({
+  parseSparkAddress: (...args: unknown[]) => mockParseSparkAddress(...args),
+}))
+
+const mockWrapDestination = jest.fn()
+jest.mock("@app/self-custodial/payment-details/wrap-destination", () => ({
+  wrapDestination: (...args: unknown[]) => mockWrapDestination(...args),
+}))
+
+// Payment-detail builders are lazy (createPaymentDetail closures); stub them so the
+// real parser graph loads without pulling the heavy detail factories.
+jest.mock("@app/screens/send-bitcoin-screen/payment-details", () => ({
+  createIntraledgerPaymentDetails: jest.fn(),
+  createLnurlPaymentDetails: jest.fn(),
+}))
+
+const mockGetParams = getParams as jest.MockedFunction<typeof getParams>
+const mockRequestPayServiceParams = requestPayServiceParams as jest.MockedFunction<
+  typeof requestPayServiceParams
+>
+
+describe("resolveDestination (integration: real parser)", () => {
+  const fakeSdk = { id: "sdk" } as never
+  const lnAddressHostname = "blink.sv"
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockParseSparkAddress.mockResolvedValue(null)
+    mockWrapDestination.mockImplementation((result) => result)
+    mockGetParams.mockResolvedValue({} as never)
+    mockRequestPayServiceParams.mockResolvedValue({
+      callback: "https://blink.sv/callback",
+      fixed: false,
+      min: 1,
+      max: 1000000,
+      domain: lnAddressHostname,
+      metadata: [["text/plain", "pay esaudeveloper"]],
+      metadataHash: "hash",
+      identifier: `esaudeveloper@${lnAddressHostname}`,
+      description: "",
+      image: "",
+      commentAllowed: 0,
+      rawData: {},
+    } as never)
+  })
+
+  it("routes a self-custodial send to a bare username through LNURL, not the custodial intraledger path", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+
+    const result = await resolveDestination(
+      {
+        rawInput: "esaudeveloper",
+        myWalletIds: ["my-wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: [],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+      },
+      fakeSdk,
+      lnAddressHostname,
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+    expect(mockWrapDestination).toHaveBeenCalled()
+  })
+})

--- a/__tests__/payment-destination/resolve-destination.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.spec.ts
@@ -7,6 +7,7 @@ const mockParseDestination = jest.fn()
 const mockParseSparkAddress = jest.fn()
 const mockResolveSparkDestination = jest.fn()
 const mockWrapDestination = jest.fn()
+const mockResolveUsername = jest.fn()
 
 jest.mock("@app/screens/send-bitcoin-screen/payment-destination/index", () => ({
   parseDestination: (...args: unknown[]) => mockParseDestination(...args),
@@ -22,6 +23,7 @@ jest.mock("@app/self-custodial/bridge", () => ({
 
 jest.mock("@app/self-custodial/payment-details/wrap-destination", () => ({
   wrapDestination: (...args: unknown[]) => mockWrapDestination(...args),
+  resolveUsername: (...args: unknown[]) => mockResolveUsername(...args),
 }))
 
 const baseParams = {
@@ -32,6 +34,7 @@ const baseParams = {
   accountDefaultWalletQuery: jest.fn() as never,
 }
 
+const lnAddressHostname = "blink.sv"
 const fakeSdk = { id: "sdk" } as never
 
 describe("resolveDestination", () => {
@@ -44,9 +47,10 @@ describe("resolveDestination", () => {
       const parsed = { valid: true, validDestination: { paymentType: "Lightning" } }
       mockParseDestination.mockResolvedValue(parsed)
 
-      const result = await resolveDestination(baseParams, null)
+      const result = await resolveDestination(baseParams, null, lnAddressHostname)
 
       expect(mockParseSparkAddress).not.toHaveBeenCalled()
+      expect(mockResolveUsername).not.toHaveBeenCalled()
       expect(mockWrapDestination).not.toHaveBeenCalled()
       expect(result).toBe(parsed)
     })
@@ -54,7 +58,7 @@ describe("resolveDestination", () => {
     it("does not attempt the Spark pre-check when sdk is null", async () => {
       mockParseDestination.mockResolvedValue({ valid: false })
 
-      await resolveDestination(baseParams, null)
+      await resolveDestination(baseParams, null, lnAddressHostname)
 
       expect(mockParseSparkAddress).not.toHaveBeenCalled()
     })
@@ -73,37 +77,68 @@ describe("resolveDestination", () => {
       const result = await resolveDestination(
         { ...baseParams, rawInput: "sp1qabc" },
         fakeSdk,
+        lnAddressHostname,
       )
 
       expect(mockParseSparkAddress).toHaveBeenCalledWith(fakeSdk, "sp1qabc")
       expect(mockResolveSparkDestination).toHaveBeenCalledWith(sparkParsed)
       expect(mockWrapDestination).toHaveBeenCalledWith(sparkResolved, fakeSdk)
       expect(mockParseDestination).not.toHaveBeenCalled()
+      expect(mockResolveUsername).not.toHaveBeenCalled()
       expect(result).toBe(wrapped)
     })
 
-    it("falls back to parseDestination + wrap when not a Spark address", async () => {
-      const parsed = { valid: true, validDestination: { paymentType: "Lightning" } }
-      const wrapped = { ...parsed, createPaymentDetail: jest.fn() }
+    it("resolves the parsed destination via resolveUsername, then wraps it", async () => {
+      const parsed = { valid: true, validDestination: { paymentType: "Intraledger" } }
+      const resolved = { valid: true, validDestination: { paymentType: "Lnurl" } }
+      const wrapped = { ...resolved, createPaymentDetail: jest.fn() }
 
       mockParseSparkAddress.mockResolvedValue(null)
       mockParseDestination.mockResolvedValue(parsed)
+      mockResolveUsername.mockResolvedValue(resolved)
       mockWrapDestination.mockReturnValue(wrapped)
 
-      const result = await resolveDestination(baseParams, fakeSdk)
+      const result = await resolveDestination(baseParams, fakeSdk, lnAddressHostname)
 
       expect(mockParseDestination).toHaveBeenCalledWith(baseParams)
-      expect(mockWrapDestination).toHaveBeenCalledWith(parsed, fakeSdk)
+      expect(mockResolveUsername).toHaveBeenCalledWith(
+        parsed,
+        lnAddressHostname,
+        expect.any(Function),
+      )
+      expect(mockWrapDestination).toHaveBeenCalledWith(resolved, fakeSdk)
       expect(result).toBe(wrapped)
     })
 
-    it("wraps invalid parsed destinations too (wrapDestination decides what to do)", async () => {
+    it("injects a re-parse callback that re-parses the Lightning Address against the same params", async () => {
+      const parsed = { valid: true, validDestination: { paymentType: "Intraledger" } }
+
+      mockParseSparkAddress.mockResolvedValue(null)
+      mockParseDestination.mockResolvedValue(parsed)
+      mockResolveUsername.mockResolvedValue(parsed)
+      mockWrapDestination.mockReturnValue(parsed)
+
+      await resolveDestination(baseParams, fakeSdk, lnAddressHostname)
+
+      const resolveLnAddress = mockResolveUsername.mock.calls[0][2]
+      mockParseDestination.mockClear()
+      await resolveLnAddress("esaudeveloper@blink.sv")
+
+      expect(mockParseDestination).toHaveBeenCalledWith({
+        ...baseParams,
+        rawInput: "esaudeveloper@blink.sv",
+      })
+    })
+
+    it("wraps whatever resolveUsername returns, including invalid results", async () => {
       const invalid = { valid: false, invalidReason: "UnknownDestination" }
+
       mockParseSparkAddress.mockResolvedValue(null)
       mockParseDestination.mockResolvedValue(invalid)
+      mockResolveUsername.mockResolvedValue(invalid)
       mockWrapDestination.mockReturnValue(invalid)
 
-      const result = await resolveDestination(baseParams, fakeSdk)
+      const result = await resolveDestination(baseParams, fakeSdk, lnAddressHostname)
 
       expect(mockWrapDestination).toHaveBeenCalledWith(invalid, fakeSdk)
       expect(result).toBe(invalid)

--- a/__tests__/payment-destination/resolve-destination.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.spec.ts
@@ -23,8 +23,14 @@ jest.mock("@app/self-custodial/bridge", () => ({
 
 jest.mock("@app/self-custodial/payment-details/wrap-destination", () => ({
   wrapDestination: (...args: unknown[]) => mockWrapDestination(...args),
-  resolveUsername: (...args: unknown[]) => mockResolveUsername(...args),
 }))
+
+jest.mock(
+  "@app/screens/send-bitcoin-screen/payment-destination/resolve-username",
+  () => ({
+    resolveUsername: (...args: unknown[]) => mockResolveUsername(...args),
+  }),
+)
 
 const baseParams = {
   rawInput: "lnbc1...",

--- a/__tests__/payment-destination/resolve-username.spec.ts
+++ b/__tests__/payment-destination/resolve-username.spec.ts
@@ -1,0 +1,76 @@
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
+import { resolveUsername } from "@app/screens/send-bitcoin-screen/payment-destination/resolve-username"
+
+const createValidResult = (paymentType: PaymentType, extra = {}) =>
+  ({
+    valid: true,
+    destinationDirection: "Send",
+    validDestination: { paymentType, ...extra },
+  }) as never
+
+describe("resolveUsername", () => {
+  const lnAddressHostname = "blink.sv"
+
+  it("re-resolves a bare username as a Lightning Address via the injected resolver", async () => {
+    const intraledger = createValidResult(PaymentType.Intraledger, {
+      handle: "esaudeveloper",
+    })
+    const lnurl = createValidResult(PaymentType.Lnurl, {
+      lnurl: "esaudeveloper@blink.sv",
+    })
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("re-resolves an intraledger-with-flag handle (USD) the same way, stripped to the bare username", async () => {
+    const intraledger = createValidResult(PaymentType.IntraledgerWithFlag, {
+      handle: "esaudeveloper",
+    })
+    const lnurl = createValidResult(PaymentType.Lnurl, {})
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("passes a Lnurl destination through unchanged (no re-resolution)", async () => {
+    const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "alice@blink.sv" })
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(lnurl, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(lnurl)
+  })
+
+  it("passes invalid destinations through unchanged", async () => {
+    const invalid = { valid: false } as never
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(invalid)
+  })
+
+  it("passes Receive-direction destinations through unchanged", async () => {
+    const receive = {
+      valid: true,
+      destinationDirection: "Receive",
+      validDestination: { paymentType: PaymentType.Intraledger, handle: "esaudeveloper" },
+    } as never
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(receive, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(receive)
+  })
+})

--- a/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-screen/scanning-qrcode-screen.spec.tsx
@@ -140,6 +140,7 @@ describe("ScanningQRCodeScreen", () => {
     expect(mockResolveDestination).toHaveBeenCalledWith(
       expect.objectContaining({ rawInput: "lnbc1qrcode", inputSource: "qr" }),
       null,
+      "blink.sv",
     )
   })
 
@@ -160,6 +161,7 @@ describe("ScanningQRCodeScreen", () => {
     expect(mockResolveDestination).toHaveBeenCalledWith(
       expect.objectContaining({ rawInput: "sp1qabc" }),
       sdk,
+      "blink.sv",
     )
   })
 
@@ -179,6 +181,7 @@ describe("ScanningQRCodeScreen", () => {
     expect(mockResolveDestination).toHaveBeenCalledWith(
       expect.objectContaining({ lnurlDomains: [] }),
       expect.anything(),
+      "blink.sv",
     )
   })
 
@@ -198,6 +201,7 @@ describe("ScanningQRCodeScreen", () => {
         lnurlDomains: ["blink.sv", "blink.sv", "pay.blink.sv", "pay.bbw.sv"],
       }),
       null,
+      "blink.sv",
     )
   })
 

--- a/__tests__/screens/settings-screen/multi-account.spec.tsx
+++ b/__tests__/screens/settings-screen/multi-account.spec.tsx
@@ -29,6 +29,7 @@ jest.mock("@app/utils/storage/secureStorage", () => ({
 }))
 
 const mockSaveProfile = jest.fn()
+let mockAppConfigToken = "mock-token-1"
 
 jest.mock("@app/hooks", () => ({
   useAppConfig: () => ({
@@ -36,7 +37,7 @@ jest.mock("@app/hooks", () => ({
       galoyInstance: {
         authUrl: "https://api.blink.sv",
       },
-      token: "mock-token-1",
+      token: mockAppConfigToken,
     },
   }),
   useSaveSessionProfile: () => ({
@@ -50,6 +51,8 @@ describe("Settings", () => {
   beforeEach(() => {
     loadLocale("en")
     LL = i18nObject("en")
+    mockAppConfigToken = "mock-token-1"
+    mockSaveProfile.mockClear()
   })
 
   it("Switch account shows user profiles", async () => {
@@ -70,5 +73,21 @@ describe("Settings", () => {
     const profiles = await KeyStoreWrapper.getSessionProfiles()
     expect(profiles).toEqual(expectedProfiles)
     expect(screen.getByTestId(LL.ProfileScreen.addAccount())).toBeTruthy()
+  })
+
+  it("shows stored custodial profiles even with no current token (self-custodial active)", async () => {
+    mockAppConfigToken = ""
+    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockResolvedValue(expectedProfiles)
+
+    render(
+      <ContextForScreen>
+        <SwitchAccountComponent />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("TestUser")).toBeTruthy()
+    })
+    expect(mockSaveProfile).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/screens/settings-screen/multi-account.spec.tsx
+++ b/__tests__/screens/settings-screen/multi-account.spec.tsx
@@ -3,6 +3,7 @@ import { render, waitFor, screen } from "@testing-library/react-native"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 import { SwitchAccountComponent } from "@app/screens/settings-screen/account/multi-account/switch-account.stories"
+import { fetchProfiles } from "@app/screens/settings-screen/account/multi-account/utils"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 import { ContextForScreen } from "../helper"
 
@@ -89,5 +90,41 @@ describe("Settings", () => {
       expect(screen.getByText("TestUser")).toBeTruthy()
     })
     expect(mockSaveProfile).not.toHaveBeenCalled()
+  })
+
+  it("saves the active custodial profile when a token is present and none are stored yet", async () => {
+    mockAppConfigToken = "mock-token-1"
+    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(expectedProfiles)
+
+    render(
+      <ContextForScreen>
+        <SwitchAccountComponent />
+      </ContextForScreen>,
+    )
+
+    await waitFor(() => {
+      expect(mockSaveProfile).toHaveBeenCalledWith("mock-token-1")
+    })
+  })
+})
+
+describe("fetchProfiles", () => {
+  it("marks no profile as selected when there is no current token", async () => {
+    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockResolvedValue(expectedProfiles)
+
+    const profiles = await fetchProfiles("")
+
+    expect(profiles).toHaveLength(1)
+    expect(profiles.some((profile) => profile.selected)).toBe(false)
+  })
+
+  it("marks only the profile whose token matches the current token as selected", async () => {
+    ;(KeyStoreWrapper.getSessionProfiles as jest.Mock).mockResolvedValue(expectedProfiles)
+
+    const profiles = await fetchProfiles("mock-token-1")
+
+    expect(profiles[0].selected).toBe(true)
   })
 })

--- a/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
+++ b/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
@@ -1,10 +1,7 @@
 import { WalletCurrency } from "@app/graphql/generated"
 import { PaymentType } from "@blinkbitcoin/blink-client"
 
-import {
-  resolveUsername,
-  wrapDestination,
-} from "@app/self-custodial/payment-details/wrap-destination"
+import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destination"
 
 const mockCreateLightning = jest.fn().mockReturnValue({ paymentType: "lightning" })
 const mockCreateOnchain = jest.fn().mockReturnValue({ paymentType: "onchain" })
@@ -198,71 +195,5 @@ describe("wrapDestination", () => {
     expect(originalCreatePaymentDetail).toHaveBeenCalled()
     expect(mockCreateLightning).not.toHaveBeenCalled()
     expect(mockCreateOnchain).not.toHaveBeenCalled()
-  })
-})
-
-describe("resolveUsername", () => {
-  const lnAddressHostname = "blink.sv"
-
-  it("re-resolves a bare username as a Lightning Address via the injected resolver", async () => {
-    const intraledger = createValidResult(PaymentType.Intraledger, {
-      handle: "esaudeveloper",
-    })
-    const lnurl = createValidResult(PaymentType.Lnurl, {
-      lnurl: "esaudeveloper@blink.sv",
-    })
-    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
-
-    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
-    expect(result).toBe(lnurl)
-  })
-
-  it("re-resolves an intraledger-with-flag handle (USD) the same way, stripped to the bare username", async () => {
-    const intraledger = createValidResult(PaymentType.IntraledgerWithFlag, {
-      handle: "esaudeveloper",
-    })
-    const lnurl = createValidResult(PaymentType.Lnurl, {})
-    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
-
-    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
-    expect(result).toBe(lnurl)
-  })
-
-  it("passes a Lnurl destination through unchanged (no re-resolution)", async () => {
-    const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "alice@blink.sv" })
-    const resolveLnAddress = jest.fn()
-
-    const result = await resolveUsername(lnurl, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).not.toHaveBeenCalled()
-    expect(result).toBe(lnurl)
-  })
-
-  it("passes invalid destinations through unchanged", async () => {
-    const invalid = { valid: false } as never
-    const resolveLnAddress = jest.fn()
-
-    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).not.toHaveBeenCalled()
-    expect(result).toBe(invalid)
-  })
-
-  it("passes Receive-direction destinations through unchanged", async () => {
-    const receive = {
-      valid: true,
-      destinationDirection: "Receive",
-      validDestination: { paymentType: PaymentType.Intraledger, handle: "esaudeveloper" },
-    } as never
-    const resolveLnAddress = jest.fn()
-
-    const result = await resolveUsername(receive, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).not.toHaveBeenCalled()
-    expect(result).toBe(receive)
   })
 })

--- a/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
+++ b/__tests__/self-custodial/payment-details/wrap-destination.spec.ts
@@ -1,7 +1,10 @@
 import { WalletCurrency } from "@app/graphql/generated"
 import { PaymentType } from "@blinkbitcoin/blink-client"
 
-import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destination"
+import {
+  resolveUsername,
+  wrapDestination,
+} from "@app/self-custodial/payment-details/wrap-destination"
 
 const mockCreateLightning = jest.fn().mockReturnValue({ paymentType: "lightning" })
 const mockCreateOnchain = jest.fn().mockReturnValue({ paymentType: "onchain" })
@@ -195,5 +198,71 @@ describe("wrapDestination", () => {
     expect(originalCreatePaymentDetail).toHaveBeenCalled()
     expect(mockCreateLightning).not.toHaveBeenCalled()
     expect(mockCreateOnchain).not.toHaveBeenCalled()
+  })
+})
+
+describe("resolveUsername", () => {
+  const lnAddressHostname = "blink.sv"
+
+  it("re-resolves a bare username as a Lightning Address via the injected resolver", async () => {
+    const intraledger = createValidResult(PaymentType.Intraledger, {
+      handle: "esaudeveloper",
+    })
+    const lnurl = createValidResult(PaymentType.Lnurl, {
+      lnurl: "esaudeveloper@blink.sv",
+    })
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("re-resolves an intraledger-with-flag handle (USD) the same way, stripped to the bare username", async () => {
+    const intraledger = createValidResult(PaymentType.IntraledgerWithFlag, {
+      handle: "esaudeveloper",
+    })
+    const lnurl = createValidResult(PaymentType.Lnurl, {})
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(intraledger, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("esaudeveloper@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("passes a Lnurl destination through unchanged (no re-resolution)", async () => {
+    const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "alice@blink.sv" })
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(lnurl, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(lnurl)
+  })
+
+  it("passes invalid destinations through unchanged", async () => {
+    const invalid = { valid: false } as never
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(invalid)
+  })
+
+  it("passes Receive-direction destinations through unchanged", async () => {
+    const receive = {
+      valid: true,
+      destinationDirection: "Receive",
+      validDestination: { paymentType: PaymentType.Intraledger, handle: "esaudeveloper" },
+    } as never
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(receive, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(receive)
   })
 })

--- a/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
@@ -61,6 +61,11 @@ export type ReceiveDestination = {
   destinationDirection: typeof DestinationDirection.Receive
 }
 
+export const isSendDestination = (
+  result: ParseDestinationResult,
+): result is PaymentDestination =>
+  result.valid && result.destinationDirection === DestinationDirection.Send
+
 export type InvalidDestination = {
   valid: false
   invalidPaymentDestination: ParsedPaymentDestination

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
@@ -1,24 +1,31 @@
 import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 
 import { parseSparkAddress } from "@app/self-custodial/bridge"
-import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destination"
+import {
+  resolveUsername,
+  wrapDestination,
+} from "@app/self-custodial/payment-details/wrap-destination"
 
 import { parseDestination } from "./index"
 import { type ParseDestinationParams, type ParseDestinationResult } from "./index.types"
 import { resolveSparkDestination } from "./spark"
 
-/** parseDestination + self-custodial-aware wrap when an SDK is connected. */
+/** parseDestination + self-custodial-aware resolution and wrap when an SDK is connected. */
 export const resolveDestination = async (
   params: ParseDestinationParams,
   sdk: BreezSdkInterface | null,
+  lnAddressHostname: string,
 ): Promise<ParseDestinationResult> => {
-  if (sdk) {
-    const sparkParsed = await parseSparkAddress(sdk, params.rawInput)
-    if (sparkParsed) {
-      return wrapDestination(resolveSparkDestination(sparkParsed), sdk)
-    }
+  if (!sdk) return parseDestination(params)
+
+  const sparkParsed = await parseSparkAddress(sdk, params.rawInput)
+  if (sparkParsed) {
+    return wrapDestination(resolveSparkDestination(sparkParsed), sdk)
   }
 
   const parsed = await parseDestination(params)
-  return sdk ? wrapDestination(parsed, sdk) : parsed
+  const destination = await resolveUsername(parsed, lnAddressHostname, (rawInput) =>
+    parseDestination({ ...params, rawInput }),
+  )
+  return wrapDestination(destination, sdk)
 }

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
@@ -1,14 +1,12 @@
 import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 
 import { parseSparkAddress } from "@app/self-custodial/bridge"
-import {
-  resolveUsername,
-  wrapDestination,
-} from "@app/self-custodial/payment-details/wrap-destination"
+import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destination"
 
 import { parseDestination } from "./index"
 import { type ParseDestinationParams, type ParseDestinationResult } from "./index.types"
 import { resolveSparkDestination } from "./spark"
+import { resolveUsername } from "./resolve-username"
 
 /** parseDestination + self-custodial-aware resolution and wrap when an SDK is connected. */
 export const resolveDestination = async (

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-username.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-username.ts
@@ -1,0 +1,33 @@
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
+import { getLightningAddress } from "@app/utils/pay-links"
+
+import { isSendDestination, type ParseDestinationResult } from "./index.types"
+
+const intraledgerHandle = (result: ParseDestinationResult): string | undefined => {
+  if (!isSendDestination(result)) return undefined
+  const { validDestination } = result
+  if (
+    validDestination.paymentType === PaymentType.Intraledger ||
+    validDestination.paymentType === PaymentType.IntraledgerWithFlag
+  ) {
+    return validDestination.handle
+  }
+  return undefined
+}
+
+/**
+ * Re-resolves a bare Blink username as its Lightning Address so a self-custodial
+ * account pays it over LNURL instead of the custodial intraledger mutation it has
+ * no token for. Non-username destinations pass through unchanged.
+ */
+export const resolveUsername = async (
+  result: ParseDestinationResult,
+  lnAddressHostname: string,
+  resolveLnAddress: (rawInput: string) => Promise<ParseDestinationResult>,
+): Promise<ParseDestinationResult> => {
+  const handle = intraledgerHandle(result)
+  return handle
+    ? resolveLnAddress(getLightningAddress(lnAddressHostname, handle))
+    : result
+}

--- a/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
+++ b/app/screens/send-bitcoin-screen/scanning-qrcode-screen.tsx
@@ -20,6 +20,7 @@ import {
   useAccountDefaultWalletLazyQuery,
   useRealtimePriceQuery,
 } from "@app/graphql/generated"
+import { useAppConfig } from "@app/hooks"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useScanContext } from "@app/hooks/use-scan-context"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
@@ -90,6 +91,11 @@ export const ScanningQRCodeScreen: React.FC = () => {
   const { LL } = useI18nContext()
   const { displayCurrency } = useDisplayCurrency()
   const { sdk } = useSelfCustodialWallet()
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname },
+    },
+  } = useAppConfig()
 
   React.useEffect(() => {
     if (!isFocused) {
@@ -151,6 +157,7 @@ export const ScanningQRCodeScreen: React.FC = () => {
             displayCurrency,
           },
           sdk,
+          lnAddressHostname,
         )
         logParseDestinationResult(destination)
 
@@ -264,6 +271,7 @@ export const ScanningQRCodeScreen: React.FC = () => {
     accountDefaultWalletQuery,
     displayCurrency,
     sdk,
+    lnAddressHostname,
   ])
 
   const handleCodeScanned = React.useCallback(

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -350,6 +350,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
           accountDefaultWalletQuery,
         },
         sdk,
+        lnAddressHostname,
       )
       logParseDestinationResult(wrappedDestination)
 
@@ -452,6 +453,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
       contacts,
       parseValidPhone,
       sdk,
+      lnAddressHostname,
     ],
   )
 

--- a/app/screens/settings-screen/account/multi-account/switch-account.tsx
+++ b/app/screens/settings-screen/account/multi-account/switch-account.tsx
@@ -32,12 +32,11 @@ export const SwitchAccount: React.FC = () => {
   const [nextProfileToken, setNextProfileToken] = useState<string>()
 
   useEffect(() => {
-    if (!currentToken) return
     let isMounted = true
 
     const loadProfiles = async () => {
       let profilesList = await fetchProfiles(currentToken)
-      if (profilesList.length === 0) {
+      if (profilesList.length === 0 && currentToken) {
         await saveProfile(currentToken)
         profilesList = await fetchProfiles(currentToken)
       }

--- a/app/self-custodial/payment-details/wrap-destination.ts
+++ b/app/self-custodial/payment-details/wrap-destination.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
 import { toBtcMoneyAmount } from "@app/types/amounts"
 import { PaymentType as SelfCustodialPaymentType } from "@app/types/transaction"
+import { getLightningAddress } from "@app/utils/pay-links"
 
 import { createSelfCustodialLightningPaymentDetails } from "./lightning"
 import { createSelfCustodialLnurlPaymentDetails } from "./lnurl"
@@ -159,4 +160,29 @@ export const wrapDestination = (
       }
     },
   }
+}
+
+const intraledgerHandle = (result: ParseDestinationResult): string | undefined => {
+  if (!result.valid || result.destinationDirection !== DestinationDirection.Send) {
+    return undefined
+  }
+  const { validDestination } = result
+  if (
+    validDestination.paymentType === PaymentType.Intraledger ||
+    validDestination.paymentType === PaymentType.IntraledgerWithFlag
+  ) {
+    return validDestination.handle
+  }
+  return undefined
+}
+
+export const resolveUsername = async (
+  result: ParseDestinationResult,
+  lnAddressHostname: string,
+  resolveLnAddress: (rawInput: string) => Promise<ParseDestinationResult>,
+): Promise<ParseDestinationResult> => {
+  const handle = intraledgerHandle(result)
+  return handle
+    ? resolveLnAddress(getLightningAddress(lnAddressHostname, handle))
+    : result
 }

--- a/app/self-custodial/payment-details/wrap-destination.ts
+++ b/app/self-custodial/payment-details/wrap-destination.ts
@@ -6,12 +6,11 @@ import { WalletCurrency } from "@app/graphql/generated"
 import { FeeTierOption } from "@app/screens/send-bitcoin-screen/hooks/fee-tiers.types"
 import {
   type CreatePaymentDetailParams,
-  DestinationDirection,
+  isSendDestination,
   type ParseDestinationResult,
 } from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
 import { toBtcMoneyAmount } from "@app/types/amounts"
 import { PaymentType as SelfCustodialPaymentType } from "@app/types/transaction"
-import { getLightningAddress } from "@app/utils/pay-links"
 
 import { createSelfCustodialLightningPaymentDetails } from "./lightning"
 import { createSelfCustodialLnurlPaymentDetails } from "./lnurl"
@@ -116,8 +115,7 @@ export const wrapDestination = (
   sdk: BreezSdkInterface,
   options: WrapOptions = {},
 ): ParseDestinationResult => {
-  if (!result.valid) return result
-  if (result.destinationDirection !== DestinationDirection.Send) return result
+  if (!isSendDestination(result)) return result
 
   const original = result.validDestination
 
@@ -160,29 +158,4 @@ export const wrapDestination = (
       }
     },
   }
-}
-
-const intraledgerHandle = (result: ParseDestinationResult): string | undefined => {
-  if (!result.valid || result.destinationDirection !== DestinationDirection.Send) {
-    return undefined
-  }
-  const { validDestination } = result
-  if (
-    validDestination.paymentType === PaymentType.Intraledger ||
-    validDestination.paymentType === PaymentType.IntraledgerWithFlag
-  ) {
-    return validDestination.handle
-  }
-  return undefined
-}
-
-export const resolveUsername = async (
-  result: ParseDestinationResult,
-  lnAddressHostname: string,
-  resolveLnAddress: (rawInput: string) => Promise<ParseDestinationResult>,
-): Promise<ParseDestinationResult> => {
-  const handle = intraledgerHandle(result)
-  return handle
-    ? resolveLnAddress(getLightningAddress(lnAddressHostname, handle))
-    : result
 }


### PR DESCRIPTION
## Summary

Fixes the reported "Not Authorized" when a self-custodial account sends to a Blink username, plus an account-switcher bug found alongside it.

Closes #3845

## Changes

**1. Self-custodial send to a username returned "Not Authorized"** — a bare Blink username is classified by the parser as a custodial intraledger handle (before any domain/LNURL logic and independent of the configured LN-address domains). The send then ran the custodial `intraLedgerPaymentSend` GraphQL mutation, which a self-custodial account has no JWT for, so it failed with "Not Authorized" (and showed Fee 0 SAT). For a self-custodial account, a username is now re-resolved as its Lightning Address (`username@<lnAddressHostname>`) and paid through the existing LNURL path. The pure parser stays account-agnostic and the routing lives in the self-custodial layer; the custodial flow is untouched.

**2. Custodial account missing from the account switcher** — the switcher loaded stored custodial profiles only when a custodial token was present, so a self-custodial-active user (no token) saw only their self-custodial account. Stored profiles are read from the keystore and do not need a token (it only marks which one is selected); the switcher now lists them regardless, and only persists a new profile when a token exists.

## Notes

- Custodial behavior is unchanged: the username re-routing runs only for a self-custodial account (when the Spark SDK is connected); the custodial path returns the parser output unchanged.
- The username re-resolution reuses the existing LNURL send path and the `getLightningAddress` helper, so no new destination or payment-detail shapes were introduced.
