### PR TITLE
fix(self-custodial): home intermittently shows a zero balance for a funded account

### DIFF
--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -825,4 +825,63 @@ describe("HomeScreen", () => {
       expect(lastIsVisible()).toBe(false)
     })
   })
+
+  describe("self-custodial balance loading (#3852)", () => {
+    afterEach(() => {
+      mockActiveWalletOverride = null
+    })
+
+    it("shows the loading state instead of $0.00 when the self-custodial balance failed to load", async () => {
+      mockActiveWalletOverride = {
+        wallets: [],
+        status: "error",
+        accountType: "self-custodial",
+        isReady: false,
+        isSelfCustodial: true,
+        needsBackendAuth: false,
+      }
+
+      const { queryByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      expect(queryByTestId("balance-value")).toBeNull()
+    })
+
+    it("keeps showing the balance when a later refresh goes offline and the wallets are retained", async () => {
+      mockActiveWalletOverride = {
+        wallets: [
+          {
+            id: "btc-1",
+            walletCurrency: "BTC",
+            balance: { amount: 5000, currency: "BTC", currencyCode: "BTC" },
+            transactions: [],
+          },
+          {
+            id: "usd-1",
+            walletCurrency: "USD",
+            balance: { amount: 0, currency: "USD", currencyCode: "USD" },
+            transactions: [],
+          },
+        ],
+        status: "offline",
+        accountType: "self-custodial",
+        isReady: false,
+        isSelfCustodial: true,
+        needsBackendAuth: false,
+      }
+
+      const { getByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      expect(getByTestId("balance-value")).toBeTruthy()
+    })
+  })
 })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -883,5 +883,45 @@ describe("HomeScreen", () => {
 
       expect(getByTestId("balance-value")).toBeTruthy()
     })
+
+    it("shows the loading state during an account switch, before the new wallets load", async () => {
+      mockActiveWalletOverride = {
+        wallets: [],
+        status: "loading",
+        accountType: "self-custodial",
+        isReady: false,
+        isSelfCustodial: true,
+        needsBackendAuth: false,
+      }
+
+      const { queryByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      expect(queryByTestId("balance-value")).toBeNull()
+    })
+
+    it("shows a zero balance, not a skeleton, for a ready account with no wallets", async () => {
+      mockActiveWalletOverride = {
+        wallets: [],
+        status: "ready",
+        accountType: "self-custodial",
+        isReady: true,
+        isSelfCustodial: true,
+        needsBackendAuth: false,
+      }
+
+      const { getByTestId } = render(
+        <ContextForScreen>
+          <HomeScreen />
+        </ContextForScreen>,
+      )
+      await flushEffects()
+
+      expect(getByTestId("balance-value")).toBeTruthy()
+    })
   })
 })

--- a/__tests__/self-custodial/providers/wallet.spec.tsx
+++ b/__tests__/self-custodial/providers/wallet.spec.tsx
@@ -892,6 +892,59 @@ describe("SelfCustodialWalletProvider — async ops, connectivity & polling", ()
     }
   })
 
+  it("lets a slow snapshot that resolves within the timeout finish successfully", async () => {
+    // keep setImmediate real so flushEffects settles while setTimeout stays faked for the advance
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+    try {
+      setupConnectedWallet(
+        {
+          getMnemonicForAccount: mockGetMnemonicForAccount,
+          listSelfCustodialAccounts: mockListSelfCustodialAccounts,
+          setActiveAccountId: (id: string) => {
+            mockState.activeAccountId = id
+          },
+          initSdk: mockInitSdk,
+          addSdkEventListener: mockAddSdkEventListener,
+        },
+        { wallets: [], hasMore: false },
+      )
+      const snapshot = getWalletSnapshotMocks()
+      let resolveSnapshot: (value: unknown) => void = () => {}
+      snapshot.getSelfCustodialWalletSnapshot.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSnapshot = resolve
+          }),
+      )
+
+      const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
+
+      // settle the async init so refreshWallets runs and the slow snapshot arms withTimeout
+      await flushEffects()
+
+      // 6s elapse: past the old 5s budget but within the new 10s one, so withTimeout has not aborted
+      await act(async () => {
+        jest.advanceTimersByTime(6000)
+      })
+
+      // the slow snapshot now arrives and is accepted instead of aborted
+      await act(async () => {
+        resolveSnapshot({ wallets: [{ id: "btc-1" }], hasMore: false })
+      })
+      await flushEffects()
+
+      expect(result.current.status).toBe(ActiveWalletStatus.Ready)
+      expect(result.current.wallets).toHaveLength(1)
+      expect(mockCrashlyticsRecordError).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("wallet snapshot timed out"),
+        }),
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
   it("transitions out of Loading to Error when both snapshot and connectivity check fail", async () => {
     const isOnline = jest.requireMock("@app/self-custodial/providers/is-online")
     isOnline.getOnlineState.mockResolvedValueOnce("unknown")

--- a/__tests__/self-custodial/providers/wallet.spec.tsx
+++ b/__tests__/self-custodial/providers/wallet.spec.tsx
@@ -9,6 +9,7 @@ import {
   SelfCustodialWalletProvider,
   useSelfCustodialWallet,
 } from "@app/self-custodial/providers/wallet"
+import { WALLET_SNAPSHOT_TIMEOUT_MS } from "@app/self-custodial/hooks/use-sdk-lifecycle"
 
 import { flushEffects } from "../../helpers/flush-effects"
 
@@ -844,48 +845,51 @@ describe("SelfCustodialWalletProvider — async ops, connectivity & polling", ()
   })
 
   it("recovers from a snapshot that hangs past the timeout instead of staying in Loading", async () => {
-    jest.useFakeTimers()
-    setupConnectedWallet(
-      {
-        getMnemonicForAccount: mockGetMnemonicForAccount,
-        listSelfCustodialAccounts: mockListSelfCustodialAccounts,
-        setActiveAccountId: (id: string) => {
-          mockState.activeAccountId = id
+    // keep setImmediate real so flushEffects settles while setTimeout stays faked for the advance
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+    try {
+      setupConnectedWallet(
+        {
+          getMnemonicForAccount: mockGetMnemonicForAccount,
+          listSelfCustodialAccounts: mockListSelfCustodialAccounts,
+          setActiveAccountId: (id: string) => {
+            mockState.activeAccountId = id
+          },
+          initSdk: mockInitSdk,
+          addSdkEventListener: mockAddSdkEventListener,
         },
-        initSdk: mockInitSdk,
-        addSdkEventListener: mockAddSdkEventListener,
-      },
-      { wallets: [], hasMore: false },
-    )
-    const snapshot = getWalletSnapshotMocks()
-    snapshot.getSelfCustodialWalletSnapshot.mockImplementation(
-      () =>
-        new Promise(() => {
-          // never resolves; should be aborted by the 5s timeout race
-        }),
-    )
+        { wallets: [], hasMore: false },
+      )
+      const snapshot = getWalletSnapshotMocks()
+      snapshot.getSelfCustodialWalletSnapshot.mockImplementation(
+        () =>
+          new Promise(() => {
+            // never resolves; aborted by the snapshot timeout race
+          }),
+      )
 
-    const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
+      const { result } = renderHook(() => useSelfCustodialWallet(), { wrapper })
 
-    await waitFor(() => {
-      expect(mockInitSdk).toHaveBeenCalled()
-    })
+      // settle the async init so refreshWallets runs and the hung snapshot arms withTimeout
+      await flushEffects()
 
-    await act(async () => {
-      jest.advanceTimersByTime(5_001)
-    })
+      // cross the snapshot timeout: withTimeout aborts the hung snapshot
+      await act(async () => {
+        jest.advanceTimersByTime(WALLET_SNAPSHOT_TIMEOUT_MS + 1)
+      })
 
-    await waitFor(() => {
+      // settle the catch so the status moves off Loading
+      await flushEffects()
+
       expect(result.current.status).not.toBe(ActiveWalletStatus.Loading)
-    })
-
-    expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining("wallet snapshot timed out"),
-      }),
-    )
-
-    jest.useRealTimers()
+      expect(mockCrashlyticsRecordError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("wallet snapshot timed out"),
+        }),
+      )
+    } finally {
+      jest.useRealTimers()
+    }
   })
 
   it("transitions out of Loading to Error when both snapshot and connectivity check fail", async () => {

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -83,6 +83,7 @@ export const BalanceHeader: React.FC<Props> = ({
               <Loader />
             ) : (
               <Text
+                {...testProps("balance-value")}
                 style={styles.primaryBalanceText}
                 allowFontScaling
                 adjustsFontSizeToFit

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -252,9 +252,10 @@ export const HomeScreen: React.FC = () => {
     variables: { first: 1 },
   })
 
-  // empty wallets means the balance has not loaded yet, not that it is zero
+  // not loaded yet: no wallets while not ready (a loaded account keeps its balance
+  // when a refresh goes offline, and a ready empty account shows zero, not a skeleton)
   const queryLoading = isSelfCustodial
-    ? activeWallet.wallets.length === 0
+    ? !activeWallet.isReady && activeWallet.wallets.length === 0
     : loadingAuthed || loadingPrice || loadingUnauthed || loadingSettings
 
   const { username, phone } = currentUser?.me ?? {}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -252,8 +252,9 @@ export const HomeScreen: React.FC = () => {
     variables: { first: 1 },
   })
 
+  // empty wallets means the balance has not loaded yet, not that it is zero
   const queryLoading = isSelfCustodial
-    ? activeWallet.status === "loading"
+    ? activeWallet.wallets.length === 0
     : loadingAuthed || loadingPrice || loadingUnauthed || loadingSettings
 
   const { username, phone } = currentUser?.me ?? {}

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -61,7 +61,7 @@ const OFFLINE_EXEMPT_STATUSES: readonly ActiveWalletStatus[] = [
 ]
 
 const RECONNECT_BACKOFF_MS: readonly number[] = [1000, 3000, 9000]
-const WALLET_SNAPSHOT_TIMEOUT_MS = 10000
+export const WALLET_SNAPSHOT_TIMEOUT_MS = 10000
 
 const teardownSdk = async (
   sdk: BreezSdkInterface,

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -30,7 +30,6 @@ import {
   getServiceStatus,
   isDegradedStatus,
   OnlineState,
-  STATUS_TIMEOUT_MS,
 } from "../providers/is-online"
 import {
   appendTransactions,
@@ -62,6 +61,7 @@ const OFFLINE_EXEMPT_STATUSES: readonly ActiveWalletStatus[] = [
 ]
 
 const RECONNECT_BACKOFF_MS: readonly number[] = [1000, 3000, 9000]
+const WALLET_SNAPSHOT_TIMEOUT_MS = 10000
 
 const teardownSdk = async (
   sdk: BreezSdkInterface,
@@ -113,7 +113,7 @@ export const useSdkLifecycle = (
       try {
         const snapshot = await withTimeout(
           getSelfCustodialWalletSnapshot(sdk, rawTxOffsetRef.current),
-          STATUS_TIMEOUT_MS,
+          WALLET_SNAPSHOT_TIMEOUT_MS,
           "wallet snapshot",
         )
         if (isStale()) return


### PR DESCRIPTION
## Summary

On slow connections, a funded self-custodial account could show a $0.00 balance on the home screen. The home only treated the account as loading while the SDK status said so; when the wallet snapshot did not respond within the 5s timeout, the status flipped to error/offline with the wallets not loaded yet but the price already cached, so the home rendered a real $0.00 instead of a loading state.

Closes #3852

## Changes

**1. Show a loading state instead of a false zero** — the home now keys the self-custodial loading state off whether the wallets have actually loaded (empty wallets means the balance has not loaded yet, not that it is zero) instead of the SDK status. A slow or failed snapshot now shows the balance skeleton, and once the wallets are loaded it keeps the last known balance instead of dropping to $0.00.

**2. More time to load on slow networks** — the wallet-snapshot fetch now has its own 10s timeout instead of sharing the 5s status budget, so congested connections have more time to load the balance before falling back.

## Notes

- Custodial behavior is unchanged: the loading-state change is gated to self-custodial accounts; the custodial path keeps its existing query-based loading logic.
- The snapshot timeout is a separate constant from the connectivity-probe budget, so raising it to 10s does not slow down offline detection (the probes stay at 5s).
