### PR TITLE
fix(self-custodial): resolve Blink username sends via their Lightning address


### DIFF
--- a/__tests__/payment-destination/resolve-destination.integration.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.integration.spec.ts
@@ -89,6 +89,28 @@ describe("resolveDestination (integration: real parser)", () => {
     expect(mockWrapDestination).toHaveBeenCalled()
   })
 
+  it("routes a custodial send to a non-custodial Blink username through LNURL via the flag fallback", async () => {
+    // No custodial wallet for the handle: the recipient is self-custodial, not custodial.
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: null },
+    })
+
+    const result = await resolveDestination(
+      {
+        rawInput: "esaudeveloper@blink.sv",
+        myWalletIds: ["my-wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: [lnAddressHostname],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+      },
+      { sdk: null, network: mockSparkNetwork.Regtest },
+      lnAddressHostname,
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+  })
+
   it("resolves a matching-network Spark address to a valid Spark destination", async () => {
     mockParseSparkAddress.mockResolvedValue({
       address: "sparkrt1qabcdefghijklmn",

--- a/__tests__/payment-destination/resolve-destination.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.spec.ts
@@ -51,7 +51,7 @@ describe("resolveDestination", () => {
   })
 
   describe("custodial path (sdk = null)", () => {
-    it("returns parseDestination output unchanged", async () => {
+    it("returns a resolved destination unchanged without an LNURL fallback", async () => {
       const parsed = { valid: true, validDestination: { paymentType: "Lightning" } }
       mockParseDestination.mockResolvedValue(parsed)
 
@@ -61,10 +61,47 @@ describe("resolveDestination", () => {
         lnAddressHostname,
       )
 
+      expect(mockParseDestination).toHaveBeenCalledTimes(1)
       expect(mockParseSparkAddress).not.toHaveBeenCalled()
       expect(mockResolveUsername).not.toHaveBeenCalled()
       expect(mockWrapDestination).not.toHaveBeenCalled()
       expect(result).toBe(parsed)
+    })
+
+    it("re-resolves an unresolved Blink username as a lightning address over LNURL", async () => {
+      const unresolved = { valid: false, invalidReason: "UsernameDoesNotExist" }
+      const lnurlResolved = { valid: true, validDestination: { paymentType: "Lnurl" } }
+      mockParseDestination
+        .mockResolvedValueOnce(unresolved)
+        .mockResolvedValueOnce(lnurlResolved)
+
+      const result = await resolveDestination(
+        baseParams,
+        { sdk: null, network: SparkNetwork.Regtest },
+        lnAddressHostname,
+      )
+
+      expect(mockParseDestination).toHaveBeenNthCalledWith(1, baseParams)
+      expect(mockParseDestination).toHaveBeenNthCalledWith(2, {
+        ...baseParams,
+        preferLnurlForInternalHandles: true,
+      })
+      expect(mockResolveUsername).not.toHaveBeenCalled()
+      expect(result).toBe(lnurlResolved)
+    })
+
+    it("does not fall back when the destination is invalid for a reason other than a missing username", async () => {
+      const invalid = { valid: false, invalidReason: "WrongNetwork" }
+      mockParseDestination.mockResolvedValue(invalid)
+
+      const result = await resolveDestination(
+        baseParams,
+        { sdk: null, network: SparkNetwork.Regtest },
+        lnAddressHostname,
+      )
+
+      expect(mockParseDestination).toHaveBeenCalledTimes(1)
+      expect(result).toBe(invalid)
     })
 
     it("does not attempt the Spark pre-check when sdk is null", async () => {

--- a/__tests__/payment-destination/resolve-username.spec.ts
+++ b/__tests__/payment-destination/resolve-username.spec.ts
@@ -9,6 +9,17 @@ const createValidResult = (paymentType: PaymentType, extra = {}) =>
     validDestination: { paymentType, ...extra },
   }) as never
 
+const createInvalidResult = (
+  paymentType: PaymentType,
+  invalidReason: string,
+  extra = {},
+) =>
+  ({
+    valid: false,
+    invalidReason,
+    invalidPaymentDestination: { paymentType, ...extra },
+  }) as never
+
 describe("resolveUsername", () => {
   const lnAddressHostname = "blink.sv"
 
@@ -40,6 +51,46 @@ describe("resolveUsername", () => {
     expect(result).toBe(lnurl)
   })
 
+  it("re-resolves an unresolved username (not a custodial account) as a Lightning Address", async () => {
+    const invalid = createInvalidResult(PaymentType.Intraledger, "UsernameDoesNotExist", {
+      handle: "bulus",
+    })
+    const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "bulus@blink.sv" })
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("bulus@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("re-resolves an unresolved intraledger-with-flag username as a Lightning Address", async () => {
+    const invalid = createInvalidResult(
+      PaymentType.IntraledgerWithFlag,
+      "UsernameDoesNotExist",
+      { handle: "bulus" },
+    )
+    const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "bulus@blink.sv" })
+    const resolveLnAddress = jest.fn().mockResolvedValue(lnurl)
+
+    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).toHaveBeenCalledWith("bulus@blink.sv")
+    expect(result).toBe(lnurl)
+  })
+
+  it("does not re-resolve an intraledger result invalid for a reason other than a missing username", async () => {
+    const invalid = createInvalidResult(PaymentType.Intraledger, "WrongDomain", {
+      handle: "bob",
+    })
+    const resolveLnAddress = jest.fn()
+
+    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
+
+    expect(resolveLnAddress).not.toHaveBeenCalled()
+    expect(result).toBe(invalid)
+  })
+
   it("passes a Lnurl destination through unchanged (no re-resolution)", async () => {
     const lnurl = createValidResult(PaymentType.Lnurl, { lnurl: "alice@blink.sv" })
     const resolveLnAddress = jest.fn()
@@ -48,16 +99,6 @@ describe("resolveUsername", () => {
 
     expect(resolveLnAddress).not.toHaveBeenCalled()
     expect(result).toBe(lnurl)
-  })
-
-  it("passes invalid destinations through unchanged", async () => {
-    const invalid = { valid: false } as never
-    const resolveLnAddress = jest.fn()
-
-    const result = await resolveUsername(invalid, lnAddressHostname, resolveLnAddress)
-
-    expect(resolveLnAddress).not.toHaveBeenCalled()
-    expect(result).toBe(invalid)
   })
 
   it("passes Receive-direction destinations through unchanged", async () => {

--- a/app/screens/send-bitcoin-screen/payment-destination/index.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.ts
@@ -28,6 +28,7 @@ export const parseDestination = async ({
   accountDefaultWalletQuery,
   inputSource,
   displayCurrency,
+  preferLnurlForInternalHandles,
 }: ParseDestinationParams): Promise<ParseDestinationResult> => {
   const parsedDestination = parsePaymentDestination({
     destination: rawInput,
@@ -35,6 +36,7 @@ export const parseDestination = async ({
     lnAddressDomains: lnurlDomains,
     inputSource,
     displayCurrency,
+    preferLnurlForInternalHandles,
   })
 
   switch (parsedDestination.paymentType) {

--- a/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.types.ts
@@ -29,6 +29,7 @@ export type ParseDestinationParams = {
   accountDefaultWalletQuery: AccountDefaultWalletLazyQueryHookResult[0]
   inputSource?: InputSource
   displayCurrency?: string
+  preferLnurlForInternalHandles?: boolean
 }
 
 export const DestinationDirection = {
@@ -88,6 +89,9 @@ export const InvalidDestinationReason = {
 
 export type InvalidDestinationReason =
   (typeof InvalidDestinationReason)[keyof typeof InvalidDestinationReason]
+
+export const isUnresolvedUsername = (result: ParseDestinationResult): boolean =>
+  !result.valid && result.invalidReason === InvalidDestinationReason.UsernameDoesNotExist
 
 export type ValidParsedPaymentDestination = (
   | ResolvedLnurlPaymentDestination

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
@@ -7,7 +7,11 @@ import { parseSparkAddress } from "@app/self-custodial/bridge"
 import { wrapDestination } from "@app/self-custodial/payment-details/wrap-destination"
 
 import { parseDestination } from "./index"
-import { type ParseDestinationParams, type ParseDestinationResult } from "./index.types"
+import {
+  isUnresolvedUsername,
+  type ParseDestinationParams,
+  type ParseDestinationResult,
+} from "./index.types"
 import { resolveSparkDestination } from "./spark"
 import { resolveUsername } from "./resolve-username"
 
@@ -16,14 +20,24 @@ export type SparkSession = {
   network: Network
 }
 
-/** parseDestination + self-custodial-aware resolution and wrap when an SDK is connected. */
+/**
+ * parseDestination with account-aware resolution: a custodial sender re-tries a Blink
+ * username that is not a custodial account as a lightning address over LNURL; a
+ * self-custodial sender resolves and wraps through the connected SDK.
+ */
 export const resolveDestination = async (
   params: ParseDestinationParams,
   session: SparkSession,
   lnAddressHostname: string,
 ): Promise<ParseDestinationResult> => {
   const { sdk, network } = session
-  if (!sdk) return parseDestination(params)
+  if (!sdk) {
+    const parsed = await parseDestination(params)
+    if (isUnresolvedUsername(parsed)) {
+      return parseDestination({ ...params, preferLnurlForInternalHandles: true })
+    }
+    return parsed
+  }
 
   const sparkParsed = await parseSparkAddress(sdk, params.rawInput, network)
   if (sparkParsed) {

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-username.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-username.ts
@@ -1,17 +1,35 @@
-import { PaymentType } from "@blinkbitcoin/blink-client"
+import { PaymentType, type ParsedPaymentDestination } from "@blinkbitcoin/blink-client"
 
 import { getLightningAddress } from "@app/utils/pay-links"
 
-import { isSendDestination, type ParseDestinationResult } from "./index.types"
+import {
+  InvalidDestinationReason,
+  isSendDestination,
+  type ParseDestinationResult,
+  type ValidParsedPaymentDestination,
+} from "./index.types"
+
+const parsedPaymentDestination = (
+  result: ParseDestinationResult,
+): ValidParsedPaymentDestination | ParsedPaymentDestination | undefined => {
+  if (isSendDestination(result)) return result.validDestination
+  if (
+    !result.valid &&
+    result.invalidReason === InvalidDestinationReason.UsernameDoesNotExist
+  ) {
+    return result.invalidPaymentDestination
+  }
+  return undefined
+}
 
 const intraledgerHandle = (result: ParseDestinationResult): string | undefined => {
-  if (!isSendDestination(result)) return undefined
-  const { validDestination } = result
+  const destination = parsedPaymentDestination(result)
+  if (!destination) return undefined
   if (
-    validDestination.paymentType === PaymentType.Intraledger ||
-    validDestination.paymentType === PaymentType.IntraledgerWithFlag
+    destination.paymentType === PaymentType.Intraledger ||
+    destination.paymentType === PaymentType.IntraledgerWithFlag
   ) {
-    return validDestination.handle
+    return destination.handle
   }
   return undefined
 }
@@ -19,7 +37,9 @@ const intraledgerHandle = (result: ParseDestinationResult): string | undefined =
 /**
  * Re-resolves a bare Blink username as its Lightning Address so a self-custodial
  * account pays it over LNURL instead of the custodial intraledger mutation it has
- * no token for. Non-username destinations pass through unchanged.
+ * no token for. A Blink username that does not resolve to a custodial account is
+ * also re-tried this way, since it may belong to a self-custodial recipient.
+ * Non-username destinations pass through unchanged.
  */
 export const resolveUsername = async (
   result: ParseDestinationResult,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@apollo/client": "^3.9.11",
     "@bitcoinerlab/secp256k1": "^1.1.1",
-    "@blinkbitcoin/blink-client": "0.5.3",
+    "@blinkbitcoin/blink-client": "0.6.0",
     "@breeztech/breez-sdk-spark-react-native": "0.15.0",
     "@expo/react-native-action-sheet": "^4.0.1",
     "@formatjs/intl-getcanonicallocales": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,10 +2582,10 @@
     "@noble/hashes" "^1.1.5"
     "@noble/secp256k1" "^1.7.1"
 
-"@blinkbitcoin/blink-client@0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@blinkbitcoin/blink-client/-/blink-client-0.5.3.tgz#7ef372f264e1fb94f7638c35e1eb5ec8dd3601f5"
-  integrity sha512-jdd9qJEnMvceZzzI2iLVf4ArHqNC2RcusL9qYP1F2O4AK5XEkh7HMW1KB3t0MXS4DqjYmMeIFW169o1WEIahCA==
+"@blinkbitcoin/blink-client@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@blinkbitcoin/blink-client/-/blink-client-0.6.0.tgz#2d404c0c24f3ea65ac52ed63c49750d0accd10ce"
+  integrity sha512-ikW6liGeFAoi3SJB9i+C5d2QICVhEzdP9lJYdMZnEaL1WoitRO4uiG1n6vQTFEQwg0Q0OOeBK1Qoa3rNKbcF2Q==
 
 "@breeztech/breez-sdk-spark-react-native@0.15.0":
   version "0.15.0"


### PR DESCRIPTION
## Summary

Sending to a Blink Lightning address was rejected in two cases, both fixed here (part of blinkbitcoin/blink-wip#879):

- A **self-custodial** account paying a Blink username: a full address like `bulus@blink.sv` already worked, but a bare `bulus` (or any username that does not map to a custodial account) was rejected.
- A **custodial** account paying a **self-custodial** recipient's Blink Lightning address.

Both now resolve over LNURL so the payment goes through.

## Root cause

A Blink username/address is classified as an `Intraledger` destination and resolved through a custodial mutation. A self-custodial sender has no token for that mutation, and a custodial sender to a self-custodial recipient hits a username that has no custodial account. In both cases the intraledger lookup returns `UsernameDoesNotExist` and the send was never retried over LNURL.

## Fix

- **Self-custodial sender** (`resolve-username.ts`): recovers the handle from an invalid intraledger result scoped strictly to `UsernameDoesNotExist` and re-resolves `handle@<lnAddressHostname>` over LNURL. Any other invalid reason (for example `WrongDomain`) passes through unchanged, so a non-Blink URL is never rewritten into a Blink address.
- **Custodial sender** (`resolve-destination.ts`): when the intraledger lookup fails with `UsernameDoesNotExist`, re-parses the destination with the new `preferLnurlForInternalHandles` flag (added in `@blinkbitcoin/blink-client` 0.6.0, which this PR bumps to) so the Blink address resolves over LNURL. Custodial-to-custodial sends keep using intraledger; the fallback only triggers when the username is not a custodial account.
