### PR TITLE
test(conversion): update unavailable-message assertion to the new transfer copy

### DIFF
--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -2047,7 +2047,7 @@ describe("Self-custodial conversion limits gating", () => {
     expect(getByTestId("next-button").props.accessibilityState?.disabled).toBe(true)
     await waitFor(() => {
       expect(getByTestId("amount-field-error").props.children).toContain(
-        "Conversion is temporarily unavailable",
+        "Transfers are temporarily unavailable",
       )
     })
   })


### PR DESCRIPTION
### TL;DR

Updates error message text from "Conversion" to "Transfers" for temporarily unavailable state.

### What changed?

The error message displayed when the feature is temporarily unavailable has been updated from `"Conversion is temporarily unavailable"` to `"Transfers are temporarily unavailable"`.

### How to test?

Trigger the temporarily unavailable error state on the conversion details screen and verify the error message reads `"Transfers are temporarily unavailable"`.

### Why make this change?

The previous wording was too specific to "Conversion," while "Transfers" is a more accurate and consistent term that better reflects the broader scope of the feature being restricted.