### PR TITLE
fix: ignore failed location fallback for dollar restrictions

### DIFF
--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -213,6 +213,22 @@ describe("useDollarBalanceRestrictionSync", () => {
       expect(mockUpdateState).toHaveBeenCalledTimes(1)
     })
 
+    it("persists the stable-token flag when phone fallback fails but IP is blocked", () => {
+      mockUseDeviceLocation.mockReturnValue({
+        countryCode: "SV",
+        source: "phone",
+        detectionFailed: true,
+      })
+      mockUseIpCountryCode.mockReturnValue("FR")
+
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      expect(mockUseIpCountryCode).toHaveBeenCalledWith(true)
+      expect(mockUpdateState).toHaveBeenCalledTimes(1)
+      const updater = mockUpdateState.mock.calls[0][0]
+      expect(getStableTokenRestricted(updater(baseState))).toBe(true)
+    })
+
     it("does not persist the stable-token flag when the blocked country came from a failed location fallback", () => {
       mockUseRemoteConfig.mockReturnValue({
         ...remoteConfig,

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -113,6 +113,31 @@ describe("useDollarBalanceRestricted", () => {
       expect(read()).toBe(true)
     })
 
+    it("does not restrict when the blocked country came from a failed location fallback", () => {
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        selfCustodialDollarBalanceBlockedCountries: ["SV"],
+      })
+      mockUseDeviceLocation.mockReturnValue({
+        countryCode: "SV",
+        detectionFailed: true,
+      })
+      expect(read()).toBe(false)
+    })
+
+    it("still honors an existing persisted stable-token flag after location detection fails", () => {
+      mockPersistentState = { ...baseState, stableTokenRestricted: true }
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        selfCustodialDollarBalanceBlockedCountries: ["SV"],
+      })
+      mockUseDeviceLocation.mockReturnValue({
+        countryCode: "SV",
+        detectionFailed: true,
+      })
+      expect(read()).toBe(true)
+    })
+
     it("ignores the custodial persisted flag", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
       mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
@@ -186,6 +211,23 @@ describe("useDollarBalanceRestrictionSync", () => {
       renderHook(() => useDollarBalanceRestrictionSync())
       expect(mockUseIpCountryCode).toHaveBeenCalledWith(true)
       expect(mockUpdateState).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not persist the stable-token flag when the blocked country came from a failed location fallback", () => {
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        selfCustodialDollarBalanceBlockedCountries: ["SV"],
+      })
+      mockUseDeviceLocation.mockReturnValue({
+        countryCode: "SV",
+        source: "ip",
+        detectionFailed: true,
+      })
+
+      renderHook(() => useDollarBalanceRestrictionSync())
+
+      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
+      expect(mockUpdateState).not.toHaveBeenCalled()
     })
   })
 

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -57,8 +57,7 @@ export const useDollarBalanceRestricted = (): boolean => {
   const { countryCode, detectionFailed } = useDeviceLocation()
 
   return (
-    isPersisted ||
-    (!detectionFailed && isBlockedCountry(countryCode, blockedCountries))
+    isPersisted || (!detectionFailed && isBlockedCountry(countryCode, blockedCountries))
   )
 }
 

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -54,24 +54,30 @@ const useDollarBalanceRestrictionPolicy = (): DollarBalanceRestrictionPolicy => 
 
 export const useDollarBalanceRestricted = (): boolean => {
   const { blockedCountries, isPersisted } = useDollarBalanceRestrictionPolicy()
-  const { countryCode } = useDeviceLocation()
+  const { countryCode, detectionFailed } = useDeviceLocation()
 
-  return isPersisted || isBlockedCountry(countryCode, blockedCountries)
+  return isPersisted || (!detectionFailed && isBlockedCountry(countryCode, blockedCountries))
 }
 
 export const useDollarBalanceRestrictionSync = (): void => {
   const { blockedCountries, isPersisted, persist } = useDollarBalanceRestrictionPolicy()
-  const { countryCode, source } = useDeviceLocation()
+  const { countryCode, source, detectionFailed } = useDeviceLocation()
   const { updateState } = usePersistentStateContext()
 
-  const primaryBlocked = isBlockedCountry(countryCode, blockedCountries)
+  const primaryBlocked =
+    !detectionFailed && isBlockedCountry(countryCode, blockedCountries)
 
   const ipCountryCode = useIpCountryCode(
-    source === LocationSource.Phone && !isPersisted && !primaryBlocked,
+    source === LocationSource.Phone &&
+      !detectionFailed &&
+      !isPersisted &&
+      !primaryBlocked,
   )
 
   const shouldPersist =
-    !isPersisted && (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
+    !isPersisted &&
+    !detectionFailed &&
+    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
 
   /**
    * `persist` is in the deps on purpose: its identity flips with accountType, so

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -70,16 +70,11 @@ export const useDollarBalanceRestrictionSync = (): void => {
     !detectionFailed && isBlockedCountry(countryCode, blockedCountries)
 
   const ipCountryCode = useIpCountryCode(
-    source === LocationSource.Phone &&
-      !detectionFailed &&
-      !isPersisted &&
-      !primaryBlocked,
+    source === LocationSource.Phone && !isPersisted && !primaryBlocked,
   )
 
   const shouldPersist =
-    !isPersisted &&
-    !detectionFailed &&
-    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
+    !isPersisted && (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
 
   /**
    * `persist` is in the deps on purpose: its identity flips with accountType, so

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -56,7 +56,10 @@ export const useDollarBalanceRestricted = (): boolean => {
   const { blockedCountries, isPersisted } = useDollarBalanceRestrictionPolicy()
   const { countryCode, detectionFailed } = useDeviceLocation()
 
-  return isPersisted || (!detectionFailed && isBlockedCountry(countryCode, blockedCountries))
+  return (
+    isPersisted ||
+    (!detectionFailed && isBlockedCountry(countryCode, blockedCountries))
+  )
 }
 
 export const useDollarBalanceRestrictionSync = (): void => {


### PR DESCRIPTION
## Summary

Fixes a false-positive self-custodial Dollar account restriction when primary country detection falls back to `SV`.

`useDeviceLocation` can return `SV` with `detectionFailed=true` when phone/IP country detection fails. If Remote Config blocks `SV` for `selfCustodialDollarBalanceBlockedCountries`, the app could treat that fallback as a real blocked country and persist `stableTokenRestricted`, making the Dollar account remain unavailable even after switching regions.

This change ignores failed primary country fallbacks for Dollar balance restriction decisions, while still allowing the secondary IP lookup to persist the restriction when the real IP country is blocked.

## Changes

- Treat `detectionFailed=true` primary country values as non-blocking.
- Keep secondary IP lookup active for phone-source detection failures.
- Allow `stableTokenRestricted` persistence from a blocked IP result.
- Keep existing persisted restriction flags honored.
- Add regression coverage for:
  - failed `SV` fallback not blocking by itself
  - existing persisted stable-token restriction still blocking
  - failed phone fallback with blocked IP country still persisting the restriction

## Testing

- `direnv exec . yarn prettier --check app/hooks/use-dollar-balance-restricted.ts __tests__/hooks/use-dollar-balance-restricted.spec.ts`
- `direnv exec . yarn tsc:check`
- `direnv exec . ./node_modules/.bin/eslint app/hooks/use-dollar-balance-restricted.ts __tests__/hooks/use-dollar-balance-restricted.spec.ts --ext .js,.ts,.tsx`
- `direnv exec . yarn test __tests__/hooks/use-dollar-balance-restricted.spec.ts --runInBand`
- `direnv exec . yarn check:translations`
- `direnv exec . yarn check:codegen`
- `direnv exec . yarn graphql-check`
- `direnv exec . bash -lc 'git ls-files -z "*.js" "*.ts" "*.tsx" | xargs -0 ./node_modules/.bin/eslint'`

Results:
- Focused Jest passed: 22 tests.
- Prettier, TypeScript, focused ESLint, translations, codegen, and GraphQL checks passed.
- Tracked-file ESLint completed with 0 errors and existing warnings only.