### PR TITLE
fix(bulletins): prevent app crash from bulletin icons with unmapped names


### DIFF
--- a/__tests__/components/atomic/galoy-icon/galoy-icon.spec.tsx
+++ b/__tests__/components/atomic/galoy-icon/galoy-icon.spec.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+import { ThemeProvider } from "@rn-vui/themed"
+
+import { GaloyIcon, IconNamesType } from "@app/components/atomic/galoy-icon"
+import theme from "@app/rne-theme/theme"
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>)
+
+describe("GaloyIcon", () => {
+  it("returns null for an unmapped icon name instead of rendering undefined", () => {
+    const { toJSON } = renderWithTheme(
+      <GaloyIcon name={"warning-with_background" as IconNamesType} size={24} />,
+    )
+
+    expect(toJSON()).toBeNull()
+  })
+
+  describe("phosphor icons", () => {
+    it("renders with a numeric size", () => {
+      expect(renderWithTheme(<GaloyIcon name="info" size={24} />).toJSON()).not.toBeNull()
+    })
+
+    it("renders inside a background container", () => {
+      expect(
+        renderWithTheme(
+          <GaloyIcon name="info" size={24} backgroundColor="red" />,
+        ).toJSON(),
+      ).not.toBeNull()
+    })
+
+    it("renders with a custom color and opacity", () => {
+      expect(
+        renderWithTheme(
+          <GaloyIcon name="info" size={24} color="blue" opacity={0.5} />,
+        ).toJSON(),
+      ).not.toBeNull()
+    })
+
+    it("renders with a size variant", () => {
+      expect(
+        renderWithTheme(<GaloyIcon name="info" sizeVariant="lg" />).toJSON(),
+      ).not.toBeNull()
+    })
+  })
+
+  describe("custom SVG icons", () => {
+    it("renders with a numeric size", () => {
+      expect(
+        renderWithTheme(<GaloyIcon name="warning-with-background" size={24} />).toJSON(),
+      ).not.toBeNull()
+    })
+
+    it("renders inside a background container", () => {
+      expect(
+        renderWithTheme(
+          <GaloyIcon name="warning-with-background" size={24} backgroundColor="red" />,
+        ).toJSON(),
+      ).not.toBeNull()
+    })
+
+    it("renders with explicit width and height", () => {
+      expect(
+        renderWithTheme(
+          <GaloyIcon name="warning-with-background" width={24} height={24} />,
+        ).toJSON(),
+      ).not.toBeNull()
+    })
+  })
+})

--- a/__tests__/components/bulletins.spec.tsx
+++ b/__tests__/components/bulletins.spec.tsx
@@ -178,6 +178,17 @@ describe("BulletinsCard", () => {
     expect(queryByTestId("galoy-icon-payment-success")).toBeTruthy()
   })
 
+  it("replaces every underscore in a multi-word icon enum", () => {
+    const bulletins = makeBulletinsQuery([
+      makeBulletin({ icon: "WARNING_WITH_BACKGROUND" as Icon }),
+    ])
+    const { queryByTestId } = render(
+      <BulletinsCard loading={false} bulletins={bulletins} />,
+    )
+
+    expect(queryByTestId("galoy-icon-warning-with-background")).toBeTruthy()
+  })
+
   it("does not render icon when icon is null", () => {
     const bulletins = makeBulletinsQuery([makeBulletin()])
     const { queryByTestId } = render(

--- a/app/components/atomic/galoy-icon/galoy-icon.tsx
+++ b/app/components/atomic/galoy-icon/galoy-icon.tsx
@@ -333,6 +333,16 @@ export const GaloyIcon = ({
     )
   }
 
+  /**
+   * `name` is typed as a valid icon key, but callers can cast an arbitrary
+   * runtime string (e.g. a backend-provided icon name) through `as IconNamesType`,
+   * so an unmapped name can reach here. Render nothing rather than `undefined`,
+   * which would otherwise crash the whole subtree with "Element type is invalid".
+   */
+  if (!(name in customSvgMap)) {
+    return null
+  }
+
   const SvgIcon = customSvgMap[name as keyof typeof customSvgMap]
   if (backgroundColor) {
     return (

--- a/app/components/notifications/bulletins.tsx
+++ b/app/components/notifications/bulletins.tsx
@@ -75,7 +75,7 @@ export const BulletinsCard: React.FC<Props> = ({ loading, bulletins }) => {
             <NotificationCardUI
               icon={
                 bulletin.icon
-                  ? (bulletin.icon.toLowerCase().replace("_", "-") as IconNamesType)
+                  ? (bulletin.icon.toLowerCase().replace(/_/g, "-") as IconNamesType)
                   : undefined
               }
               key={bulletin.id}


### PR DESCRIPTION
## Problem

The app crashes with a React error boundary showing `Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined` when a bulletin is rendered. The whole subtree is bricked and restarting the app does not help.

The original report (blinkbitcoin/blink-wip#919) framed it as happening "after an account switch via push notification", but that was only the trigger: switching accounts surfaced a bulletin belonging to that account, and rendering that bulletin is what crashed.

## Root cause

It was **not** a missing icon, and **not** an icon that does not exist. The backend sent a **valid** icon (`WARNING_WITH_BACKGROUND`, which is present in the icon map as `warning-with-background`). The bug was in how the icon name was converted before the map lookup:

```ts
bulletin.icon.toLowerCase().replace("_", "-")
```

`String.prototype.replace` with a string argument replaces only the **first** occurrence, so a name with more than one underscore was converted incorrectly:

| step | value |
|------|-------|
| backend `bulletin.icon` | `WARNING_WITH_BACKGROUND` |
| `.toLowerCase()` | `warning_with_background` |
| `.replace("_", "-")` | `warning-with_background` (only the first `_` replaced) |
| icon map lookup | `icons["warning-with_background"]` = `undefined` |

`GaloyIcon` then rendered `<undefined />`, which throws "Element type is invalid" and trips the error boundary. The icon itself was fine; the generated lookup key was wrong.

## Fix (two layers)

1. `bulletins.tsx`: use `.replace(/_/g, "-")` so **every** underscore is replaced. `WARNING_WITH_BACKGROUND` now resolves to `warning-with-background` and the icon renders as intended. Single-underscore names (e.g. `PAYMENT_SUCCESS`) produce the same result as before, so existing bulletins are unaffected.
2. `galoy-icon.tsx`: guard the SVG lookup so an unmapped name returns `null` instead of rendering `undefined`. `name` is typed as a valid icon key, but callers can cast an arbitrary runtime string through `as IconNamesType`, so this is defense in depth: no bulletin (or any other caller) can ever crash the whole app with a bad icon name again.
