### PR TITLE
feat(self-custodial): register a Blink-domain lightning address via the Breez SDK

### DIFF
--- a/__mocks__/@breeztech/breez-sdk-spark-react-native.js
+++ b/__mocks__/@breeztech/breez-sdk-spark-react-native.js
@@ -83,6 +83,7 @@ module.exports = {
     IncreasedToAvoidDust: "IncreasedToAvoidDust",
   },
   PrepareSendPaymentRequest: { create: (p) => p },
+  RegisterLightningAddressRequest: { create: (p) => p },
   SendPaymentRequest: { create: (p) => p },
   SyncWalletRequest: { create: (p) => p },
   ReceivePaymentRequest: { create: (p) => p },

--- a/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
@@ -227,12 +227,15 @@ describe("ProfileRow", () => {
     })
   })
 
-  it("renders the lightning address as the row title when one is set", () => {
-    const { getByText } = render(
-      <ProfileRow entry={{ id: TEST_ENTRY_ID, lightningAddress: "alice@example.com" }} />,
+  it("renders the lightning username without the domain as the row title when one is set", () => {
+    const { getByText, queryByText } = render(
+      <ProfileRow
+        entry={{ id: TEST_ENTRY_ID, lightningAddress: "alice@lnurl.staging.blink.sv" }}
+      />,
     )
 
-    expect(getByText("alice@example.com")).toBeTruthy()
+    expect(getByText("alice")).toBeTruthy()
+    expect(queryByText("alice@lnurl.staging.blink.sv")).toBeNull()
   })
 
   it("falls back to anonymous user label when no lightning address is set", () => {
@@ -560,7 +563,7 @@ describe("ProfileRow", () => {
       <ProfileRow entry={{ id: TEST_ENTRY_ID, lightningAddress: "stale@example.com" }} />,
     )
 
-    expect(getByText("magentamouse1845@breez.tips")).toBeTruthy()
+    expect(getByText("magentamouse1845")).toBeTruthy()
   })
 
   it("ignores the live lightning address for inactive rows and uses the persisted entry value", () => {
@@ -575,6 +578,6 @@ describe("ProfileRow", () => {
       />,
     )
 
-    expect(getByText("stored@example.com")).toBeTruthy()
+    expect(getByText("stored")).toBeTruthy()
   })
 })

--- a/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
@@ -230,12 +230,12 @@ describe("ProfileRow", () => {
   it("renders the lightning username without the domain as the row title when one is set", () => {
     const { getByText, queryByText } = render(
       <ProfileRow
-        entry={{ id: TEST_ENTRY_ID, lightningAddress: "alice@lnurl.staging.blink.sv" }}
+        entry={{ id: TEST_ENTRY_ID, lightningAddress: "alice@staging.blink.sv" }}
       />,
     )
 
     expect(getByText("alice")).toBeTruthy()
-    expect(queryByText("alice@lnurl.staging.blink.sv")).toBeNull()
+    expect(queryByText("alice@staging.blink.sv")).toBeNull()
   })
 
   it("falls back to anonymous user label when no lightning address is set", () => {

--- a/__tests__/screens/settings-screen/self-custodial/set-lightning-address-modal.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/set-lightning-address-modal.spec.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { Network as mockSparkNetwork } from "@breeztech/breez-sdk-spark-react-native"
+import { render } from "@testing-library/react-native"
+
+jest.mock("react-native-config", () => ({}))
+jest.mock("react-native-fs", () => ({ DocumentDirectoryPath: "/test" }))
+
+const mockUI = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock("@app/components/set-lightning-address-modal", () => ({
+  SetLightningAddressModalUI: mockUI,
+}))
+
+const mockRegister = jest.fn()
+const mockSetLnAddress = jest.fn()
+let lastOnRegistered: () => void = () => {}
+jest.mock("@app/self-custodial/hooks/use-register-lightning-address", () => ({
+  useRegisterLightningAddress: (onRegistered: () => void) => {
+    lastOnRegistered = onRegistered
+    return {
+      lnAddress: "alice",
+      error: undefined,
+      loading: false,
+      setLnAddress: mockSetLnAddress,
+      register: mockRegister,
+    }
+  },
+}))
+
+let mockNetwork = mockSparkNetwork.Regtest
+jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
+  useSparkNetwork: () => mockNetwork,
+}))
+
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({ appConfig: { galoyInstance: { name: "Blink" } } }),
+}))
+
+import { SetSelfCustodialLightningAddressModal } from "@app/screens/settings-screen/self-custodial/set-lightning-address-modal"
+
+const lastProps = (): Record<string, unknown> =>
+  (mockUI.mock.calls.at(-1)?.[0] ?? {}) as Record<string, unknown>
+
+describe("SetSelfCustodialLightningAddressModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockNetwork = mockSparkNetwork.Regtest
+  })
+
+  it("renders the shared modal UI with the staging Blink LNURL host on regtest", () => {
+    render(<SetSelfCustodialLightningAddressModal isVisible toggleModal={jest.fn()} />)
+
+    expect(lastProps().hostname).toBe("lnurl.staging.blink.sv")
+    expect(lastProps().bankName).toBe("Blink")
+    expect(lastProps().lnAddress).toBe("alice")
+    expect(lastProps().loading).toBe(false)
+    expect(lastProps().setLnAddress).toBe(mockSetLnAddress)
+  })
+
+  it("uses the production Blink LNURL host on mainnet", () => {
+    mockNetwork = mockSparkNetwork.Mainnet
+
+    render(<SetSelfCustodialLightningAddressModal isVisible toggleModal={jest.fn()} />)
+
+    expect(lastProps().hostname).toBe("lnurl.blink.sv")
+  })
+
+  it("wires register to the primary action and passes toggleModal as the onRegistered callback", () => {
+    const toggleModal = jest.fn()
+    render(<SetSelfCustodialLightningAddressModal isVisible toggleModal={toggleModal} />)
+    ;(lastProps().onSetLightningAddress as () => void)()
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+
+    lastOnRegistered()
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/screens/settings-screen/self-custodial/set-lightning-address-modal.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/set-lightning-address-modal.spec.tsx
@@ -49,7 +49,7 @@ describe("SetSelfCustodialLightningAddressModal", () => {
   it("renders the shared modal UI with the staging Blink LNURL host on regtest", () => {
     render(<SetSelfCustodialLightningAddressModal isVisible toggleModal={jest.fn()} />)
 
-    expect(lastProps().hostname).toBe("lnurl.staging.blink.sv")
+    expect(lastProps().hostname).toBe("staging.blink.sv")
     expect(lastProps().bankName).toBe("Blink")
     expect(lastProps().lnAddress).toBe("alice")
     expect(lastProps().loading).toBe(false)
@@ -61,7 +61,7 @@ describe("SetSelfCustodialLightningAddressModal", () => {
 
     render(<SetSelfCustodialLightningAddressModal isVisible toggleModal={jest.fn()} />)
 
-    expect(lastProps().hostname).toBe("lnurl.blink.sv")
+    expect(lastProps().hostname).toBe("blink.sv")
   })
 
   it("wires register to the primary action and passes toggleModal as the onRegistered callback", () => {

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -67,7 +67,7 @@ import { AccountLNAddress } from "@app/screens/settings-screen/settings/account-
 const lastRowProps = (): Record<string, unknown> =>
   (mockSettingsRow.mock.calls.at(-1)?.[0] ?? {}) as Record<string, unknown>
 
-const SC_ADDRESS = "alice@lnurl.staging.blink.sv"
+const SC_ADDRESS = "alice@staging.blink.sv"
 
 describe("AccountLNAddress (self-custodial)", () => {
   beforeEach(() => {

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -1,0 +1,171 @@
+import React from "react"
+import { act, render } from "@testing-library/react-native"
+
+import { AccountType } from "@app/types/wallet"
+
+const mockSettingsRow = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock("@app/screens/settings-screen/row", () => ({
+  SettingsRow: mockSettingsRow,
+}))
+
+const mockScModal = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock(
+  "@app/screens/settings-screen/self-custodial/set-lightning-address-modal",
+  () => ({
+    SetSelfCustodialLightningAddressModal: mockScModal,
+  }),
+)
+
+const mockCustodialModal = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock("@app/components/set-lightning-address-modal", () => ({
+  SetLightningAddressModal: mockCustodialModal,
+}))
+
+jest.mock("@app/components/atomic/galoy-icon", () => ({
+  GaloyIcon: () => null,
+}))
+
+const mockUseAccountRegistry = jest.fn()
+jest.mock("@app/hooks/use-account-registry", () => ({
+  useAccountRegistry: () => mockUseAccountRegistry(),
+}))
+
+const mockUseSelfCustodialWallet = jest.fn()
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => mockUseSelfCustodialWallet(),
+}))
+
+const mockCopyToClipboard = jest.fn()
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({
+    appConfig: { galoyInstance: { lnAddressHostname: "blink.sv" } },
+  }),
+  useClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({ useIsAuthed: () => true }))
+const mockSettingsScreenQuery = jest.fn()
+jest.mock("@app/graphql/generated", () => ({
+  useSettingsScreenQuery: () => mockSettingsScreenQuery(),
+}))
+
+jest.mock("@rn-vui/themed", () => ({
+  useTheme: () => ({ theme: { colors: { primary: "#fc5805" } } }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      SettingsScreen: { setYourLightningAddress: () => "Set your lightning address" },
+      GaloyAddressScreen: { copiedLightningAddressToClipboard: () => "Copied" },
+    },
+  }),
+}))
+
+import { AccountLNAddress } from "@app/screens/settings-screen/settings/account-ln-address"
+
+const lastRowProps = (): Record<string, unknown> =>
+  (mockSettingsRow.mock.calls.at(-1)?.[0] ?? {}) as Record<string, unknown>
+
+const SC_ADDRESS = "alice@lnurl.staging.blink.sv"
+
+describe("AccountLNAddress (self-custodial)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSettingsScreenQuery.mockReturnValue({ data: undefined, loading: false })
+    mockUseAccountRegistry.mockReturnValue({
+      activeAccount: { id: "sc-1", type: AccountType.SelfCustodial },
+      selfCustodialEntries: [],
+    })
+  })
+
+  it("prompts to set an address and opens the modal when none is registered", () => {
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe("Set your lightning address")
+    expect(lastRowProps().rightIcon).toBeUndefined()
+    expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+    expect(mockCopyToClipboard).not.toHaveBeenCalled()
+  })
+
+  it("shows the registered address and copies it on press", () => {
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: SC_ADDRESS })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe(SC_ADDRESS)
+    expect(lastRowProps().rightIcon).toBeTruthy()
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.objectContaining({ content: SC_ADDRESS }),
+    )
+    expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+  })
+
+  it("shows the persisted address (not the set prompt) while the live address is still resolving", () => {
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+    mockUseAccountRegistry.mockReturnValue({
+      activeAccount: { id: "sc-1", type: AccountType.SelfCustodial },
+      selfCustodialEntries: [{ id: "sc-1", lightningAddress: SC_ADDRESS }],
+    })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe(SC_ADDRESS)
+    expect(lastRowProps().rightIcon).toBeTruthy()
+  })
+})
+
+describe("AccountLNAddress (custodial)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+    mockUseAccountRegistry.mockReturnValue({
+      activeAccount: { id: "cust-1", type: AccountType.Custodial },
+    })
+  })
+
+  it("prompts to set an address and opens the custodial modal when there is no username", () => {
+    mockSettingsScreenQuery.mockReturnValue({
+      data: { me: { username: null } },
+      loading: false,
+    })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe("Set your lightning address")
+    expect(lastRowProps().rightIcon).toBeUndefined()
+    expect(mockCustodialModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockCustodialModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+    expect(mockCopyToClipboard).not.toHaveBeenCalled()
+  })
+
+  it("shows the username@host address and copies it on press", () => {
+    mockSettingsScreenQuery.mockReturnValue({
+      data: { me: { username: "bob" } },
+      loading: false,
+    })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe("bob@blink.sv")
+    expect(lastRowProps().rightIcon).toBeTruthy()
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "bob@blink.sv" }),
+    )
+  })
+})

--- a/__tests__/self-custodial/bridge/lifecycle.spec.ts
+++ b/__tests__/self-custodial/bridge/lifecycle.spec.ts
@@ -119,7 +119,7 @@ describe("initSdk", () => {
         seed: expect.objectContaining({ tag: "Mnemonic", mnemonic: "word1 word2 word3" }),
         config: expect.objectContaining({
           apiKey: "test-api-key",
-          lnurlDomain: "lnurl.staging.blink.sv",
+          lnurlDomain: "staging.blink.sv",
         }),
       }),
     )

--- a/__tests__/self-custodial/bridge/lifecycle.spec.ts
+++ b/__tests__/self-custodial/bridge/lifecycle.spec.ts
@@ -117,7 +117,10 @@ describe("initSdk", () => {
     expect(mockConnect).toHaveBeenCalledWith(
       expect.objectContaining({
         seed: expect.objectContaining({ tag: "Mnemonic", mnemonic: "word1 word2 word3" }),
-        config: expect.objectContaining({ apiKey: "test-api-key" }),
+        config: expect.objectContaining({
+          apiKey: "test-api-key",
+          lnurlDomain: "lnurl.staging.blink.sv",
+        }),
       }),
     )
     expect(result).toBe(sdk)

--- a/__tests__/self-custodial/bridge/wallet.spec.ts
+++ b/__tests__/self-custodial/bridge/wallet.spec.ts
@@ -64,7 +64,7 @@ describe("registerLightningAddress", () => {
   it("forwards the username and description and returns the address info", async () => {
     const register = jest
       .fn()
-      .mockResolvedValue({ lightningAddress: "alice@lnurl.staging.blink.sv" })
+      .mockResolvedValue({ lightningAddress: "alice@staging.blink.sv" })
 
     const result = await registerLightningAddress(
       { registerLightningAddress: register } as never,
@@ -72,6 +72,6 @@ describe("registerLightningAddress", () => {
     )
 
     expect(register).toHaveBeenCalledWith({ username: "alice", description: undefined })
-    expect(result).toEqual({ lightningAddress: "alice@lnurl.staging.blink.sv" })
+    expect(result).toEqual({ lightningAddress: "alice@staging.blink.sv" })
   })
 })

--- a/__tests__/self-custodial/bridge/wallet.spec.ts
+++ b/__tests__/self-custodial/bridge/wallet.spec.ts
@@ -61,7 +61,7 @@ describe("checkLightningAddressAvailable", () => {
 })
 
 describe("registerLightningAddress", () => {
-  it("forwards the username and description and returns the address info", async () => {
+  it("forwards the username and returns the address info", async () => {
     const register = jest
       .fn()
       .mockResolvedValue({ lightningAddress: "alice@staging.blink.sv" })
@@ -71,7 +71,7 @@ describe("registerLightningAddress", () => {
       "alice",
     )
 
-    expect(register).toHaveBeenCalledWith({ username: "alice", description: undefined })
+    expect(register).toHaveBeenCalledWith(expect.objectContaining({ username: "alice" }))
     expect(result).toEqual({ lightningAddress: "alice@staging.blink.sv" })
   })
 })

--- a/__tests__/self-custodial/bridge/wallet.spec.ts
+++ b/__tests__/self-custodial/bridge/wallet.spec.ts
@@ -1,7 +1,9 @@
 import {
+  checkLightningAddressAvailable,
   getUserSettings,
   getWalletInfo,
   listPayments,
+  registerLightningAddress,
 } from "@app/self-custodial/bridge/wallet"
 
 describe("getWalletInfo", () => {
@@ -41,5 +43,35 @@ describe("getUserSettings", () => {
     getUserSettings({ getUserSettings: getSettings } as never)
 
     expect(getSettings).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("checkLightningAddressAvailable", () => {
+  it("forwards the username and returns the SDK availability result", async () => {
+    const check = jest.fn().mockResolvedValue(true)
+
+    const result = await checkLightningAddressAvailable(
+      { checkLightningAddressAvailable: check } as never,
+      "alice",
+    )
+
+    expect(check).toHaveBeenCalledWith({ username: "alice" })
+    expect(result).toBe(true)
+  })
+})
+
+describe("registerLightningAddress", () => {
+  it("forwards the username and description and returns the address info", async () => {
+    const register = jest
+      .fn()
+      .mockResolvedValue({ lightningAddress: "alice@lnurl.staging.blink.sv" })
+
+    const result = await registerLightningAddress(
+      { registerLightningAddress: register } as never,
+      "alice",
+    )
+
+    expect(register).toHaveBeenCalledWith({ username: "alice", description: undefined })
+    expect(result).toEqual({ lightningAddress: "alice@lnurl.staging.blink.sv" })
   })
 })

--- a/__tests__/self-custodial/config.spec.ts
+++ b/__tests__/self-custodial/config.spec.ts
@@ -121,11 +121,11 @@ describe("isRegtestNetwork", () => {
 
 describe("lnurlDomainFor", () => {
   it("uses the production Blink LNURL host on mainnet", () => {
-    expect(lnurlDomainFor(Network.Mainnet)).toBe("lnurl.blink.sv")
+    expect(lnurlDomainFor(Network.Mainnet)).toBe("blink.sv")
   })
 
   it("uses the staging Blink LNURL host on regtest", () => {
-    expect(lnurlDomainFor(Network.Regtest)).toBe("lnurl.staging.blink.sv")
+    expect(lnurlDomainFor(Network.Regtest)).toBe("staging.blink.sv")
   })
 })
 

--- a/__tests__/self-custodial/config.spec.ts
+++ b/__tests__/self-custodial/config.spec.ts
@@ -3,6 +3,7 @@ import { Network } from "@breeztech/breez-sdk-spark-react-native"
 import {
   hasSparkAddressShape,
   isRegtestNetwork,
+  lnurlDomainFor,
   mismatchedNetworkLabel,
   networkForInstance,
   networkLabelFor,
@@ -115,6 +116,16 @@ describe("isRegtestNetwork", () => {
 
   it("is false for mainnet", () => {
     expect(isRegtestNetwork(Network.Mainnet)).toBe(false)
+  })
+})
+
+describe("lnurlDomainFor", () => {
+  it("uses the production Blink LNURL host on mainnet", () => {
+    expect(lnurlDomainFor(Network.Mainnet)).toBe("lnurl.blink.sv")
+  })
+
+  it("uses the staging Blink LNURL host on regtest", () => {
+    expect(lnurlDomainFor(Network.Regtest)).toBe("lnurl.staging.blink.sv")
   })
 })
 

--- a/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
+++ b/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
@@ -26,7 +26,7 @@ describe("useRegisterLightningAddress", () => {
     jest.clearAllMocks()
     mockSdk = FAKE_SDK
     mockCheckAvailable.mockResolvedValue(true)
-    mockRegister.mockResolvedValue({ lightningAddress: "alice@lnurl.staging.blink.sv" })
+    mockRegister.mockResolvedValue({ lightningAddress: "alice@staging.blink.sv" })
     mockUpdateAccount.mockResolvedValue(undefined)
   })
 

--- a/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
+++ b/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
@@ -143,6 +143,33 @@ describe("useRegisterLightningAddress", () => {
     expect(result.current.error).toBe(SetUsernameError.TOO_LONG)
   })
 
+  it("ignores a second register() call while the first is still in flight", async () => {
+    let resolveCheck: (available: boolean) => void = () => {}
+    mockCheckAvailable.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveCheck = resolve
+      }),
+    )
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("alice"))
+
+    let calls: Array<Promise<void>> = []
+    act(() => {
+      calls = [result.current.register(), result.current.register()]
+    })
+
+    await act(async () => {
+      resolveCheck(true)
+      await Promise.all(calls)
+    })
+
+    expect(mockCheckAvailable).toHaveBeenCalledTimes(1)
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(onRegistered).toHaveBeenCalledTimes(1)
+  })
+
   it("keeps loading true while the registration request is in flight", async () => {
     let resolveCheck: (available: boolean) => void = () => {}
     mockCheckAvailable.mockReturnValue(

--- a/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
+++ b/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
@@ -1,0 +1,170 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { SetUsernameError } from "@app/components/set-lightning-address-modal/username-validation"
+import { useRegisterLightningAddress } from "@app/self-custodial/hooks/use-register-lightning-address"
+
+const mockCheckAvailable = jest.fn()
+const mockRegister = jest.fn()
+jest.mock("@app/self-custodial/bridge", () => ({
+  checkLightningAddressAvailable: (...args: unknown[]) => mockCheckAvailable(...args),
+  registerLightningAddress: (...args: unknown[]) => mockRegister(...args),
+}))
+
+const mockUpdateAccount = jest.fn()
+let mockSdk: unknown = { id: "sdk" }
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => ({
+    sdk: mockSdk,
+    updateCurrentSelfCustodialAccount: mockUpdateAccount,
+  }),
+}))
+
+const FAKE_SDK = { id: "sdk" }
+
+describe("useRegisterLightningAddress", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSdk = FAKE_SDK
+    mockCheckAvailable.mockResolvedValue(true)
+    mockRegister.mockResolvedValue({ lightningAddress: "alice@lnurl.staging.blink.sv" })
+    mockUpdateAccount.mockResolvedValue(undefined)
+  })
+
+  it("registers a valid available username, refreshes the account and reports success", async () => {
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(mockCheckAvailable).toHaveBeenCalledWith(FAKE_SDK, "alice")
+    expect(mockRegister).toHaveBeenCalledWith(FAKE_SDK, "alice")
+    expect(mockUpdateAccount).toHaveBeenCalledTimes(1)
+    expect(onRegistered).toHaveBeenCalledTimes(1)
+    expect(result.current.error).toBeUndefined()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("surfaces a validation error and never touches the SDK for an invalid username", async () => {
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("ab"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.TOO_SHORT)
+    expect(mockCheckAvailable).not.toHaveBeenCalled()
+    expect(mockRegister).not.toHaveBeenCalled()
+    expect(onRegistered).not.toHaveBeenCalled()
+  })
+
+  it("reports an unknown error when the SDK is not connected", async () => {
+    mockSdk = null
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.UNKNOWN_ERROR)
+    expect(mockCheckAvailable).not.toHaveBeenCalled()
+  })
+
+  it("reports address-unavailable and does not register when the username is taken", async () => {
+    mockCheckAvailable.mockResolvedValue(false)
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.ADDRESS_UNAVAILABLE)
+    expect(mockRegister).not.toHaveBeenCalled()
+    expect(onRegistered).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("reports an unknown error when registration throws", async () => {
+    mockRegister.mockRejectedValue(new Error("server down"))
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.UNKNOWN_ERROR)
+    expect(onRegistered).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("clears a previous error when the username is edited", async () => {
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("ab"))
+    await act(async () => {
+      await result.current.register()
+    })
+    expect(result.current.error).toBe(SetUsernameError.TOO_SHORT)
+
+    act(() => result.current.setLnAddress("alice"))
+
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it("surfaces the invalid-character error for a username with disallowed characters", async () => {
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("invalid!name"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.INVALID_CHARACTER)
+    expect(mockRegister).not.toHaveBeenCalled()
+  })
+
+  it("surfaces the too-long error for an over-length username", async () => {
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("a".repeat(51)))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.TOO_LONG)
+  })
+
+  it("keeps loading true while the registration request is in flight", async () => {
+    let resolveCheck: (available: boolean) => void = () => {}
+    mockCheckAvailable.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveCheck = resolve
+      }),
+    )
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("alice"))
+    let pending: Promise<void> = Promise.resolve()
+    act(() => {
+      pending = result.current.register()
+    })
+
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      resolveCheck(true)
+      await pending
+    })
+
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/app/components/set-lightning-address-modal/set-lightning-address-modal.stories.tsx
+++ b/app/components/set-lightning-address-modal/set-lightning-address-modal.stories.tsx
@@ -42,6 +42,8 @@ export const Default = () => {
       lnAddress="Testing"
       setLnAddress={console.log}
       error=""
+      hostname="blink.sv"
+      bankName="Blink"
     />
   )
 }
@@ -56,6 +58,8 @@ export const Error = () => {
       setLnAddress={console.log}
       loading={false}
       error="This is an error message"
+      hostname="blink.sv"
+      bankName="Blink"
     />
   )
 }

--- a/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
+++ b/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
@@ -104,6 +104,12 @@ export const SetLightningAddressModal = ({
     toggleModal()
   }
 
+  const {
+    appConfig: {
+      galoyInstance: { lnAddressHostname, name: bankName },
+    },
+  } = useAppConfig()
+
   return (
     <SetLightningAddressModalUI
       isVisible={isVisible}
@@ -113,6 +119,8 @@ export const SetLightningAddressModal = ({
       loading={loading}
       setLnAddress={onChangeLnAddress}
       onSetLightningAddress={onSetLightningAddress}
+      hostname={lnAddressHostname}
+      bankName={bankName}
     />
   )
 }
@@ -130,6 +138,8 @@ export type SetLightningAddressModalUIProps = {
   error?: SetUsernameError
   lnAddress: string
   setLnAddress?: (lightningAddress: string) => void
+  hostname: string
+  bankName: string
 }
 
 export const SetLightningAddressModalUI = ({
@@ -140,12 +150,9 @@ export const SetLightningAddressModalUI = ({
   setLnAddress,
   loading,
   error,
+  hostname,
+  bankName,
 }: SetLightningAddressModalUIProps) => {
-  const {
-    appConfig: {
-      galoyInstance: { lnAddressHostname, name: bankName },
-    },
-  } = useAppConfig()
   const {
     theme: { colors },
   } = useTheme()
@@ -198,7 +205,7 @@ export const SetLightningAddressModalUI = ({
               placeholder={"SatoshiNakamoto"}
               placeholderTextColor={colors.grey3}
             />
-            <Text type={"p1"}>{`@${lnAddressHostname}`}</Text>
+            <Text type={"p1"}>{`@${hostname}`}</Text>
           </View>
           {errorMessage && <GaloyErrorBox errorMessage={errorMessage} />}
           <Text type={"p1"} style={styles.centerAlign}>

--- a/app/screens/settings-screen/self-custodial/profile-row.tsx
+++ b/app/screens/settings-screen/self-custodial/profile-row.tsx
@@ -23,6 +23,7 @@ import { type SelfCustodialAccountEntry } from "@app/self-custodial/storage/acco
 import { AccountType, type WalletState } from "@app/types/wallet"
 import { reportError } from "@app/utils/error-logging"
 import { hasFunds } from "@app/utils/has-funds"
+import { extractLightningAddressUsername } from "@app/utils/pay-links"
 import { testProps } from "@app/utils/testProps"
 import { toastShow } from "@app/utils/toast"
 
@@ -61,7 +62,8 @@ export const ProfileRow: React.FC<ProfileRowProps> = ({ entry, isFirstItem }) =>
   const lightningAddress = isActive
     ? liveLightningAddress ?? persistedLightningAddress
     : persistedLightningAddress
-  const rowTitle = lightningAddress ?? LL.common.anonymousUser()
+  const rowTitle =
+    extractLightningAddressUsername(lightningAddress) ?? LL.common.anonymousUser()
 
   const handleSwitch = () => {
     if (isActive) return

--- a/app/screens/settings-screen/self-custodial/set-lightning-address-modal.tsx
+++ b/app/screens/settings-screen/self-custodial/set-lightning-address-modal.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+
+import { SetLightningAddressModalUI } from "@app/components/set-lightning-address-modal"
+import { useAppConfig } from "@app/hooks"
+import { lnurlDomainFor } from "@app/self-custodial/config"
+import { useRegisterLightningAddress } from "@app/self-custodial/hooks/use-register-lightning-address"
+import { useSparkNetwork } from "@app/self-custodial/hooks/use-spark-network"
+
+type SetSelfCustodialLightningAddressModalProps = {
+  isVisible: boolean
+  toggleModal: () => void
+}
+
+export const SetSelfCustodialLightningAddressModal = ({
+  isVisible,
+  toggleModal,
+}: SetSelfCustodialLightningAddressModalProps) => {
+  const network = useSparkNetwork()
+  const {
+    appConfig: {
+      galoyInstance: { name: bankName },
+    },
+  } = useAppConfig()
+  const { lnAddress, error, loading, setLnAddress, register } =
+    useRegisterLightningAddress(toggleModal)
+
+  return (
+    <SetLightningAddressModalUI
+      isVisible={isVisible}
+      toggleModal={toggleModal}
+      onSetLightningAddress={register}
+      loading={loading}
+      error={error}
+      lnAddress={lnAddress}
+      setLnAddress={setLnAddress}
+      hostname={lnurlDomainFor(network)}
+      bankName={bankName}
+    />
+  )
+}

--- a/app/screens/settings-screen/settings/account-ln-address.tsx
+++ b/app/screens/settings-screen/settings/account-ln-address.tsx
@@ -99,9 +99,15 @@ const SelfCustodialLightningAddressRow: React.FC = () => {
     selfCustodialEntries.find((entry) => entry.id === activeAccount?.id)
       ?.lightningAddress ?? null
 
+  /**
+   * Prefer the live SDK address but fall back to the persisted one while the SDK
+   * reconnects, so a user who already registered never sees the "set" prompt.
+   */
+  const address = liveLightningAddress ?? persistedLightningAddress
+
   return (
     <LightningAddressRow
-      address={liveLightningAddress ?? persistedLightningAddress}
+      address={address}
       renderModal={({ isVisible, toggleModal }) => (
         <SetSelfCustodialLightningAddressModal
           isVisible={isVisible}

--- a/app/screens/settings-screen/settings/account-ln-address.tsx
+++ b/app/screens/settings-screen/settings/account-ln-address.tsx
@@ -3,6 +3,7 @@ import { useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { SetLightningAddressModal } from "@app/components/set-lightning-address-modal"
+import { SetSelfCustodialLightningAddressModal } from "@app/screens/settings-screen/self-custodial/set-lightning-address-modal"
 import { useSettingsScreenQuery } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useAppConfig, useClipboard } from "@app/hooks"
@@ -10,92 +11,103 @@ import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { AccountType } from "@app/types/wallet"
+import { getLightningAddress } from "@app/utils/pay-links"
 
 import { SettingsRow } from "../row"
 
+const SUBTITLE_SHORTER_LENGTH = 22
+
 export const AccountLNAddress: React.FC = () => {
   const { activeAccount } = useAccountRegistry()
-  const { lightningAddress: selfCustodialLightningAddress } = useSelfCustodialWallet()
 
   if (activeAccount?.type === AccountType.SelfCustodial) {
-    if (!selfCustodialLightningAddress) return null
     return <SelfCustodialLightningAddressRow />
   }
   return <CustodialLightningAddressRow />
 }
 
-const CustodialLightningAddressRow: React.FC = () => {
-  const { appConfig } = useAppConfig()
+type LightningAddressRowProps = {
+  address: string | null
+  loading?: boolean
+  renderModal: (modal: { isVisible: boolean; toggleModal: () => void }) => React.ReactNode
+}
+
+const LightningAddressRow: React.FC<LightningAddressRowProps> = ({
+  address,
+  loading,
+  renderModal,
+}) => {
   const {
     theme: { colors },
   } = useTheme()
-  const hostName = appConfig.galoyInstance.lnAddressHostname
-
-  const [isModalShown, setModalShown] = useState(false)
-  const toggleModalVisibility = () => setModalShown((x) => !x)
-
-  const isAuthed = useIsAuthed()
-  const { data, loading } = useSettingsScreenQuery({ skip: !isAuthed })
-
   const { LL } = useI18nContext()
   const { copyToClipboard } = useClipboard()
+  const [isModalShown, setModalShown] = useState(false)
+  const toggleModal = () => setModalShown((shown) => !shown)
 
-  const hasUsername = Boolean(data?.me?.username)
-  const lnAddress = `${data?.me?.username}@${hostName}`
+  const copyAddress = (value: string) =>
+    copyToClipboard({
+      content: value,
+      message: LL.GaloyAddressScreen.copiedLightningAddressToClipboard(),
+    })
 
   return (
     <>
       <SettingsRow
         loading={loading}
-        title={hasUsername ? lnAddress : LL.SettingsScreen.setYourLightningAddress()}
-        subtitleShorter={(data?.me?.username || "").length > 22}
+        title={address ?? LL.SettingsScreen.setYourLightningAddress()}
+        subtitleShorter={(address ?? "").length > SUBTITLE_SHORTER_LENGTH}
         leftGaloyIcon="lightning-address"
         rightIcon={
-          hasUsername ? (
+          address ? (
             <GaloyIcon name="copy-paste" size={20} color={colors.primary} />
           ) : undefined
         }
-        action={() => {
-          if (hasUsername) {
-            copyToClipboard({
-              content: lnAddress,
-              message: LL.GaloyAddressScreen.copiedLightningAddressToClipboard(),
-            })
-          } else {
-            toggleModalVisibility()
-          }
-        }}
+        action={address ? () => copyAddress(address) : toggleModal}
       />
-      <SetLightningAddressModal
-        isVisible={isModalShown}
-        toggleModal={toggleModalVisibility}
-      />
+      {renderModal({ isVisible: isModalShown, toggleModal })}
     </>
   )
 }
 
-const SelfCustodialLightningAddressRow: React.FC = () => {
-  const {
-    theme: { colors },
-  } = useTheme()
-  const { LL } = useI18nContext()
-  const { lightningAddress } = useSelfCustodialWallet()
-  const { copyToClipboard } = useClipboard()
+const CustodialLightningAddressRow: React.FC = () => {
+  const { appConfig } = useAppConfig()
+  const isAuthed = useIsAuthed()
+  const { data, loading } = useSettingsScreenQuery({ skip: !isAuthed })
 
-  if (!lightningAddress) return null
+  const username = data?.me?.username
+  const address = username
+    ? getLightningAddress(appConfig.galoyInstance.lnAddressHostname, username)
+    : null
 
   return (
-    <SettingsRow
-      title={lightningAddress}
-      subtitleShorter={lightningAddress.length > 22}
-      leftGaloyIcon="lightning-address"
-      rightIcon={<GaloyIcon name="copy-paste" size={20} color={colors.primary} />}
-      action={() =>
-        copyToClipboard({
-          content: lightningAddress,
-          message: LL.GaloyAddressScreen.copiedLightningAddressToClipboard(),
-        })
-      }
+    <LightningAddressRow
+      address={address}
+      loading={loading}
+      renderModal={({ isVisible, toggleModal }) => (
+        <SetLightningAddressModal isVisible={isVisible} toggleModal={toggleModal} />
+      )}
+    />
+  )
+}
+
+const SelfCustodialLightningAddressRow: React.FC = () => {
+  const { activeAccount, selfCustodialEntries } = useAccountRegistry()
+  const { lightningAddress: liveLightningAddress } = useSelfCustodialWallet()
+
+  const persistedLightningAddress =
+    selfCustodialEntries.find((entry) => entry.id === activeAccount?.id)
+      ?.lightningAddress ?? null
+
+  return (
+    <LightningAddressRow
+      address={liveLightningAddress ?? persistedLightningAddress}
+      renderModal={({ isVisible, toggleModal }) => (
+        <SetSelfCustodialLightningAddressModal
+          isVisible={isVisible}
+          toggleModal={toggleModal}
+        />
+      )}
     />
   )
 }

--- a/app/self-custodial/bridge/index.ts
+++ b/app/self-custodial/bridge/index.ts
@@ -12,6 +12,8 @@ export {
   getUserSettings,
   syncSelfCustodialWallet,
   getLightningAddress,
+  checkLightningAddressAvailable,
+  registerLightningAddress,
 } from "./wallet"
 export { getSparkStatus } from "./status"
 export { activateStableBalance, deactivateStableBalance } from "./stable-balance"

--- a/app/self-custodial/bridge/lifecycle.ts
+++ b/app/self-custodial/bridge/lifecycle.ts
@@ -15,6 +15,7 @@ import { normalizeMnemonic } from "@app/utils/mnemonic"
 import KeyStoreWrapper from "@app/utils/storage/secureStorage"
 
 import {
+  lnurlDomainFor,
   MAX_SLIPPAGE_BPS,
   networkLabelFor,
   requireBreezApiKey,
@@ -41,6 +42,7 @@ const initializeLogging = (() => {
 const createSdkConfig = (network: Network) => {
   const config = defaultConfig(network)
   config.apiKey = requireBreezApiKey()
+  config.lnurlDomain = lnurlDomainFor(network)
 
   config.stableBalanceConfig = {
     tokens: [{ label: SparkToken.Label, tokenIdentifier: requireSparkTokenIdentifier() }],

--- a/app/self-custodial/bridge/wallet.ts
+++ b/app/self-custodial/bridge/wallet.ts
@@ -1,4 +1,5 @@
 import {
+  RegisterLightningAddressRequest,
   SyncWalletRequest,
   type BreezSdkInterface,
 } from "@breeztech/breez-sdk-spark-react-native"
@@ -32,4 +33,4 @@ export const checkLightningAddressAvailable = (
 ) => sdk.checkLightningAddressAvailable({ username })
 
 export const registerLightningAddress = (sdk: BreezSdkInterface, username: string) =>
-  sdk.registerLightningAddress({ username, description: undefined })
+  sdk.registerLightningAddress(RegisterLightningAddressRequest.create({ username }))

--- a/app/self-custodial/bridge/wallet.ts
+++ b/app/self-custodial/bridge/wallet.ts
@@ -25,3 +25,11 @@ export const listPayments = (sdk: BreezSdkInterface, offset: number, limit: numb
 export const getUserSettings = (sdk: BreezSdkInterface) => sdk.getUserSettings()
 
 export const getLightningAddress = (sdk: BreezSdkInterface) => sdk.getLightningAddress()
+
+export const checkLightningAddressAvailable = (
+  sdk: BreezSdkInterface,
+  username: string,
+) => sdk.checkLightningAddressAvailable({ username })
+
+export const registerLightningAddress = (sdk: BreezSdkInterface, username: string) =>
+  sdk.registerLightningAddress({ username, description: undefined })

--- a/app/self-custodial/config.ts
+++ b/app/self-custodial/config.ts
@@ -33,8 +33,8 @@ export const networkLabelFor = (network: Network): SparkNetworkLabel =>
 
 export const isRegtestNetwork = (network: Network): boolean => network === Network.Regtest
 
-const MAINNET_LNURL_DOMAIN = "lnurl.blink.sv"
-const REGTEST_LNURL_DOMAIN = "lnurl.staging.blink.sv"
+const MAINNET_LNURL_DOMAIN = "blink.sv"
+const REGTEST_LNURL_DOMAIN = "staging.blink.sv"
 
 export const lnurlDomainFor = (network: Network): string =>
   network === Network.Mainnet ? MAINNET_LNURL_DOMAIN : REGTEST_LNURL_DOMAIN

--- a/app/self-custodial/config.ts
+++ b/app/self-custodial/config.ts
@@ -33,6 +33,12 @@ export const networkLabelFor = (network: Network): SparkNetworkLabel =>
 
 export const isRegtestNetwork = (network: Network): boolean => network === Network.Regtest
 
+const MAINNET_LNURL_DOMAIN = "lnurl.blink.sv"
+const REGTEST_LNURL_DOMAIN = "lnurl.staging.blink.sv"
+
+export const lnurlDomainFor = (network: Network): string =>
+  network === Network.Mainnet ? MAINNET_LNURL_DOMAIN : REGTEST_LNURL_DOMAIN
+
 /**
  * Returns the wallet's stored network label when it conflicts with the current
  * network, or null when there is no stored label or it matches. Single source

--- a/app/self-custodial/hooks/use-register-lightning-address.ts
+++ b/app/self-custodial/hooks/use-register-lightning-address.ts
@@ -4,6 +4,7 @@ import {
   SetUsernameError,
   validateUsername,
 } from "@app/components/set-lightning-address-modal/username-validation"
+import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
 import {
   checkLightningAddressAvailable,
   registerLightningAddress,
@@ -22,6 +23,7 @@ export const useRegisterLightningAddress = (
   onRegistered: () => void,
 ): UseRegisterLightningAddress => {
   const { sdk, updateCurrentSelfCustodialAccount } = useSelfCustodialWallet()
+  const guard = useInFlightGuard()
   const [lnAddress, setLnAddressValue] = useState("")
   const [error, setError] = useState<SetUsernameError | undefined>()
   const [loading, setLoading] = useState(false)
@@ -32,31 +34,33 @@ export const useRegisterLightningAddress = (
   }
 
   const register = async () => {
-    const validation = validateUsername(lnAddress)
-    if (!validation.valid) {
-      setError(validation.error)
-      return
-    }
-    if (!sdk) {
-      setError(SetUsernameError.UNKNOWN_ERROR)
-      return
-    }
-
-    setLoading(true)
-    try {
-      const available = await checkLightningAddressAvailable(sdk, lnAddress)
-      if (!available) {
-        setError(SetUsernameError.ADDRESS_UNAVAILABLE)
+    await guard.run(async () => {
+      const validation = validateUsername(lnAddress)
+      if (!validation.valid) {
+        setError(validation.error)
         return
       }
-      await registerLightningAddress(sdk, lnAddress)
-      await updateCurrentSelfCustodialAccount()
-      onRegistered()
-    } catch {
-      setError(SetUsernameError.UNKNOWN_ERROR)
-    } finally {
-      setLoading(false)
-    }
+      if (!sdk) {
+        setError(SetUsernameError.UNKNOWN_ERROR)
+        return
+      }
+
+      setLoading(true)
+      try {
+        const available = await checkLightningAddressAvailable(sdk, lnAddress)
+        if (!available) {
+          setError(SetUsernameError.ADDRESS_UNAVAILABLE)
+          return
+        }
+        await registerLightningAddress(sdk, lnAddress)
+        await updateCurrentSelfCustodialAccount()
+        onRegistered()
+      } catch {
+        setError(SetUsernameError.UNKNOWN_ERROR)
+      } finally {
+        setLoading(false)
+      }
+    })
   }
 
   return { lnAddress, error, loading, setLnAddress, register }

--- a/app/self-custodial/hooks/use-register-lightning-address.ts
+++ b/app/self-custodial/hooks/use-register-lightning-address.ts
@@ -1,0 +1,63 @@
+import { useState } from "react"
+
+import {
+  SetUsernameError,
+  validateUsername,
+} from "@app/components/set-lightning-address-modal/username-validation"
+import {
+  checkLightningAddressAvailable,
+  registerLightningAddress,
+} from "@app/self-custodial/bridge"
+import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+
+type UseRegisterLightningAddress = {
+  lnAddress: string
+  error?: SetUsernameError
+  loading: boolean
+  setLnAddress: (value: string) => void
+  register: () => Promise<void>
+}
+
+export const useRegisterLightningAddress = (
+  onRegistered: () => void,
+): UseRegisterLightningAddress => {
+  const { sdk, updateCurrentSelfCustodialAccount } = useSelfCustodialWallet()
+  const [lnAddress, setLnAddressValue] = useState("")
+  const [error, setError] = useState<SetUsernameError | undefined>()
+  const [loading, setLoading] = useState(false)
+
+  const setLnAddress = (value: string) => {
+    setLnAddressValue(value)
+    setError(undefined)
+  }
+
+  const register = async () => {
+    const validation = validateUsername(lnAddress)
+    if (!validation.valid) {
+      setError(validation.error)
+      return
+    }
+    if (!sdk) {
+      setError(SetUsernameError.UNKNOWN_ERROR)
+      return
+    }
+
+    setLoading(true)
+    try {
+      const available = await checkLightningAddressAvailable(sdk, lnAddress)
+      if (!available) {
+        setError(SetUsernameError.ADDRESS_UNAVAILABLE)
+        return
+      }
+      await registerLightningAddress(sdk, lnAddress)
+      await updateCurrentSelfCustodialAccount()
+      onRegistered()
+    } catch {
+      setError(SetUsernameError.UNKNOWN_ERROR)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { lnAddress, error, loading, setLnAddress, register }
+}


### PR DESCRIPTION
## Summary

Self-custodial (Breez Spark) wallets had no way to claim a Lightning address, so they were unreachable by `username@domain`. This lets a self-custodial user register a Blink-domain Lightning address (`username@blink.sv` on mainnet, `username@staging.blink.sv` on regtest) from Settings, using the same username rules and the same set-address modal as custodial. Registration goes through the Breez SDK against Blink's LNURL server; no Blink GraphQL mutation is involved.

## Changes

- **Register via the Breez SDK.** `config.lnurlDomain` is set to the Blink LNURL host (derived from the active network) before connect, so the SDK signs the chosen username with the Spark wallet key and registers it against Blink's LNURL server. A new `useRegisterLightningAddress` hook validates the username (reusing the custodial `validateUsername` rules), checks availability, registers, and refreshes the active account. There is no default address: the user opts in from Settings.
- **Adapter pattern over a shared UI.** The existing set-address modal UI is now pure (it takes `hostname` and `bankName` as props instead of reading config directly), with two thin containers over the same UI: custodial keeps the GraphQL `userUpdateUsername` path, self-custodial uses the SDK register path. The Settings row likewise extracts one shared presentational `LightningAddressRow` used by both account types; the self-custodial row is now set-or-show instead of hidden when empty.
- **Account list display.** The self-custodial account row shows the username without the `@domain` suffix, matching the custodial presentation one to one.
- **Network aware.** Staging works today; mainnet picks up the production host automatically once Blink deploys its LNURL server, with no app change.

## Notes

- Custodial behavior is unchanged (the custodial container renders the same modal with the same hostname and bank name it read internally before, and keeps the GraphQL flow).
- No new i18n; this reuses the existing set-address and Settings keys.
- 100% coverage on the new files; typecheck, lint, and the full test suite are green.
- Stacked on #3867 (which is stacked on #3865).
