### PR TITLE
feat(restrictions): add remote switch to disable cached account restrictions


### DIFF
--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -49,6 +49,7 @@ const baseState: PersistentState = {
 const remoteConfig = {
   custodialDollarBalanceBlockedCountries: ["HK"],
   selfCustodialDollarBalanceBlockedCountries: ["FR"],
+  dollarRestrictionCacheEnabled: true,
 }
 
 const setup = (accountType: AccountType): void => {
@@ -117,6 +118,27 @@ describe("useDollarBalanceRestricted", () => {
       mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
       mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
       expect(read()).toBe(false)
+    })
+  })
+
+  describe("with the restriction cache disabled remotely", () => {
+    beforeEach(() => {
+      setup(AccountType.Custodial)
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        dollarRestrictionCacheEnabled: false,
+      })
+    })
+
+    it("ignores the persisted flag so a stale restriction can be lifted", () => {
+      mockPersistentState = { ...baseState, stablesatsRestrictedCustodial: true }
+      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      expect(read()).toBe(false)
+    })
+
+    it("still restricts from the live device country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK" })
+      expect(read()).toBe(true)
     })
   })
 })
@@ -197,12 +219,35 @@ describe("useDollarBalanceRestrictionSync", () => {
     expect(mockUpdateState).not.toHaveBeenCalled()
   })
 
+  describe("with the restriction cache disabled remotely", () => {
+    beforeEach(() => {
+      setup(AccountType.Custodial)
+      mockUseRemoteConfig.mockReturnValue({
+        ...remoteConfig,
+        dollarRestrictionCacheEnabled: false,
+      })
+    })
+
+    it("does not persist even in a blocked country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("does not consult IP", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "SV", source: "phone" })
+      renderHook(() => useDollarBalanceRestrictionSync())
+      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
+    })
+  })
+
   it("writes the self-custodial flag too when a blocked-country user switches from custodial to self-custodial", () => {
     setup(AccountType.Custodial)
     mockUseDeviceLocation.mockReturnValue({ countryCode: "HK", source: "phone" })
     mockUseRemoteConfig.mockReturnValue({
       custodialDollarBalanceBlockedCountries: ["HK"],
       selfCustodialDollarBalanceBlockedCountries: ["HK"],
+      dollarRestrictionCacheEnabled: true,
     })
 
     const { rerender } = renderHook(() => useDollarBalanceRestrictionSync())

--- a/__tests__/hooks/use-transfer-blocked.spec.ts
+++ b/__tests__/hooks/use-transfer-blocked.spec.ts
@@ -50,6 +50,7 @@ const setup = (): void => {
   mockUseRemoteConfig.mockReturnValue({
     custodialTransferBlockedCountries: ["DE"],
     selfCustodialTransferBlockedCountries: ["FR"],
+    dollarRestrictionCacheEnabled: true,
   })
   mockUseActiveWallet.mockReturnValue({ accountType: AccountType.SelfCustodial })
   mockUseIpCountryCode.mockReturnValue(undefined)
@@ -101,6 +102,27 @@ describe("useTransferBlocked", () => {
     mockPersistentState = { ...baseState, stablesatsTransferBlocked: true }
     mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
     expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
+  })
+
+  describe("with the restriction cache disabled remotely", () => {
+    beforeEach(() => {
+      mockUseRemoteConfig.mockReturnValue({
+        custodialTransferBlockedCountries: ["DE"],
+        selfCustodialTransferBlockedCountries: ["FR"],
+        dollarRestrictionCacheEnabled: false,
+      })
+    })
+
+    it("ignores the persisted flag so a stale block can be lifted", () => {
+      mockPersistentState = { ...baseState, stableTokenTransferBlocked: true }
+      mockUseDeviceLocation.mockReturnValue({ countryCode: undefined })
+      expect(renderHook(() => useTransferBlocked()).result.current).toBe(false)
+    })
+
+    it("still blocks from the live device country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR" })
+      expect(renderHook(() => useTransferBlocked()).result.current).toBe(true)
+    })
   })
 })
 
@@ -156,6 +178,7 @@ describe("useTransferBlockedSync", () => {
     mockUseRemoteConfig.mockReturnValue({
       custodialTransferBlockedCountries: ["FR"],
       selfCustodialTransferBlockedCountries: ["FR"],
+      dollarRestrictionCacheEnabled: true,
     })
     mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
     const writes: PersistentState[] = []
@@ -183,5 +206,27 @@ describe("useTransferBlockedSync", () => {
     renderHook(() => useTransferBlockedSync())
 
     expect(mockUpdateState).not.toHaveBeenCalled()
+  })
+
+  describe("with the restriction cache disabled remotely", () => {
+    beforeEach(() => {
+      mockUseRemoteConfig.mockReturnValue({
+        custodialTransferBlockedCountries: ["DE"],
+        selfCustodialTransferBlockedCountries: ["FR"],
+        dollarRestrictionCacheEnabled: false,
+      })
+    })
+
+    it("does not persist even in a blocked country", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "FR", source: "phone" })
+      renderHook(() => useTransferBlockedSync())
+      expect(mockUpdateState).not.toHaveBeenCalled()
+    })
+
+    it("does not consult IP", () => {
+      mockUseDeviceLocation.mockReturnValue({ countryCode: "AR", source: "phone" })
+      renderHook(() => useTransferBlockedSync())
+      expect(mockUseIpCountryCode).toHaveBeenCalledWith(false)
+    })
   })
 })

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -30,6 +30,7 @@ const BackupNudgeBannerThresholdKey = "backupNudgeBannerThreshold"
 const BackupNudgeModalThresholdKey = "backupNudgeModalThreshold"
 const NonCustodialEnabledKey = "nonCustodialEnabled"
 const StableBalanceEnabledKey = "stableBalanceEnabled"
+const DollarRestrictionCacheEnabledKey = "dollarRestrictionCacheEnabled"
 const AutoConvertMaxAttemptsKey = "autoConvertMaxAttempts"
 const AutoConvertPollMaxAttemptsKey = "autoConvertPollMaxAttempts"
 const AutoConvertPollIntervalMsKey = "autoConvertPollIntervalMs"
@@ -77,6 +78,7 @@ type RemoteConfig = {
   [BackupNudgeModalThresholdKey]: number
   [NonCustodialEnabledKey]: boolean
   [StableBalanceEnabledKey]: boolean
+  [DollarRestrictionCacheEnabledKey]: boolean
   [AutoConvertMaxAttemptsKey]: number
   [AutoConvertPollMaxAttemptsKey]: number
   [AutoConvertPollIntervalMsKey]: number
@@ -146,6 +148,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   backupNudgeModalThreshold: 21000,
   nonCustodialEnabled: false,
   stableBalanceEnabled: false,
+  dollarRestrictionCacheEnabled: true,
   autoConvertMaxAttempts: 3,
   autoConvertPollMaxAttempts: 30,
   autoConvertPollIntervalMs: 500,
@@ -287,6 +290,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .getValue(StableBalanceEnabledKey)
           .asBoolean()
 
+        const dollarRestrictionCacheEnabled = remoteConfigInstance()
+          .getValue(DollarRestrictionCacheEnabledKey)
+          .asBoolean()
+
         const autoConvertMaxAttempts = remoteConfigInstance()
           .getValue(AutoConvertMaxAttemptsKey)
           .asNumber()
@@ -367,6 +374,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           backupNudgeModalThreshold,
           nonCustodialEnabled,
           stableBalanceEnabled,
+          dollarRestrictionCacheEnabled,
           autoConvertMaxAttempts,
           autoConvertPollMaxAttempts,
           autoConvertPollIntervalMs,

--- a/app/hooks/use-dollar-balance-restricted.ts
+++ b/app/hooks/use-dollar-balance-restricted.ts
@@ -54,24 +54,31 @@ const useDollarBalanceRestrictionPolicy = (): DollarBalanceRestrictionPolicy => 
 
 export const useDollarBalanceRestricted = (): boolean => {
   const { blockedCountries, isPersisted } = useDollarBalanceRestrictionPolicy()
+  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
   const { countryCode } = useDeviceLocation()
 
-  return isPersisted || isBlockedCountry(countryCode, blockedCountries)
+  const isCachedRestriction = dollarRestrictionCacheEnabled && isPersisted
+
+  return isCachedRestriction || isBlockedCountry(countryCode, blockedCountries)
 }
 
 export const useDollarBalanceRestrictionSync = (): void => {
   const { blockedCountries, isPersisted, persist } = useDollarBalanceRestrictionPolicy()
+  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
   const { countryCode, source } = useDeviceLocation()
   const { updateState } = usePersistentStateContext()
 
+  const canPersistRestriction = dollarRestrictionCacheEnabled && !isPersisted
   const primaryBlocked = isBlockedCountry(countryCode, blockedCountries)
+  const isPhoneSource = source === LocationSource.Phone
 
-  const ipCountryCode = useIpCountryCode(
-    source === LocationSource.Phone && !isPersisted && !primaryBlocked,
-  )
+  const shouldConsultIp = canPersistRestriction && isPhoneSource && !primaryBlocked
+
+  const ipCountryCode = useIpCountryCode(shouldConsultIp)
 
   const shouldPersist =
-    !isPersisted && (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
+    canPersistRestriction &&
+    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
 
   /**
    * `persist` is in the deps on purpose: its identity flips with accountType, so

--- a/app/hooks/use-transfer-blocked.ts
+++ b/app/hooks/use-transfer-blocked.ts
@@ -49,24 +49,31 @@ const useTransferBlockPolicy = (): TransferBlockPolicy => {
 
 export const useTransferBlocked = (): boolean => {
   const { blockedCountries, isPersisted } = useTransferBlockPolicy()
+  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
   const { countryCode } = useDeviceLocation()
 
-  return isPersisted || isBlockedCountry(countryCode, blockedCountries)
+  const isCachedRestriction = dollarRestrictionCacheEnabled && isPersisted
+
+  return isCachedRestriction || isBlockedCountry(countryCode, blockedCountries)
 }
 
 export const useTransferBlockedSync = (): void => {
   const { blockedCountries, isPersisted, persist } = useTransferBlockPolicy()
+  const { dollarRestrictionCacheEnabled } = useRemoteConfig()
   const { countryCode, source } = useDeviceLocation()
   const { updateState } = usePersistentStateContext()
 
+  const canPersistRestriction = dollarRestrictionCacheEnabled && !isPersisted
   const primaryBlocked = isBlockedCountry(countryCode, blockedCountries)
+  const isPhoneSource = source === LocationSource.Phone
 
-  const ipCountryCode = useIpCountryCode(
-    source === LocationSource.Phone && !isPersisted && !primaryBlocked,
-  )
+  const shouldConsultIp = canPersistRestriction && isPhoneSource && !primaryBlocked
+
+  const ipCountryCode = useIpCountryCode(shouldConsultIp)
 
   const shouldPersist =
-    !isPersisted && (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
+    canPersistRestriction &&
+    (primaryBlocked || isBlockedCountry(ipCountryCode, blockedCountries))
 
   /** `persist` is in the deps so an accountType switch re-fires and writes the other flag too (anti-bypass). */
   useEffect(() => {


### PR DESCRIPTION
## What

Adds a single Firebase Remote Config switch, `dollarRestrictionCacheEnabled` (default `true`), that turns off the caching/persistence of all account restrictions: Dollar Balance and Transfer block, for both custodial (Stablesats) and self-custodial (Stable Token).

## Why

When the IP geolocation lookup is rate-limited, device detection falls back to `SV`. If `SV` happens to be in a blocked list, the restriction gets computed, **persisted**, and then sticks even after detection recovers, leaving the user wrongly restricted with no way out from the client.

This is a remote kill-switch: flipping it to `false` makes the app ignore the persisted restriction so a falsely-stuck user is released, without shipping a new build.

## How

Both restriction reads gate the persisted flag behind the switch, and both sync hooks stop writing when it is off:

- read: `(dollarRestrictionCacheEnabled && isPersisted) || isBlockedCountry(country, blockedCountries)`
- sync: only persists (and only consults IP) when the switch is on.

Live country detection is **not** touched: a user genuinely in a blocked country stays restricted regardless of the switch. The flag only governs the cached/persisted part.

## Scope

Covers every cached restriction, all read through the gated hooks (no direct reads of the persisted flags):

| Restriction | Custodial | Self-custodial |
|---|---|---|
| Dollar Balance | `stablesatsRestrictedCustodial` | `stableTokenRestricted` |
| Transfer block | `stablesatsTransferBlocked` | `stableTokenTransferBlocked` |

The Transfer button visibility and the Dollar Balance gating both flow through these hooks, so both respond to the switch. Creation/region blocks are live-only (no persistence), so they are intentionally out of scope.

## Notes

- Default `true` preserves current behavior exactly: with the flag on the logic reduces to the previous code, so existing users see no change until the switch is flipped remotely.
- The `dollarRestrictionCacheEnabled` key must be created in Firebase Remote Config (boolean). Until it exists, it falls back to the `true` default.

## Tests

Added cache-disabled coverage for both hooks (read and sync) and updated the existing specs. Full suite green.
