### PR TITLE
feat(location): prioritized IP geolocation adapter chain

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -18,16 +18,18 @@ BREEZ_NETWORK=
 # ── IP geolocation (country detection fallback) ───────────────────────────────
 # Used when the user has no phone number on file.
 # Adapters are tried in priority order; the first successful response wins.
-# All keys are optional — the adapter is skipped when its key is absent.
-# Without any key, ipapi.co is used on its free (rate-limited) tier.
-
-# https://geo.ipify.org  — priority 1 (recommended)
-GEO_IPIFY_API_KEY=
-
-# https://ipinfo.io      — priority 2
+# All keys are optional — without any key the adapters run on their free tiers.
+#
+# Priority 1: ipinfo.io — free tier (ipinfo.io/json), or authenticated lite API
+#             (api.ipinfo.io/lite, Bearer header, field: country_code)
 IPINFO_API_KEY=
 
-# https://ipapi.co       — priority 3 (free tier used if key is absent)
+# Priority 2: geo.ipify.org — key required, skipped when absent
+#             (geo.ipify.org/api/v2/country, field: location.country)
+GEO_IPIFY_API_KEY=
+
+# Priority 3: ipapi.co — free tier used when key absent
+#             (ipapi.co/json/, field: country_code)
 IPAPI_API_KEY=
 
 # ── Firebase App Check (CI / debug builds only) ───────────────────────────────

--- a/.env.local.example
+++ b/.env.local.example
@@ -24,11 +24,15 @@ BREEZ_NETWORK=
 #             (api.ipinfo.io/lite, Bearer header, field: country_code)
 IPINFO_API_KEY=
 
-# Priority 2: geo.ipify.org — key required, skipped when absent
+# Priority 2: proxycheck.io — free tier used when key absent
+#             (proxycheck.io/v3/, field: <ip>.location.country_code)
+PROXYCHECK_API_KEY=
+
+# Priority 3: geo.ipify.org — key required, skipped when absent
 #             (geo.ipify.org/api/v2/country, field: location.country)
 GEO_IPIFY_API_KEY=
 
-# Priority 3: ipapi.co — free tier used when key absent
+# Priority 4: ipapi.co — free tier used when key absent
 #             (ipapi.co/json/, field: country_code)
 IPAPI_API_KEY=
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,41 @@
+# Copy this file to .env.local and fill in the values you need.
+# .env.local is gitignored. This file is the committed reference.
+#
+# All variables are optional unless marked REQUIRED.
+
+# ── Breez / Spark (self-custodial Lightning) ──────────────────────────────────
+
+# REQUIRED for self-custodial features.
+BREEZ_API_KEY=
+
+# REQUIRED for self-custodial features.
+SPARK_TOKEN_IDENTIFIER=
+
+# Lightning network to connect to. Defaults to mainnet when unset.
+# Values: mainnet | testnet | regtest
+BREEZ_NETWORK=
+
+# ── IP geolocation (country detection fallback) ───────────────────────────────
+# Used when the user has no phone number on file.
+# Adapters are tried in priority order; the first successful response wins.
+# All keys are optional — the adapter is skipped when its key is absent.
+# Without any key, ipapi.co is used on its free (rate-limited) tier.
+
+# https://geo.ipify.org  — priority 1 (recommended)
+GEO_IPIFY_API_KEY=
+
+# https://ipinfo.io      — priority 2
+IPINFO_API_KEY=
+
+# https://ipapi.co       — priority 3 (free tier used if key is absent)
+IPAPI_API_KEY=
+
+# ── Firebase App Check (CI / debug builds only) ───────────────────────────────
+
+APP_CHECK_ANDROID_DEBUG_TOKEN=
+APP_CHECK_IOS_DEBUG_TOKEN=
+
+# ── Misc ──────────────────────────────────────────────────────────────────────
+
+# Set to "true" to suppress all console output (useful in CI).
+IGNORE_LOGS=

--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -4,5 +4,6 @@ module.exports = {
   IGNORE_LOGS: "",
   GEO_IPIFY_API_KEY: "",
   IPINFO_API_KEY: "",
+  PROXYCHECK_API_KEY: "",
   IPAPI_API_KEY: "",
 }

--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -2,4 +2,7 @@ module.exports = {
   BREEZ_API_KEY: "test-api-key",
   SPARK_TOKEN_IDENTIFIER: "test-token-id",
   IGNORE_LOGS: "",
+  GEO_IPIFY_API_KEY: "",
+  IPINFO_API_KEY: "",
+  IPAPI_API_KEY: "",
 }

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -1,12 +1,20 @@
 import { renderHook, act } from "@testing-library/react-hooks"
-import axios from "axios"
 
 import useDeviceLocation, { useIpCountryCode } from "@app/hooks/use-device-location"
 
 const mockLogError = jest.fn()
 const mockUpdateCountryCode = jest.fn()
 
-jest.mock("axios")
+const mockParsePhoneNumber = jest.fn()
+jest.mock("libphonenumber-js/mobile", () => ({
+  ...jest.requireActual("libphonenumber-js/mobile"),
+  parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
+}))
+
+const mockResolveIpCountryCode = jest.fn()
+jest.mock("@app/utils/ip-country-lookup", () => ({
+  resolveIpCountryCode: (...args: unknown[]) => mockResolveIpCountryCode(...args),
+}))
 
 jest.mock("@app/utils/log-error", () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
@@ -28,12 +36,14 @@ jest.mock("@app/graphql/generated", () => ({
   useSettingsScreenQuery: (...args: unknown[]) => mockUseSettingsScreenQuery(...args),
 }))
 
-const mockedAxios = axios as jest.Mocked<typeof axios>
-
 describe("useDeviceLocation", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
     mockUseSettingsScreenQuery.mockReturnValue({ data: undefined })
+    mockParsePhoneNumber.mockImplementation(
+      jest.requireActual("libphonenumber-js/mobile").parsePhoneNumber,
+    )
   })
 
   it("should not expose any country code while loading", () => {
@@ -46,7 +56,7 @@ describe("useDeviceLocation", () => {
     expect(result.current.detectionFailed).toBe(false)
   })
 
-  it("should resolve country from logged-in user phone without calling ipapi", async () => {
+  it("should resolve country from logged-in user phone without calling IP lookup", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: "SV" },
       error: undefined,
@@ -63,7 +73,7 @@ describe("useDeviceLocation", () => {
     expect(result.current.countryCode).toBe("DE")
     expect(result.current.detectionFailed).toBe(false)
     expect(result.current.source).toBe("phone")
-    expect(mockedAxios.get).not.toHaveBeenCalled()
+    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
   })
 
   it("should update Apollo cache when resolving from user phone", async () => {
@@ -106,7 +116,33 @@ describe("useDeviceLocation", () => {
     )
   })
 
-  it("should fall back to ipapi when user has no phone", async () => {
+  it("should fall back to SV when phone parses but returns no country", async () => {
+    mockUseCountryCodeQuery.mockReturnValue({
+      data: { countryCode: "SV" },
+      error: undefined,
+    })
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "+15555555555" } },
+    })
+    mockParsePhoneNumber.mockReturnValue({ country: undefined })
+
+    const { result } = renderHook(() => useDeviceLocation())
+
+    await act(async () => {})
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.countryCode).toBe("SV")
+    expect(result.current.detectionFailed).toBe(true)
+    expect(mockUpdateCountryCode).not.toHaveBeenCalled()
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "device-location",
+        context: expect.objectContaining({ source: "phone" }),
+      }),
+    )
+  })
+
+  it("should fall back to IP lookup when user has no phone", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: "SV" },
       error: undefined,
@@ -114,8 +150,7 @@ describe("useDeviceLocation", () => {
     mockUseSettingsScreenQuery.mockReturnValue({
       data: { me: { phone: null } },
     })
-    // eslint-disable-next-line camelcase
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "PL" } })
+    mockResolveIpCountryCode.mockResolvedValue("PL")
 
     const { result } = renderHook(() => useDeviceLocation())
 
@@ -125,17 +160,30 @@ describe("useDeviceLocation", () => {
     expect(result.current.countryCode).toBe("PL")
     expect(result.current.detectionFailed).toBe(false)
     expect(result.current.source).toBe("ip")
-    expect(mockedAxios.get).toHaveBeenCalled()
+    expect(mockResolveIpCountryCode).toHaveBeenCalled()
   })
 
-  it("should resolve to the ipapi country code and never flash SV as intermediate value", async () => {
+  it("should fall back to IP lookup when user is not logged in", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: "SV" },
       error: undefined,
     })
+    mockResolveIpCountryCode.mockResolvedValue("JP")
 
-    // eslint-disable-next-line camelcase
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "PL" } })
+    const { result } = renderHook(() => useDeviceLocation())
+
+    await act(async () => {})
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.countryCode).toBe("JP")
+  })
+
+  it("should resolve to the IP lookup country code and never flash SV as intermediate value", async () => {
+    mockUseCountryCodeQuery.mockReturnValue({
+      data: { countryCode: "SV" },
+      error: undefined,
+    })
+    mockResolveIpCountryCode.mockResolvedValue("PL")
 
     const emittedValues: Array<{ countryCode: string | undefined; loading: boolean }> = []
 
@@ -159,13 +207,12 @@ describe("useDeviceLocation", () => {
     expect(allCountryCodes).not.toContain("SV")
   })
 
-  it("uses the cached country and does NOT mark detection failed when ipapi fails but cache exists", async () => {
+  it("uses the cached country and does not mark detection failed when all adapters return nothing", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: "PL" },
       error: undefined,
     })
-
-    mockedAxios.get.mockRejectedValue(new Error("429 Too Many Requests"))
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useDeviceLocation())
 
@@ -174,21 +221,14 @@ describe("useDeviceLocation", () => {
     expect(result.current.loading).toBe(false)
     expect(result.current.countryCode).toBe("PL")
     expect(result.current.detectionFailed).toBe(false)
-    expect(mockLogError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: "device-location",
-        context: expect.objectContaining({ source: "ipapi", hasCached: true }),
-      }),
-    )
   })
 
-  it("marks detection failed when ipapi fails and no cached value exists (falls back to SV)", async () => {
+  it("marks detection failed when all adapters return nothing and no cached value exists", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: null },
       error: undefined,
     })
-
-    mockedAxios.get.mockRejectedValue(new Error("Network Error"))
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useDeviceLocation())
 
@@ -197,12 +237,6 @@ describe("useDeviceLocation", () => {
     expect(result.current.loading).toBe(false)
     expect(result.current.countryCode).toBe("SV")
     expect(result.current.detectionFailed).toBe(true)
-    expect(mockLogError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: "device-location",
-        context: expect.objectContaining({ source: "ipapi", hasCached: false }),
-      }),
-    )
   })
 
   it("marks detection failed on Apollo query error (falls back to SV)", () => {
@@ -224,14 +258,12 @@ describe("useDeviceLocation", () => {
     )
   })
 
-  it("should update Apollo cache when ipapi succeeds", async () => {
+  it("should update Apollo cache when IP lookup succeeds", async () => {
     mockUseCountryCodeQuery.mockReturnValue({
       data: { countryCode: "SV" },
       error: undefined,
     })
-
-    // eslint-disable-next-line camelcase
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
+    mockResolveIpCountryCode.mockResolvedValue("DE")
 
     renderHook(() => useDeviceLocation())
 
@@ -239,58 +271,39 @@ describe("useDeviceLocation", () => {
 
     expect(mockUpdateCountryCode).toHaveBeenCalledWith(expect.anything(), "DE")
   })
-
-  it("marks detection failed when ipapi returns no country_code and no cache exists", async () => {
-    mockUseCountryCodeQuery.mockReturnValue({
-      data: { countryCode: null },
-      error: undefined,
-    })
-
-    mockedAxios.get.mockResolvedValue({ data: {} })
-
-    const { result } = renderHook(() => useDeviceLocation())
-
-    await act(async () => {})
-
-    expect(result.current.loading).toBe(false)
-    expect(result.current.countryCode).toBe("SV")
-    expect(result.current.detectionFailed).toBe(true)
-    expect(mockLogError).toHaveBeenCalled()
-  })
 })
 
 describe("useIpCountryCode", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
   })
 
-  it("does not call ipapi while disabled", () => {
+  it("does not call IP lookup while disabled", () => {
     const { result } = renderHook(() => useIpCountryCode(false))
 
-    expect(mockedAxios.get).not.toHaveBeenCalled()
+    expect(mockResolveIpCountryCode).not.toHaveBeenCalled()
     expect(result.current).toBeUndefined()
   })
 
-  it("resolves the country from ipapi when enabled", async () => {
-    // eslint-disable-next-line camelcase
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "HK" } })
+  it("resolves the country from the adapter chain when enabled", async () => {
+    mockResolveIpCountryCode.mockResolvedValue("HK")
 
     const { result } = renderHook(() => useIpCountryCode(true))
 
     await act(async () => {})
 
-    expect(mockedAxios.get).toHaveBeenCalled()
+    expect(mockResolveIpCountryCode).toHaveBeenCalled()
     expect(result.current).toBe("HK")
   })
 
-  it("stays undefined when ipapi fails", async () => {
-    mockedAxios.get.mockRejectedValue(new Error("403 Forbidden"))
+  it("stays undefined when all adapters return nothing", async () => {
+    mockResolveIpCountryCode.mockResolvedValue(undefined)
 
     const { result } = renderHook(() => useIpCountryCode(true))
 
     await act(async () => {})
 
     expect(result.current).toBeUndefined()
-    expect(mockLogError).toHaveBeenCalled()
   })
 })

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -11,12 +11,6 @@ jest.mock("libphonenumber-js/mobile", () => ({
   parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
 }))
 
-const mockParsePhoneNumber = jest.fn()
-jest.mock("libphonenumber-js/mobile", () => ({
-  ...jest.requireActual("libphonenumber-js/mobile"),
-  parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
-}))
-
 const mockResolveIpCountryCode = jest.fn()
 jest.mock("@app/utils/ip-country-lookup", () => ({
   resolveIpCountryCode: (...args: unknown[]) => mockResolveIpCountryCode(...args),
@@ -146,25 +140,6 @@ describe("useDeviceLocation", () => {
         context: expect.objectContaining({ source: "phone" }),
       }),
     )
-  })
-
-  it("should fall back to SV when phone parses but returns no country", async () => {
-    mockUseCountryCodeQuery.mockReturnValue({
-      data: { countryCode: "SV" },
-      error: undefined,
-    })
-    mockUseSettingsScreenQuery.mockReturnValue({
-      data: { me: { phone: "+15555555555" } },
-    })
-    mockParsePhoneNumber.mockReturnValue({ country: undefined })
-
-    const { result } = renderHook(() => useDeviceLocation())
-
-    await act(async () => {})
-
-    expect(result.current.loading).toBe(false)
-    expect(result.current.countryCode).toBe("SV")
-    expect(mockUpdateCountryCode).not.toHaveBeenCalled()
   })
 
   it("should fall back to IP lookup when user has no phone", async () => {

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -1,6 +1,9 @@
 import { renderHook, act } from "@testing-library/react-hooks"
 
-import useDeviceLocation, { useIpCountryCode } from "@app/hooks/use-device-location"
+import useDeviceLocation, {
+  isBlockedCountry,
+  useIpCountryCode,
+} from "@app/hooks/use-device-location"
 
 const mockLogError = jest.fn()
 const mockUpdateCountryCode = jest.fn()
@@ -305,5 +308,23 @@ describe("useIpCountryCode", () => {
     await act(async () => {})
 
     expect(result.current).toBeUndefined()
+  })
+})
+
+describe("isBlockedCountry", () => {
+  it("returns true when country is in the blocked list", () => {
+    expect(isBlockedCountry("US", ["US", "CN"])).toBe(true)
+  })
+
+  it("is case-insensitive", () => {
+    expect(isBlockedCountry("us", ["US"])).toBe(true)
+  })
+
+  it("returns false when country is not in the blocked list", () => {
+    expect(isBlockedCountry("DE", ["US", "CN"])).toBe(false)
+  })
+
+  it("returns false when countryCode is undefined", () => {
+    expect(isBlockedCountry(undefined, ["US"])).toBe(false)
   })
 })

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -11,6 +11,12 @@ jest.mock("libphonenumber-js/mobile", () => ({
   parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
 }))
 
+const mockParsePhoneNumber = jest.fn()
+jest.mock("libphonenumber-js/mobile", () => ({
+  ...jest.requireActual("libphonenumber-js/mobile"),
+  parsePhoneNumber: (...args: unknown[]) => mockParsePhoneNumber(...args),
+}))
+
 const mockResolveIpCountryCode = jest.fn()
 jest.mock("@app/utils/ip-country-lookup", () => ({
   resolveIpCountryCode: (...args: unknown[]) => mockResolveIpCountryCode(...args),
@@ -140,6 +146,25 @@ describe("useDeviceLocation", () => {
         context: expect.objectContaining({ source: "phone" }),
       }),
     )
+  })
+
+  it("should fall back to SV when phone parses but returns no country", async () => {
+    mockUseCountryCodeQuery.mockReturnValue({
+      data: { countryCode: "SV" },
+      error: undefined,
+    })
+    mockUseSettingsScreenQuery.mockReturnValue({
+      data: { me: { phone: "+15555555555" } },
+    })
+    mockParsePhoneNumber.mockReturnValue({ country: undefined })
+
+    const { result } = renderHook(() => useDeviceLocation())
+
+    await act(async () => {})
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.countryCode).toBe("SV")
+    expect(mockUpdateCountryCode).not.toHaveBeenCalled()
   })
 
   it("should fall back to IP lookup when user has no phone", async () => {

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -83,6 +83,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     jest.clearAllMocks()
     mutableConfig.GEO_IPIFY_API_KEY = ""
     mutableConfig.IPINFO_API_KEY = ""
+    mutableConfig.PROXYCHECK_API_KEY = ""
     mutableConfig.IPAPI_API_KEY = ""
   })
 
@@ -127,18 +128,55 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     )
   })
 
-  it("uses ipify when key is present and ipinfo fails", async () => {
+  it("uses ipify when key is present and ipinfo+proxycheck fail", async () => {
     mutableConfig.GEO_IPIFY_API_KEY = "test-ipify-key"
     mockedAxios.get
       .mockRejectedValueOnce(new Error("ipinfo down"))
+      .mockRejectedValueOnce(new Error("proxycheck down"))
       .mockResolvedValueOnce({ data: { location: { country: "JP" } } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
     expect(result).toBe("JP")
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.stringContaining("ipify"),
+      expect.anything(),
+    )
+  })
+
+  it("uses proxycheck.io free tier and parses country_code from nested IP entry", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        status: "ok",
+        // eslint-disable-next-line camelcase
+        "1.2.3.4": { location: { country_code: "SE" } },
+      },
+    })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("SE")
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("proxycheck.io"),
+      expect.anything(),
+    )
+  })
+
+  it("appends the api key to the proxycheck.io url when PROXYCHECK_API_KEY is set", async () => {
+    mutableConfig.PROXYCHECK_API_KEY = "test-proxycheck-key"
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        status: "ok",
+        // eslint-disable-next-line camelcase
+        "1.2.3.4": { location: { country_code: "SE" } },
+      },
+    })
+
+    await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("key=test-proxycheck-key"),
       expect.anything(),
     )
   })
@@ -168,18 +206,19 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     )
   })
 
-  it("falls through from ipinfo to ipify when ipinfo fails", async () => {
+  it("falls through ipinfo → proxycheck → ipify in order", async () => {
     mutableConfig.GEO_IPIFY_API_KEY = "test-ipify-key"
     mockedAxios.get
       .mockRejectedValueOnce(new Error("ipinfo down"))
+      .mockRejectedValueOnce(new Error("proxycheck down"))
       .mockResolvedValueOnce({ data: { location: { country: "PL" } } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
     expect(result).toBe("PL")
-    expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3)
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
-      2,
+      3,
       expect.stringContaining("ipify"),
       expect.anything(),
     )
@@ -203,6 +242,7 @@ describe("no-key warning", () => {
       jest.mock("react-native-config", () => ({
         GEO_IPIFY_API_KEY: "",
         IPINFO_API_KEY: "",
+        PROXYCHECK_API_KEY: "",
         IPAPI_API_KEY: "",
       }))
       require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -14,7 +14,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>
 const Config = require("react-native-config")
 
 const makeAdapter = (result: string | undefined | Error): IpLookupAdapter =>
-  jest.fn(async () => {
+  jest.fn(async (_timeout: number) => {
     if (result instanceof Error) throw result
     return result as any
   })

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -148,7 +148,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   it("uses proxycheck.io free tier and parses country_code from nested IP entry", async () => {
     mockedAxios.get.mockResolvedValue({
       data: {
-        status: "ok",
+        "status": "ok",
         // eslint-disable-next-line camelcase
         "1.2.3.4": { location: { country_code: "SE" } },
       },
@@ -167,7 +167,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     mutableConfig.PROXYCHECK_API_KEY = "test-proxycheck-key"
     mockedAxios.get.mockResolvedValue({
       data: {
-        status: "ok",
+        "status": "ok",
         // eslint-disable-next-line camelcase
         "1.2.3.4": { location: { country_code: "SE" } },
       },

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -101,7 +101,8 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
 
   it("uses api.ipinfo.io/lite with Bearer header when IPINFO_API_KEY is set", async () => {
     mutableConfig.IPINFO_API_KEY = "test-ipinfo-key"
-    mockedAxios.get.mockResolvedValue({ data: { "country_code": "DE" } })
+    // eslint-disable-next-line camelcase
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -144,7 +145,8 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
 
   it("appends the api key to the ipapi.co url when IPAPI_KEY is set", async () => {
     mutableConfig.IPAPI_API_KEY = "test-ipapi-key"
-    mockedAxios.get.mockResolvedValue({ data: { "country_code": "SV" } })
+    // eslint-disable-next-line camelcase
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
 
     await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -155,7 +157,8 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("calls ipapi.co without a key when IPAPI_KEY is absent", async () => {
-    mockedAxios.get.mockResolvedValue({ data: { "country_code": "SV" } })
+    // eslint-disable-next-line camelcase
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
 
     await resolveIpCountryCode(DEFAULT_ADAPTERS)
 

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -151,3 +151,40 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     )
   })
 })
+
+describe("no-key warning", () => {
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    jest.resetModules()
+  })
+
+  it("warns on module load when no API keys are configured", () => {
+    jest.isolateModules(() => {
+      jest.mock("react-native-config", () => ({
+        GEO_IPIFY_API_KEY: "",
+        IPINFO_API_KEY: "",
+        IPAPI_API_KEY: "",
+      }))
+      require("@app/utils/ip-country-lookup")
+    })
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No API key configured"))
+  })
+
+  it("does not warn when at least one API key is configured", () => {
+    jest.isolateModules(() => {
+      jest.mock("react-native-config", () => ({
+        GEO_IPIFY_API_KEY: "test-key",
+        IPINFO_API_KEY: "",
+        IPAPI_API_KEY: "",
+      }))
+      require("@app/utils/ip-country-lookup")
+    })
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -1,0 +1,153 @@
+import axios from "axios"
+
+import { IpLookupAdapter, DEFAULT_ADAPTERS, resolveIpCountryCode } from "@app/utils/ip-country-lookup"
+
+jest.mock("axios")
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: jest.fn(),
+}))
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+// react-native-config mock is at __mocks__/react-native-config.js
+// IPIFY_API_KEY and IPINFO_TOKEN default to "" (absent)
+const Config = require("react-native-config")
+
+const makeAdapter = (result: string | undefined | Error): IpLookupAdapter =>
+  jest.fn(async () => {
+    if (result instanceof Error) throw result
+    return result as any
+  })
+
+describe("resolveIpCountryCode", () => {
+  it("returns the first adapter's result and does not call subsequent adapters", async () => {
+    const first = makeAdapter("DE")
+    const second = makeAdapter("PL")
+
+    const result = await resolveIpCountryCode([first, second])
+
+    expect(result).toBe("DE")
+    expect(second).not.toHaveBeenCalled()
+  })
+
+  it("skips to the next adapter when the first throws", async () => {
+    const first = makeAdapter(new Error("network error"))
+    const second = makeAdapter("JP")
+
+    const result = await resolveIpCountryCode([first, second])
+
+    expect(result).toBe("JP")
+    expect(first).toHaveBeenCalled()
+    expect(second).toHaveBeenCalled()
+  })
+
+  it("skips to the next adapter when the first returns undefined", async () => {
+    const first = makeAdapter(undefined)
+    const second = makeAdapter("FR")
+
+    const result = await resolveIpCountryCode([first, second])
+
+    expect(result).toBe("FR")
+  })
+
+  it("returns undefined when all adapters fail", async () => {
+    const first = makeAdapter(new Error("timeout"))
+    const second = makeAdapter(new Error("rate limited"))
+
+    const result = await resolveIpCountryCode([first, second])
+
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined when all adapters return undefined", async () => {
+    const first = makeAdapter(undefined)
+    const second = makeAdapter(undefined)
+
+    const result = await resolveIpCountryCode([first, second])
+
+    expect(result).toBeUndefined()
+  })
+
+  it("returns undefined with an empty adapter list", async () => {
+    const result = await resolveIpCountryCode([])
+    expect(result).toBeUndefined()
+  })
+})
+
+describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Config.GEO_IPIFY_API_KEY = ""
+    Config.IPINFO_API_KEY = ""
+    Config.IPAPI_API_KEY = ""
+  })
+
+  it("skips ipify and ipinfo when keys are absent, falls through to ipapi", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("DE")
+    // Only one axios call — to ipapi.co (ipify and ipinfo were skipped)
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("ipapi.co"),
+      expect.anything(),
+    )
+  })
+
+  it("uses ipify first when key is present", async () => {
+    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
+    mockedAxios.get.mockResolvedValue({ data: { location: { country: "JP" } } })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("JP")
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("ipify"),
+      expect.anything(),
+    )
+  })
+
+  it("appends the api key to the ipapi.co url when IPAPI_KEY is set", async () => {
+    Config.IPAPI_API_KEY = "test-ipapi-key"
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
+
+    await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("key=test-ipapi-key"),
+      expect.anything(),
+    )
+  })
+
+  it("calls ipapi.co without a key when IPAPI_KEY is absent", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
+
+    await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.not.stringContaining("key="),
+      expect.anything(),
+    )
+  })
+
+  it("falls through from ipify to ipinfo when ipify fails", async () => {
+    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
+    Config.IPINFO_API_KEY = "test-ipinfo-token"
+    mockedAxios.get
+      .mockRejectedValueOnce(new Error("ipify down"))
+      .mockResolvedValueOnce({ data: { country: "PL" } })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("PL")
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2)
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("ipinfo.io"),
+      expect.anything(),
+    )
+  })
+})

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -82,29 +82,57 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     Config.IPAPI_API_KEY = ""
   })
 
-  it("skips ipify and ipinfo when keys are absent, falls through to ipapi", async () => {
+  it("uses ipinfo first (free tier, no key needed)", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { country: "DE" } })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("DE")
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining("ipinfo.io"),
+      expect.anything(),
+    )
+  })
+
+  it("uses api.ipinfo.io/lite with Bearer header when IPINFO_API_KEY is set", async () => {
+    Config.IPINFO_API_KEY = "test-ipinfo-key"
     mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
     expect(result).toBe("DE")
-    // Only one axios call — to ipapi.co (ipify and ipinfo were skipped)
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      expect.stringContaining("ipapi.co"),
-      expect.anything(),
+      expect.stringContaining("api.ipinfo.io/lite"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer test-ipinfo-key" }),
+      }),
     )
   })
 
-  it("uses ipify first when key is present", async () => {
-    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
-    mockedAxios.get.mockResolvedValue({ data: { location: { country: "JP" } } })
+  it("skips ipify when key is absent, uses ipinfo free tier", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { country: "JP" } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
     expect(result).toBe("JP")
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
-    expect(mockedAxios.get).toHaveBeenCalledWith(
+    expect(mockedAxios.get).not.toHaveBeenCalledWith(
+      expect.stringContaining("ipify"),
+      expect.anything(),
+    )
+  })
+
+  it("uses ipify when key is present and ipinfo fails", async () => {
+    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
+    mockedAxios.get
+      .mockRejectedValueOnce(new Error("ipinfo down"))
+      .mockResolvedValueOnce({ data: { location: { country: "JP" } } })
+
+    const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(result).toBe("JP")
+    expect(mockedAxios.get).toHaveBeenNthCalledWith(
+      2,
       expect.stringContaining("ipify"),
       expect.anything(),
     )
@@ -133,12 +161,11 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     )
   })
 
-  it("falls through from ipify to ipinfo when ipify fails", async () => {
+  it("falls through from ipinfo to ipify when ipinfo fails", async () => {
     Config.GEO_IPIFY_API_KEY = "test-ipify-key"
-    Config.IPINFO_API_KEY = "test-ipinfo-token"
     mockedAxios.get
-      .mockRejectedValueOnce(new Error("ipify down"))
-      .mockResolvedValueOnce({ data: { country: "PL" } })
+      .mockRejectedValueOnce(new Error("ipinfo down"))
+      .mockResolvedValueOnce({ data: { location: { country: "PL" } } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -146,7 +173,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     expect(mockedAxios.get).toHaveBeenCalledTimes(2)
     expect(mockedAxios.get).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining("ipinfo.io"),
+      expect.stringContaining("ipify"),
       expect.anything(),
     )
   })

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -1,6 +1,12 @@
 import axios from "axios"
+import { CountryCode } from "libphonenumber-js/mobile"
+import Config from "react-native-config"
 
-import { IpLookupAdapter, DEFAULT_ADAPTERS, resolveIpCountryCode } from "@app/utils/ip-country-lookup"
+import {
+  IpLookupAdapter,
+  DEFAULT_ADAPTERS,
+  resolveIpCountryCode,
+} from "@app/utils/ip-country-lookup"
 
 jest.mock("axios")
 jest.mock("@app/utils/error-logging", () => ({
@@ -8,15 +14,13 @@ jest.mock("@app/utils/error-logging", () => ({
 }))
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
+// Cast for mutation in tests — the __mocks__ module is a plain object
+const mutableConfig = Config as Record<string, string>
 
-// react-native-config mock is at __mocks__/react-native-config.js
-// IPIFY_API_KEY and IPINFO_TOKEN default to "" (absent)
-const Config = require("react-native-config")
-
-const makeAdapter = (result: string | undefined | Error): IpLookupAdapter =>
+const makeAdapter = (result: CountryCode | undefined | Error): IpLookupAdapter =>
   jest.fn(async (_timeout: number) => {
     if (result instanceof Error) throw result
-    return result as any
+    return result
   })
 
 describe("resolveIpCountryCode", () => {
@@ -77,9 +81,9 @@ describe("resolveIpCountryCode", () => {
 describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    Config.GEO_IPIFY_API_KEY = ""
-    Config.IPINFO_API_KEY = ""
-    Config.IPAPI_API_KEY = ""
+    mutableConfig.GEO_IPIFY_API_KEY = ""
+    mutableConfig.IPINFO_API_KEY = ""
+    mutableConfig.IPAPI_API_KEY = ""
   })
 
   it("uses ipinfo first (free tier, no key needed)", async () => {
@@ -96,8 +100,8 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("uses api.ipinfo.io/lite with Bearer header when IPINFO_API_KEY is set", async () => {
-    Config.IPINFO_API_KEY = "test-ipinfo-key"
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
+    mutableConfig.IPINFO_API_KEY = "test-ipinfo-key"
+    mockedAxios.get.mockResolvedValue({ data: { "country_code": "DE" } })
 
     const result = await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -123,7 +127,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("uses ipify when key is present and ipinfo fails", async () => {
-    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
+    mutableConfig.GEO_IPIFY_API_KEY = "test-ipify-key"
     mockedAxios.get
       .mockRejectedValueOnce(new Error("ipinfo down"))
       .mockResolvedValueOnce({ data: { location: { country: "JP" } } })
@@ -139,8 +143,8 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("appends the api key to the ipapi.co url when IPAPI_KEY is set", async () => {
-    Config.IPAPI_API_KEY = "test-ipapi-key"
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
+    mutableConfig.IPAPI_API_KEY = "test-ipapi-key"
+    mockedAxios.get.mockResolvedValue({ data: { "country_code": "SV" } })
 
     await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -151,7 +155,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("calls ipapi.co without a key when IPAPI_KEY is absent", async () => {
-    mockedAxios.get.mockResolvedValue({ data: { country_code: "SV" } })
+    mockedAxios.get.mockResolvedValue({ data: { "country_code": "SV" } })
 
     await resolveIpCountryCode(DEFAULT_ADAPTERS)
 
@@ -162,7 +166,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
   })
 
   it("falls through from ipinfo to ipify when ipinfo fails", async () => {
-    Config.GEO_IPIFY_API_KEY = "test-ipify-key"
+    mutableConfig.GEO_IPIFY_API_KEY = "test-ipify-key"
     mockedAxios.get
       .mockRejectedValueOnce(new Error("ipinfo down"))
       .mockResolvedValueOnce({ data: { location: { country: "PL" } } })
@@ -198,7 +202,7 @@ describe("no-key warning", () => {
         IPINFO_API_KEY: "",
         IPAPI_API_KEY: "",
       }))
-      require("@app/utils/ip-country-lookup")
+      require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires
     })
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No API key configured"))
   })
@@ -210,7 +214,7 @@ describe("no-key warning", () => {
         IPINFO_API_KEY: "",
         IPAPI_API_KEY: "",
       }))
-      require("@app/utils/ip-country-lookup")
+      require("@app/utils/ip-country-lookup") // eslint-disable-line @typescript-eslint/no-var-requires
     })
     expect(warnSpy).not.toHaveBeenCalled()
   })

--- a/app/hooks/use-device-location.ts
+++ b/app/hooks/use-device-location.ts
@@ -1,14 +1,13 @@
-import axios from "axios"
 import { CountryCode, parsePhoneNumber } from "libphonenumber-js/mobile"
 import { useEffect, useState } from "react"
 
 import { useApolloClient } from "@apollo/client"
 import { updateCountryCode } from "@app/graphql/client-only-query"
 import { useCountryCodeQuery, useSettingsScreenQuery } from "@app/graphql/generated"
+import { resolveIpCountryCode } from "@app/utils/ip-country-lookup"
 import { logError } from "@app/utils/log-error"
 
 const DEFAULT_COUNTRY_CODE: CountryCode = "SV"
-const IPAPI_URL = "https://ipapi.co/json/"
 
 export const LocationSource = {
   Phone: "phone",
@@ -21,34 +20,6 @@ export const isBlockedCountry = (
   countryCode: string | undefined,
   blockedCountries: string[],
 ): boolean => Boolean(countryCode && blockedCountries.includes(countryCode.toUpperCase()))
-
-const fetchCountryFromIp = async (): Promise<CountryCode | undefined> => {
-  const { data } = await axios.get(IPAPI_URL, { timeout: 5000 })
-  return data?.country_code as CountryCode | undefined
-}
-
-const resolveIpCountryCode = async (
-  context: Record<string, unknown> = {},
-): Promise<CountryCode | undefined> => {
-  try {
-    const countryCode = await fetchCountryFromIp()
-    if (!countryCode) {
-      logError({
-        scope: "device-location",
-        error: new Error("ipapi returned no country"),
-        context: { source: "ipapi", ...context },
-      })
-    }
-    return countryCode
-  } catch (err) {
-    logError({
-      scope: "device-location",
-      error: err,
-      context: { source: "ipapi", ...context },
-    })
-    return undefined
-  }
-}
 
 type DeviceLocation = {
   countryCode: CountryCode | undefined
@@ -121,7 +92,7 @@ const useDeviceLocation = (): DeviceLocation => {
     setSource(LocationSource.Ip)
     const getLocation = async () => {
       const cached = data.countryCode as CountryCode | undefined
-      const ipCountryCode = await resolveIpCountryCode({ hasCached: Boolean(cached) })
+      const ipCountryCode = await resolveIpCountryCode()
       if (ipCountryCode) {
         setCountryCode(ipCountryCode)
         setDetectionFailed(false)

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -44,6 +44,12 @@ export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
   ipapiAdapter,
 ]
 
+if (!Config.GEO_IPIFY_API_KEY && !Config.IPINFO_API_KEY && !Config.IPAPI_API_KEY) {
+  console.warn(
+    "[ip-country-lookup] No API key configured. Falling back to ipapi.co free tier, which is rate-limited. Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, or IPAPI_API_KEY in .env.local.",
+  )
+}
+
 export const resolveIpCountryCode = async (
   adapters: IpLookupAdapter[] = DEFAULT_ADAPTERS,
   timeout: number = DEFAULT_TIMEOUT_MS,

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -33,6 +33,20 @@ const ipifyAdapter: IpLookupAdapter = async (timeout) => {
   return data?.location?.country as CountryCode | undefined
 }
 
+// Free fallback with optional key; response nests data under the detected IP key
+// e.g. { "status": "ok", "1.2.3.4": { "location": { "country_code": "SE" } } }
+const proxycheckAdapter: IpLookupAdapter = async (timeout) => {
+  const url = Config.PROXYCHECK_API_KEY
+    ? `https://proxycheck.io/v3/?key=${Config.PROXYCHECK_API_KEY}`
+    : "https://proxycheck.io/v3/"
+  const { data } = await axios.get(url, { timeout })
+  type IpEntry = { location?: { country_code?: string } }
+  const ipEntry = Object.values(data as Record<string, IpEntry>).find(
+    (v) => v && typeof v === "object" && v.location?.country_code,
+  )
+  return ipEntry?.location?.country_code as CountryCode | undefined
+}
+
 // Free fallback with optional key to avoid rate limits
 const ipapiAdapter: IpLookupAdapter = async (timeout) => {
   const url = Config.IPAPI_API_KEY
@@ -44,13 +58,19 @@ const ipapiAdapter: IpLookupAdapter = async (timeout) => {
 
 export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
   ipinfoAdapter,
+  proxycheckAdapter,
   ipifyAdapter,
   ipapiAdapter,
 ]
 
-if (!Config.GEO_IPIFY_API_KEY && !Config.IPINFO_API_KEY && !Config.IPAPI_API_KEY) {
+if (
+  !Config.GEO_IPIFY_API_KEY &&
+  !Config.IPINFO_API_KEY &&
+  !Config.PROXYCHECK_API_KEY &&
+  !Config.IPAPI_API_KEY
+) {
   console.warn(
-    "[ip-country-lookup] No API key configured. Running on free tiers only (rate-limited). Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, or IPAPI_API_KEY in .env.local.",
+    "[ip-country-lookup] No API key configured. Running on free tiers only (rate-limited). Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, PROXYCHECK_API_KEY, or IPAPI_API_KEY in .env.local.",
   )
 }
 

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -1,0 +1,57 @@
+import axios from "axios"
+import { CountryCode } from "libphonenumber-js/mobile"
+import Config from "react-native-config"
+
+import { reportError } from "@app/utils/error-logging"
+
+export type IpLookupAdapter = () => Promise<CountryCode | undefined>
+
+// Paid/key-gated adapters — skipped when the key is absent, used first when present
+
+const ipifyAdapter: IpLookupAdapter = async () => {
+  if (!Config.GEO_IPIFY_API_KEY) return undefined
+  const { data } = await axios.get(
+    `https://geo.ipify.org/api/v2/country?apiKey=${Config.GEO_IPIFY_API_KEY}`,
+    { timeout: 5000 },
+  )
+  return data?.location?.country as CountryCode | undefined
+}
+
+const ipinfoAdapter: IpLookupAdapter = async () => {
+  if (!Config.IPINFO_API_KEY) return undefined
+  const { data } = await axios.get(
+    `https://ipinfo.io/json?token=${Config.IPINFO_API_KEY}`,
+    { timeout: 5000 },
+  )
+  return data?.country as CountryCode | undefined
+}
+
+// Free adapters — no key required, used as fallback
+
+const ipapiAdapter: IpLookupAdapter = async () => {
+  const url = Config.IPAPI_API_KEY
+    ? `https://ipapi.co/json/?key=${Config.IPAPI_API_KEY}`
+    : "https://ipapi.co/json/"
+  const { data } = await axios.get(url, { timeout: 5000 })
+  return data?.country_code as CountryCode | undefined
+}
+
+export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
+  ipifyAdapter,
+  ipinfoAdapter,
+  ipapiAdapter,
+]
+
+export const resolveIpCountryCode = async (
+  adapters: IpLookupAdapter[] = DEFAULT_ADAPTERS,
+): Promise<CountryCode | undefined> => {
+  for (const adapter of adapters) {
+    try {
+      const countryCode = await adapter()
+      if (countryCode) return countryCode
+    } catch (err) {
+      reportError("ip-country-lookup", err)
+    }
+  }
+  return undefined
+}

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -4,35 +4,37 @@ import Config from "react-native-config"
 
 import { reportError } from "@app/utils/error-logging"
 
-export type IpLookupAdapter = () => Promise<CountryCode | undefined>
+const DEFAULT_TIMEOUT_MS = 5000
+
+export type IpLookupAdapter = (timeout: number) => Promise<CountryCode | undefined>
 
 // Paid/key-gated adapters — skipped when the key is absent, used first when present
 
-const ipifyAdapter: IpLookupAdapter = async () => {
+const ipifyAdapter: IpLookupAdapter = async (timeout) => {
   if (!Config.GEO_IPIFY_API_KEY) return undefined
   const { data } = await axios.get(
     `https://geo.ipify.org/api/v2/country?apiKey=${Config.GEO_IPIFY_API_KEY}`,
-    { timeout: 5000 },
+    { timeout },
   )
   return data?.location?.country as CountryCode | undefined
 }
 
-const ipinfoAdapter: IpLookupAdapter = async () => {
+const ipinfoAdapter: IpLookupAdapter = async (timeout) => {
   if (!Config.IPINFO_API_KEY) return undefined
   const { data } = await axios.get(
     `https://ipinfo.io/json?token=${Config.IPINFO_API_KEY}`,
-    { timeout: 5000 },
+    { timeout },
   )
   return data?.country as CountryCode | undefined
 }
 
 // Free adapters — no key required, used as fallback
 
-const ipapiAdapter: IpLookupAdapter = async () => {
+const ipapiAdapter: IpLookupAdapter = async (timeout) => {
   const url = Config.IPAPI_API_KEY
     ? `https://ipapi.co/json/?key=${Config.IPAPI_API_KEY}`
     : "https://ipapi.co/json/"
-  const { data } = await axios.get(url, { timeout: 5000 })
+  const { data } = await axios.get(url, { timeout })
   return data?.country_code as CountryCode | undefined
 }
 
@@ -44,10 +46,11 @@ export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
 
 export const resolveIpCountryCode = async (
   adapters: IpLookupAdapter[] = DEFAULT_ADAPTERS,
+  timeout: number = DEFAULT_TIMEOUT_MS,
 ): Promise<CountryCode | undefined> => {
   for (const adapter of adapters) {
     try {
-      const countryCode = await adapter()
+      const countryCode = await adapter(timeout)
       if (countryCode) return countryCode
     } catch (err) {
       reportError("ip-country-lookup", err)

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -8,8 +8,22 @@ const DEFAULT_TIMEOUT_MS = 5000
 
 export type IpLookupAdapter = (timeout: number) => Promise<CountryCode | undefined>
 
-// Paid/key-gated adapters — skipped when the key is absent, used first when present
+// ipinfoAdapter runs first: free tier available without a key (IPINFO_API_KEY raises rate limits)
+// Authenticated: api.ipinfo.io/lite + Bearer header → field "country_code"
+// Free tier:     ipinfo.io/json (no auth)            → field "country"
+const ipinfoAdapter: IpLookupAdapter = async (timeout) => {
+  if (Config.IPINFO_API_KEY) {
+    const { data } = await axios.get("https://api.ipinfo.io/lite/", {
+      headers: { Authorization: `Bearer ${Config.IPINFO_API_KEY}` },
+      timeout,
+    })
+    return data?.country_code as CountryCode | undefined
+  }
+  const { data } = await axios.get("https://ipinfo.io/json", { timeout })
+  return data?.country as CountryCode | undefined
+}
 
+// Key-gated adapter — skipped when absent, used before free fallbacks when present
 const ipifyAdapter: IpLookupAdapter = async (timeout) => {
   if (!Config.GEO_IPIFY_API_KEY) return undefined
   const { data } = await axios.get(
@@ -19,17 +33,7 @@ const ipifyAdapter: IpLookupAdapter = async (timeout) => {
   return data?.location?.country as CountryCode | undefined
 }
 
-const ipinfoAdapter: IpLookupAdapter = async (timeout) => {
-  if (!Config.IPINFO_API_KEY) return undefined
-  const { data } = await axios.get(
-    `https://ipinfo.io/json?token=${Config.IPINFO_API_KEY}`,
-    { timeout },
-  )
-  return data?.country as CountryCode | undefined
-}
-
-// Free adapters — no key required, used as fallback
-
+// Free fallback with optional key to avoid rate limits
 const ipapiAdapter: IpLookupAdapter = async (timeout) => {
   const url = Config.IPAPI_API_KEY
     ? `https://ipapi.co/json/?key=${Config.IPAPI_API_KEY}`
@@ -39,14 +43,14 @@ const ipapiAdapter: IpLookupAdapter = async (timeout) => {
 }
 
 export const DEFAULT_ADAPTERS: IpLookupAdapter[] = [
-  ipifyAdapter,
   ipinfoAdapter,
+  ipifyAdapter,
   ipapiAdapter,
 ]
 
 if (!Config.GEO_IPIFY_API_KEY && !Config.IPINFO_API_KEY && !Config.IPAPI_API_KEY) {
   console.warn(
-    "[ip-country-lookup] No API key configured. Falling back to ipapi.co free tier, which is rate-limited. Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, or IPAPI_API_KEY in .env.local.",
+    "[ip-country-lookup] No API key configured. Running on free tiers only (rate-limited). Set GEO_IPIFY_API_KEY, IPINFO_API_KEY, or IPAPI_API_KEY in .env.local.",
   )
 }
 


### PR DESCRIPTION
## Summary

Replaces the single hardcoded `ipapi.co` call in `use-device-location` with a pluggable adapter chain. Adapters run in priority order and stop at the first successful country code — reliable services first, free tiers as fallback, zero network cost for skipped adapters.

- `app/utils/ip-country-lookup.ts` — new utility with `IpLookupAdapter` type, four concrete adapters, and `resolveIpCountryCode` runner
- `app/hooks/use-device-location.ts` — replaces inline axios fetch with `resolveIpCountryCode()`
- `.env.local.example` — committed reference for all env keys (first time all keys are documented in one place)

**Adapter priority:**
| # | Service | Key | Auth | Free tier |
|---|---------|-----|------|-----------|
| 1 | [ipinfo.io](https://ipinfo.io) | `IPINFO_API_KEY` | `Authorization: Bearer` header → `api.ipinfo.io/lite` (`country_code`) | `ipinfo.io/json` (`country`) |
| 2 | [proxycheck.io](https://proxycheck.io) | `PROXYCHECK_API_KEY` | query param | yes (`<ip>.location.country_code`) |
| 3 | [geo.ipify.org](https://geo.ipify.org) | `GEO_IPIFY_API_KEY` (required — skipped when absent) | query param | — |
| 4 | [ipapi.co](https://ipapi.co) | `IPAPI_API_KEY` | query param | yes (`country_code`) |

ipinfo.io and proxycheck.io both have free tiers with no key required. ipify is key-gated and skipped with zero network cost when absent. All providers verified against live endpoints.

## Test plan

- [x] `yarn test __tests__/utils/ip-country-lookup.spec.ts --runInBand` — 17 tests: chain priority, error fallthrough, key-gated skip, Bearer auth, free-tier routing, proxycheck nested-IP parsing, no-key warning
- [x] `yarn test __tests__/hooks/use-device-location.spec.ts --runInBand` — hook tests pass with adapter mocked at module boundary
- [x] 100% statement/branch/function/line coverage on both changed files
- [x] `tsc -p .` — no errors
- [x] `eslint` on all changed files — no errors
- [x] API responses verified against live endpoints for all four adapters

Fixes #3878

🤖 Generated with [Claude Code](https://claude.com/claude-code)