### PR TITLE
fix(self-custodial): claim on-chain deposits at the network-recommended fee

### DIFF
--- a/__tests__/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.spec.ts
+++ b/__tests__/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.spec.ts
@@ -36,7 +36,11 @@ jest.mock("@app/self-custodial/hooks/use-spark-network", () => ({
 }))
 
 jest.mock("@app/self-custodial/bridge", () => ({
-  selfCustodialRestoreWallet: (...args: string[]) => mockRestore(...args),
+  selfCustodialRestoreWallet: (...args: unknown[]) => mockRestore(...args),
+}))
+
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => ({ selfCustodialDepositClaimLeewayVbyte: 5 }),
 }))
 
 jest.mock("@app/self-custodial/storage/account-index", () => ({
@@ -111,11 +115,12 @@ describe("useRestoreWallet", () => {
       await result.current.restore("word1 word2 word3")
     })
 
-    expect(mockRestore).toHaveBeenCalledWith(
-      TEST_ACCOUNT_ID,
-      "word1 word2 word3",
-      mockSparkNetwork.Regtest,
-    )
+    expect(mockRestore).toHaveBeenCalledWith({
+      accountId: TEST_ACCOUNT_ID,
+      mnemonic: "word1 word2 word3",
+      network: mockSparkNetwork.Regtest,
+      leewaySatPerVbyte: 5,
+    })
     expect(mockReloadSelfCustodialAccounts).toHaveBeenCalledTimes(1)
     expect(mockUpdateState).toHaveBeenCalledTimes(1)
     expect(mockReinitSdk).toHaveBeenCalledTimes(1)

--- a/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
+++ b/__tests__/screens/settings-screen/self-custodial/profile-row.spec.tsx
@@ -171,6 +171,10 @@ jest.mock("@app/self-custodial/probe-account-wallets", () => ({
   },
 }))
 
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => ({ selfCustodialDepositClaimLeewayVbyte: 5 }),
+}))
+
 jest.mock("@app/utils/error-logging", () => ({
   reportError: jest.fn(),
 }))
@@ -294,7 +298,11 @@ describe("ProfileRow", () => {
     fireEvent.press(getByTestId(`delete-button-${TEST_ENTRY_ID}`))
 
     expect(await findByTestId("delete-modal")).toBeTruthy()
-    expect(mockProbeWallets).toHaveBeenCalledWith(TEST_ENTRY_ID, mockSparkNetwork.Mainnet)
+    expect(mockProbeWallets).toHaveBeenCalledWith(
+      TEST_ENTRY_ID,
+      mockSparkNetwork.Mainnet,
+      5,
+    )
     expect(mockDeleteWallet).not.toHaveBeenCalled()
   })
 

--- a/__tests__/screens/unclaimed-deposits/use-deposit-actions.spec.ts
+++ b/__tests__/screens/unclaimed-deposits/use-deposit-actions.spec.ts
@@ -162,6 +162,73 @@ describe("useDepositActions", () => {
     })
   })
 
+  describe("handleClaim — max fee override", () => {
+    it("overrides the auto-claim cap with the SDK-reported required fee", async () => {
+      const { result } = renderHook(() => useDepositActions())
+      const deposit = buildDeposit({
+        errorReason: DepositErrorReason.FeeExceeded,
+        requiredFeeSats: 198,
+      })
+
+      await act(async () => {
+        await result.current.handleClaim(deposit)
+      })
+
+      expect(mockClaimDeposit).toHaveBeenCalledWith({
+        depositId: "deposit-1",
+        maxFeeSats: 198,
+      })
+    })
+
+    it("claims without a fee override when no required fee is known", async () => {
+      const { result } = renderHook(() => useDepositActions())
+      const deposit = buildDeposit()
+
+      await act(async () => {
+        await result.current.handleClaim(deposit)
+      })
+
+      expect(mockClaimDeposit).toHaveBeenCalledWith({
+        depositId: "deposit-1",
+        maxFeeSats: undefined,
+      })
+    })
+
+    it("toasts success when the claim is accepted", async () => {
+      const { result } = renderHook(() => useDepositActions())
+      const deposit = buildDeposit()
+
+      await act(async () => {
+        await result.current.handleClaim(deposit)
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Deposit claimed", type: "success" }),
+      )
+    })
+
+    it("surfaces the required-fee message when the claim still exceeds the cap", async () => {
+      mockClaimDeposit.mockResolvedValue({
+        status: PaymentResultStatus.Failed,
+        errors: [{ message: "MaxDepositClaimFeeExceeded" }],
+      })
+
+      const { result } = renderHook(() => useDepositActions())
+      const deposit = buildDeposit({
+        errorReason: DepositErrorReason.FeeExceeded,
+        requiredFeeSats: 198,
+      })
+
+      await act(async () => {
+        await result.current.handleClaim(deposit)
+      })
+
+      expect(mockToastShow).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Fee exceeded 198" }),
+      )
+    })
+  })
+
   describe("refresh", () => {
     it("filters out refunded deposits", async () => {
       mockListPendingDeposits.mockResolvedValue({

--- a/__tests__/self-custodial/bridge.spec.ts
+++ b/__tests__/self-custodial/bridge.spec.ts
@@ -46,6 +46,12 @@ jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
   StableBalanceActiveLabel: {
     Set: jest.fn().mockImplementation((args) => ({ tag: "Set", inner: args })),
   },
+  MaxFee: {
+    NetworkRecommended: jest
+      .fn()
+      .mockImplementation((inner) => ({ tag: "NetworkRecommended", inner })),
+    Fixed: jest.fn().mockImplementation((inner) => ({ tag: "Fixed", inner })),
+  },
   connect: (...args: readonly unknown[]) => mockConnect(...args),
   defaultConfig: jest.fn().mockReturnValue({}),
   initLogging: jest.fn(),
@@ -146,11 +152,12 @@ describe("selfCustodialRestoreWallet", () => {
   })
 
   it("stores provided mnemonic and network", async () => {
-    await selfCustodialRestoreWallet(
-      "test-account-id",
-      "restore word1 word2 word3",
-      Network.Regtest,
-    )
+    await selfCustodialRestoreWallet({
+      accountId: "test-account-id",
+      mnemonic: "restore word1 word2 word3",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockSetMnemonicForAccount).toHaveBeenCalledWith(
       "test-account-id",
@@ -166,7 +173,12 @@ describe("selfCustodialRestoreWallet", () => {
     mockSetMnemonicForAccount.mockResolvedValue(false)
 
     await expect(
-      selfCustodialRestoreWallet("test-account-id", "mnemonic", Network.Regtest),
+      selfCustodialRestoreWallet({
+        accountId: "test-account-id",
+        mnemonic: "mnemonic",
+        network: Network.Regtest,
+        leewaySatPerVbyte: 1,
+      }),
     ).rejects.toThrow("Failed to store mnemonic")
   })
 })

--- a/__tests__/self-custodial/bridge/lifecycle.spec.ts
+++ b/__tests__/self-custodial/bridge/lifecycle.spec.ts
@@ -41,6 +41,12 @@ jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
   StableBalanceActiveLabel: {
     Set: jest.fn().mockImplementation((args: unknown) => ({ tag: "Set", inner: args })),
   },
+  MaxFee: {
+    NetworkRecommended: jest
+      .fn()
+      .mockImplementation((inner: unknown) => ({ tag: "NetworkRecommended", inner })),
+    Fixed: jest.fn().mockImplementation((inner: unknown) => ({ tag: "Fixed", inner })),
+  },
   connect: (...args: unknown[]) => mockConnect(...args),
   defaultConfig: (...args: unknown[]) => mockDefaultConfig(...args),
   initLogging: jest.fn(),
@@ -110,7 +116,12 @@ describe("initSdk", () => {
     const sdk = makeSdk()
     mockConnect.mockResolvedValue(sdk)
 
-    const result = await initSdk("word1 word2 word3", "/test/storage", Network.Regtest)
+    const result = await initSdk({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/test/storage",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockDefaultConfig).toHaveBeenCalledWith(Network.Regtest)
     expect(mockConnect).toHaveBeenCalledTimes(1)
@@ -126,11 +137,104 @@ describe("initSdk", () => {
     expect(result).toBe(sdk)
   })
 
+  it("caps the automatic deposit claim fee at the network-recommended rate plus leeway", async () => {
+    mockConnect.mockResolvedValue(makeSdk())
+
+    await initSdk({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/test/storage",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          maxDepositClaimFee: {
+            tag: "NetworkRecommended",
+            inner: { leewaySatPerVbyte: 1n },
+          },
+        }),
+      }),
+    )
+  })
+
+  it("uses the provided leeway for the deposit claim fee cap", async () => {
+    mockConnect.mockResolvedValue(makeSdk())
+
+    await initSdk({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/test/storage",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 3,
+    })
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          maxDepositClaimFee: {
+            tag: "NetworkRecommended",
+            inner: { leewaySatPerVbyte: 3n },
+          },
+        }),
+      }),
+    )
+  })
+
+  it("truncates a fractional leeway so BigInt does not throw on it", async () => {
+    mockConnect.mockResolvedValue(makeSdk())
+
+    await initSdk({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/test/storage",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 2.9,
+    })
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          maxDepositClaimFee: {
+            tag: "NetworkRecommended",
+            inner: { leewaySatPerVbyte: 2n },
+          },
+        }),
+      }),
+    )
+  })
+
+  it("clamps a negative leeway to zero", async () => {
+    mockConnect.mockResolvedValue(makeSdk())
+
+    await initSdk({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/test/storage",
+      network: Network.Regtest,
+      leewaySatPerVbyte: -5,
+    })
+
+    expect(mockConnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          maxDepositClaimFee: {
+            tag: "NetworkRecommended",
+            inner: { leewaySatPerVbyte: 0n },
+          },
+        }),
+      }),
+    )
+  })
+
   it("propagates connection errors from the SDK", async () => {
     mockConnect.mockRejectedValue(new Error("connect refused"))
 
     await expect(
-      initSdk("word1 word2 word3", "/test/storage", Network.Regtest),
+      initSdk({
+        mnemonic: "word1 word2 word3",
+        storageDir: "/test/storage",
+        network: Network.Regtest,
+        leewaySatPerVbyte: 1,
+      }),
     ).rejects.toThrow("connect refused")
   })
 })
@@ -220,33 +324,36 @@ describe("selfCustodialRestoreWallet", () => {
   })
 
   it("trims/normalises whitespace before validating the mnemonic", async () => {
-    await selfCustodialRestoreWallet(
-      "test-account",
-      "  alpha   beta  gamma  ",
-      Network.Regtest,
-    )
+    await selfCustodialRestoreWallet({
+      accountId: "test-account",
+      mnemonic: "  alpha   beta  gamma  ",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockValidateMnemonic).toHaveBeenCalledWith("alpha beta gamma")
     expect(mockSetMnemonic).toHaveBeenCalledWith("alpha beta gamma")
   })
 
   it("normalises tabs and newlines before validating the mnemonic", async () => {
-    await selfCustodialRestoreWallet(
-      "test-account",
-      "\talpha\tbeta\ngamma\r\n",
-      Network.Regtest,
-    )
+    await selfCustodialRestoreWallet({
+      accountId: "test-account",
+      mnemonic: "\talpha\tbeta\ngamma\r\n",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockValidateMnemonic).toHaveBeenCalledWith("alpha beta gamma")
     expect(mockSetMnemonic).toHaveBeenCalledWith("alpha beta gamma")
   })
 
   it("normalises mixed whitespace runs before validating the mnemonic", async () => {
-    await selfCustodialRestoreWallet(
-      "test-account",
-      "  alpha\t\tbeta \n gamma  ",
-      Network.Regtest,
-    )
+    await selfCustodialRestoreWallet({
+      accountId: "test-account",
+      mnemonic: "  alpha\t\tbeta \n gamma  ",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockValidateMnemonic).toHaveBeenCalledWith("alpha beta gamma")
     expect(mockSetMnemonic).toHaveBeenCalledWith("alpha beta gamma")
@@ -256,7 +363,12 @@ describe("selfCustodialRestoreWallet", () => {
     mockValidateMnemonic.mockReturnValueOnce(false)
 
     await expect(
-      selfCustodialRestoreWallet("test-account", "totally invalid", Network.Regtest),
+      selfCustodialRestoreWallet({
+        accountId: "test-account",
+        mnemonic: "totally invalid",
+        network: Network.Regtest,
+        leewaySatPerVbyte: 1,
+      }),
     ).rejects.toThrow("Invalid BIP39 mnemonic")
 
     expect(mockSetMnemonic).not.toHaveBeenCalled()
@@ -265,11 +377,12 @@ describe("selfCustodialRestoreWallet", () => {
   })
 
   it("stores the mnemonic and writes the active network label on success", async () => {
-    await selfCustodialRestoreWallet(
-      "test-account",
-      "provided mnemonic words",
-      Network.Regtest,
-    )
+    await selfCustodialRestoreWallet({
+      accountId: "test-account",
+      mnemonic: "provided mnemonic words",
+      network: Network.Regtest,
+      leewaySatPerVbyte: 1,
+    })
 
     expect(mockSetMnemonic).toHaveBeenCalledWith("provided mnemonic words")
     expect(mockSetMnemonicNetwork).toHaveBeenCalledTimes(1)
@@ -282,7 +395,12 @@ describe("selfCustodialRestoreWallet", () => {
     mockSetMnemonic.mockResolvedValueOnce(false)
 
     await expect(
-      selfCustodialRestoreWallet("test-account", "any words", Network.Regtest),
+      selfCustodialRestoreWallet({
+        accountId: "test-account",
+        mnemonic: "any words",
+        network: Network.Regtest,
+        leewaySatPerVbyte: 1,
+      }),
     ).rejects.toThrow("Failed to store mnemonic")
     expect(mockSetMnemonicNetwork).not.toHaveBeenCalled()
     expect(mockConnect).not.toHaveBeenCalled()
@@ -292,7 +410,12 @@ describe("selfCustodialRestoreWallet", () => {
     mockConnect.mockRejectedValueOnce(new Error("SDK init refused"))
 
     await expect(
-      selfCustodialRestoreWallet("test-account", "any valid words", Network.Regtest),
+      selfCustodialRestoreWallet({
+        accountId: "test-account",
+        mnemonic: "any valid words",
+        network: Network.Regtest,
+        leewaySatPerVbyte: 1,
+      }),
     ).rejects.toThrow("SDK init refused")
 
     expect(mockSetMnemonic).toHaveBeenCalledTimes(1)

--- a/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
+++ b/__tests__/self-custodial/hooks/use-sdk-lifecycle.spec.ts
@@ -85,6 +85,13 @@ jest.mock("@app/self-custodial/config", () => ({
   storageDirFor: (id: string) => `/tmp/${id}`,
 }))
 
+let mockDepositClaimLeewayVbyte = 7
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => ({
+    selfCustodialDepositClaimLeewayVbyte: mockDepositClaimLeewayVbyte,
+  }),
+}))
+
 const mockRecordError = jest.fn()
 const mockCrashlyticsLog = jest.fn()
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
@@ -110,6 +117,7 @@ const buildSdk = (id: string) => ({ id }) as unknown as object
 describe("useSdkLifecycle", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockDepositClaimLeewayVbyte = 7
     mockGetMnemonicForAccount.mockResolvedValue("word1 word2 word3")
     mockValidateStoredNetwork.mockResolvedValue(true)
     mockGetSnapshot.mockResolvedValue({
@@ -171,6 +179,30 @@ describe("useSdkLifecycle", () => {
     })
   })
 
+  describe("remote-config leeway changes", () => {
+    it("does not reconnect the SDK when only the deposit-claim leeway changes", async () => {
+      mockInitSdk.mockResolvedValue(buildSdk("sdk-1"))
+      captureListener()
+
+      const { rerender, result } = renderHook(
+        ({ accountId }: { accountId: string }) => useSdkLifecycle(accountId, 0),
+        { initialProps: { accountId: "acct-1" } },
+      )
+
+      await waitFor(() => {
+        expect(result.current.sdk).not.toBeNull()
+      })
+      expect(mockInitSdk).toHaveBeenCalledTimes(1)
+
+      mockDepositClaimLeewayVbyte = 9
+      rerender({ accountId: "acct-1" })
+      await act(async () => {})
+
+      expect(mockInitSdk).toHaveBeenCalledTimes(1)
+      expect(mockDisconnectSdk).not.toHaveBeenCalled()
+    })
+  })
+
   describe("happy path", () => {
     it("loads the mnemonic, validates the network, initializes the SDK, and reaches Ready after the Synced event", async () => {
       const sdk = buildSdk("sdk-1")
@@ -188,11 +220,12 @@ describe("useSdkLifecycle", () => {
         "acct-1",
         mockSparkNetwork.Regtest,
       )
-      expect(mockInitSdk).toHaveBeenCalledWith(
-        "word1 word2 word3",
-        "/tmp/acct-1",
-        mockSparkNetwork.Regtest,
-      )
+      expect(mockInitSdk).toHaveBeenCalledWith({
+        mnemonic: "word1 word2 word3",
+        storageDir: "/tmp/acct-1",
+        network: mockSparkNetwork.Regtest,
+        leewaySatPerVbyte: 7,
+      })
       expect(result.current.connectedAccountId).toBe("acct-1")
 
       await waitFor(() => {
@@ -252,11 +285,12 @@ describe("useSdkLifecycle", () => {
       )
 
       await waitFor(() => {
-        expect(mockInitSdk).toHaveBeenCalledWith(
-          "word1 word2 word3",
-          "/tmp/acct-A",
-          mockSparkNetwork.Regtest,
-        )
+        expect(mockInitSdk).toHaveBeenCalledWith({
+          mnemonic: "word1 word2 word3",
+          storageDir: "/tmp/acct-A",
+          network: mockSparkNetwork.Regtest,
+          leewaySatPerVbyte: 7,
+        })
       })
 
       rerender({ accountId: "acct-B" })
@@ -265,11 +299,12 @@ describe("useSdkLifecycle", () => {
         expect(mockDisconnectSdk).toHaveBeenCalledWith(sdkA)
       })
       await waitFor(() => {
-        expect(mockInitSdk).toHaveBeenCalledWith(
-          "word1 word2 word3",
-          "/tmp/acct-B",
-          mockSparkNetwork.Regtest,
-        )
+        expect(mockInitSdk).toHaveBeenCalledWith({
+          mnemonic: "word1 word2 word3",
+          storageDir: "/tmp/acct-B",
+          network: mockSparkNetwork.Regtest,
+          leewaySatPerVbyte: 7,
+        })
       })
 
       expect(mockDisconnectSdk.mock.invocationCallOrder[0]).toBeLessThan(

--- a/__tests__/self-custodial/probe-account-wallets.spec.ts
+++ b/__tests__/self-custodial/probe-account-wallets.spec.ts
@@ -41,6 +41,7 @@ jest.mock("@react-native-firebase/crashlytics", () => () => ({
 const TEST_ACCOUNT_ID = "account-123"
 const TEST_MNEMONIC = "abandon abandon abandon abandon abandon abandon"
 const FAKE_SDK = { id: "sdk-instance" }
+const TEST_LEEWAY = 4
 
 const sampleWallets = [
   {
@@ -68,6 +69,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
     expect(result).toEqual({ status: ProbeAccountWalletsStatus.NoMnemonic })
@@ -87,13 +89,15 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
-    expect(mockInitSdk).toHaveBeenCalledWith(
-      TEST_MNEMONIC,
-      `/storage/spark/${TEST_ACCOUNT_ID}`,
-      Network.Regtest,
-    )
+    expect(mockInitSdk).toHaveBeenCalledWith({
+      mnemonic: TEST_MNEMONIC,
+      storageDir: `/storage/spark/${TEST_ACCOUNT_ID}`,
+      network: Network.Regtest,
+      leewaySatPerVbyte: TEST_LEEWAY,
+    })
     expect(mockGetSnapshot).toHaveBeenCalledWith(FAKE_SDK)
     expect(result).toEqual({
       status: ProbeAccountWalletsStatus.Ok,
@@ -110,7 +114,7 @@ describe("probeSelfCustodialAccountWallets", () => {
       rawTransactionCount: 0,
     })
 
-    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest)
+    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest, TEST_LEEWAY)
 
     expect(mockDisconnectSdk).toHaveBeenCalledWith(FAKE_SDK)
   })
@@ -123,6 +127,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
     expect(result.status).toBe(ProbeAccountWalletsStatus.ProbeFailed)
@@ -139,6 +144,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
     expect(result.status).toBe(ProbeAccountWalletsStatus.ProbeFailed)
@@ -156,6 +162,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
     expect(result.status).toBe(ProbeAccountWalletsStatus.ProbeFailed)
@@ -178,6 +185,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const result = await probeSelfCustodialAccountWallets(
       TEST_ACCOUNT_ID,
       Network.Regtest,
+      TEST_LEEWAY,
     )
 
     expect(result).toEqual({
@@ -197,7 +205,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     const disconnectError = new Error("SQLite handle locked")
     mockDisconnectSdk.mockRejectedValueOnce(disconnectError)
 
-    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest)
+    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest, TEST_LEEWAY)
 
     expect(mockRecordError).toHaveBeenCalledWith(disconnectError)
   })
@@ -212,7 +220,7 @@ describe("probeSelfCustodialAccountWallets", () => {
     })
     mockDisconnectSdk.mockRejectedValueOnce("native handle invalid")
 
-    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest)
+    await probeSelfCustodialAccountWallets(TEST_ACCOUNT_ID, Network.Regtest, TEST_LEEWAY)
 
     expect(mockRecordError).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/__tests__/self-custodial/providers/wallet.spec.tsx
+++ b/__tests__/self-custodial/providers/wallet.spec.tsx
@@ -101,6 +101,7 @@ jest.mock("@app/config/feature-flags-context", () => ({
     nonCustodialEnabled: true,
     stableBalanceEnabled: mockStableBalanceEnabled,
   }),
+  useRemoteConfig: () => ({ selfCustodialDepositClaimLeewayVbyte: 1 }),
 }))
 
 jest.mock("@app/i18n/i18n-react", () => ({
@@ -357,11 +358,12 @@ describe("SelfCustodialWalletProvider", () => {
       expect(result.current.status).toBe(ActiveWalletStatus.Ready)
     })
 
-    expect(mockInitSdk).toHaveBeenCalledWith(
-      "word1 word2 word3",
-      "/tmp/test-self-custodial-uuid",
-      mockSparkNetwork.Regtest,
-    )
+    expect(mockInitSdk).toHaveBeenCalledWith({
+      mnemonic: "word1 word2 word3",
+      storageDir: "/tmp/test-self-custodial-uuid",
+      network: mockSparkNetwork.Regtest,
+      leewaySatPerVbyte: 1,
+    })
   })
 
   it("handles refresh error gracefully", async () => {

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -43,6 +43,7 @@ const SelfCustodialTransferBlockedCountriesKey = "selfCustodialTransferBlockedCo
 const CustodialTransferBlockedCountriesKey = "custodialTransferBlockedCountries"
 const CustodialCreationBlockedCountriesKey = "custodialCreationBlockedCountries"
 const SelfCustodialCreationBlockedCountriesKey = "selfCustodialCreationBlockedCountries"
+const SelfCustodialDepositClaimLeewayVbyteKey = "selfCustodialDepositClaimLeewayVbyte"
 
 type DeliveryOptionConfig = {
   minDays: number
@@ -90,6 +91,7 @@ type RemoteConfig = {
   [CustodialTransferBlockedCountriesKey]: string[]
   [CustodialCreationBlockedCountriesKey]: string[]
   [SelfCustodialCreationBlockedCountriesKey]: string[]
+  [SelfCustodialDepositClaimLeewayVbyteKey]: number
 }
 
 const defaultReplaceCardDeliveryConfig = {
@@ -160,6 +162,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   custodialTransferBlockedCountries: transferBlockedDefault,
   custodialCreationBlockedCountries: creationBlockedDefault,
   selfCustodialCreationBlockedCountries: creationBlockedDefault,
+  selfCustodialDepositClaimLeewayVbyte: 1,
 }
 
 const defaultFeatureFlags: FeatureFlags = {
@@ -355,6 +358,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           defaultRemoteConfig.selfCustodialCreationBlockedCountries,
         )
 
+        const selfCustodialDepositClaimLeewayVbyte = remoteConfigInstance()
+          .getValue(SelfCustodialDepositClaimLeewayVbyteKey)
+          .asNumber()
+
         setRemoteConfig({
           deviceAccountEnabledRestAuth,
           balanceLimitToTriggerUpgradeModal,
@@ -386,6 +393,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           custodialTransferBlockedCountries,
           custodialCreationBlockedCountries,
           selfCustodialCreationBlockedCountries,
+          selfCustodialDepositClaimLeewayVbyte,
         })
       } catch (err) {
         logError({

--- a/app/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.ts
+++ b/app/screens/self-custodial/onboarding/restore/hooks/use-restore-wallet.ts
@@ -5,6 +5,7 @@ import Crypto from "react-native-quick-crypto"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 
+import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -43,6 +44,7 @@ export const useRestoreWallet = () => {
   const [status, setStatus] = useState<RestoreWalletStatus>(RestoreWalletStatus.Idle)
   const guard = useInFlightGuard()
   const network = useSparkNetwork()
+  const { selfCustodialDepositClaimLeewayVbyte } = useRemoteConfig()
 
   const activateAccount = useCallback(
     (accountId: string) => {
@@ -79,7 +81,12 @@ export const useRestoreWallet = () => {
           }
 
           const accountId = Crypto.randomUUID()
-          await selfCustodialRestoreWallet(accountId, normalized, network)
+          await selfCustodialRestoreWallet({
+            accountId,
+            mnemonic: normalized,
+            network,
+            leewaySatPerVbyte: selfCustodialDepositClaimLeewayVbyte,
+          })
           await markBackupCompletedFor(accountId, BackupMethod.Manual)
           await reloadSelfCustodialAccounts()
 
@@ -103,6 +110,7 @@ export const useRestoreWallet = () => {
       navigation,
       LL,
       network,
+      selfCustodialDepositClaimLeewayVbyte,
     ],
   )
 

--- a/app/screens/settings-screen/self-custodial/profile-row.tsx
+++ b/app/screens/settings-screen/self-custodial/profile-row.tsx
@@ -7,6 +7,7 @@ import { ListItem, makeStyles, Overlay, Text, useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { GaloyIconButton } from "@app/components/atomic/galoy-icon-button/galoy-icon-button"
+import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
@@ -48,6 +49,7 @@ export const ProfileRow: React.FC<ProfileRowProps> = ({ entry, isFirstItem }) =>
   const { activeAccount, setActiveAccountId } = useAccountRegistry()
   const { lightningAddress: liveLightningAddress, wallets: liveWallets } =
     useSelfCustodialWallet()
+  const { selfCustodialDepositClaimLeewayVbyte } = useRemoteConfig()
   const { state: deleteState, deleteWallet } = useDeleteAccount()
   const network = useSparkNetwork()
 
@@ -112,7 +114,11 @@ export const ProfileRow: React.FC<ProfileRowProps> = ({ entry, isFirstItem }) =>
     }
 
     setProbingBalance(true)
-    const result = await probeSelfCustodialAccountWallets(accountId, network)
+    const result = await probeSelfCustodialAccountWallets(
+      accountId,
+      network,
+      selfCustodialDepositClaimLeewayVbyte,
+    )
     setProbingBalance(false)
 
     switch (result.status) {

--- a/app/screens/unclaimed-deposits/hooks/use-deposit-actions.ts
+++ b/app/screens/unclaimed-deposits/hooks/use-deposit-actions.ts
@@ -95,7 +95,14 @@ export const useDepositActions = () => {
       }
       setActiveAction({ depositId: deposit.id, type: DepositActionType.Claim })
       try {
-        const result = await claimDeposit.claimDeposit({ depositId: deposit.id })
+        /**
+         * Override the auto-claim cap with the fee the SDK reported as required, so
+         * an explicit "Claim now" is not blocked by the same MaxDepositClaimFeeExceeded.
+         */
+        const result = await claimDeposit.claimDeposit({
+          depositId: deposit.id,
+          maxFeeSats: deposit.requiredFeeSats,
+        })
         if (result.status === PaymentResultStatus.Failed) {
           const message = resolveClaimErrorMessage(deposit, result.errors, LL)
           toastShow({ message, LL })

--- a/app/self-custodial/bridge/lifecycle.ts
+++ b/app/self-custodial/bridge/lifecycle.ts
@@ -3,6 +3,7 @@ import {
   connect,
   defaultConfig,
   initLogging,
+  MaxFee,
   type BreezSdkInterface,
   type Network,
   type SdkEvent,
@@ -39,10 +40,21 @@ const initializeLogging = (() => {
   }
 })()
 
-const createSdkConfig = (network: Network) => {
+const createSdkConfig = (network: Network, leewaySatPerVbyte: number) => {
   const config = defaultConfig(network)
   config.apiKey = requireBreezApiKey()
   config.lnurlDomain = lnurlDomainFor(network)
+
+  /**
+   * The SDK default cap is 1 sat/vByte, which blocks almost every deposit claim.
+   * Track the network-recommended rate plus a small remote-config leeway so
+   * automatic claims succeed at normal fees. Coerce to a non-negative integer:
+   * BigInt() throws on the fractional values an operator could set remotely.
+   */
+  const safeLeewaySatPerVbyte = Math.max(0, Math.trunc(leewaySatPerVbyte))
+  config.maxDepositClaimFee = new MaxFee.NetworkRecommended({
+    leewaySatPerVbyte: BigInt(safeLeewaySatPerVbyte),
+  })
 
   config.stableBalanceConfig = {
     tokens: [{ label: SparkToken.Label, tokenIdentifier: requireSparkTokenIdentifier() }],
@@ -54,14 +66,23 @@ const createSdkConfig = (network: Network) => {
   return config
 }
 
-export const initSdk = async (
-  mnemonic: string,
-  storageDir: string,
-  network: Network,
-): Promise<BreezSdkInterface> => {
+type InitSdkParams = {
+  mnemonic: string
+  storageDir: string
+  network: Network
+  /** Leeway (sat/vByte) over the network-recommended fee for auto-claiming deposits. */
+  leewaySatPerVbyte: number
+}
+
+export const initSdk = async ({
+  mnemonic,
+  storageDir,
+  network,
+  leewaySatPerVbyte,
+}: InitSdkParams): Promise<BreezSdkInterface> => {
   initializeLogging()
   const seed = new Seed.Mnemonic({ mnemonic, passphrase: undefined })
-  const config = createSdkConfig(network)
+  const config = createSdkConfig(network, leewaySatPerVbyte)
   return connect({ config, seed, storageDir })
 }
 
@@ -93,11 +114,20 @@ export const selfCustodialCreateWallet = async (
   await addSelfCustodialAccountId(accountId)
 }
 
-export const selfCustodialRestoreWallet = async (
-  accountId: string,
-  mnemonic: string,
-  network: Network,
-): Promise<void> => {
+type RestoreWalletParams = {
+  accountId: string
+  mnemonic: string
+  network: Network
+  /** Leeway (sat/vByte) over the network-recommended fee for auto-claiming deposits. */
+  leewaySatPerVbyte: number
+}
+
+export const selfCustodialRestoreWallet = async ({
+  accountId,
+  mnemonic,
+  network,
+  leewaySatPerVbyte,
+}: RestoreWalletParams): Promise<void> => {
   const normalized = normalizeMnemonic(mnemonic)
   if (!validateMnemonic(normalized)) {
     throw new Error("Invalid BIP39 mnemonic")
@@ -111,7 +141,12 @@ export const selfCustodialRestoreWallet = async (
       accountId,
       networkLabelFor(network),
     )
-    const sdk = await initSdk(normalized, storageDirFor(accountId, network), network)
+    const sdk = await initSdk({
+      mnemonic: normalized,
+      storageDir: storageDirFor(accountId, network),
+      network,
+      leewaySatPerVbyte,
+    })
     await disconnectSdk(sdk)
     await addSelfCustodialAccountId(accountId)
   } catch (err) {

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -4,6 +4,7 @@ import { AppState } from "react-native"
 import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 import crashlytics from "@react-native-firebase/crashlytics"
 
+import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { type NormalizedTransaction } from "@app/types/transaction"
 import { ActiveWalletStatus, type WalletState } from "@app/types/wallet"
 import { reportError } from "@app/utils/error-logging"
@@ -77,6 +78,7 @@ export const useSdkLifecycle = (
   retryCount: number,
 ): SdkLifecycleState => {
   const network = useSparkNetwork()
+  const { selfCustodialDepositClaimLeewayVbyte } = useRemoteConfig()
   const [wallets, setWallets] = useState<WalletState[]>([])
   const [allTransactions, setAllTransactions] = useState<NormalizedTransaction[]>([])
   const [status, setStatus] = useState<ActiveWalletStatus>(ActiveWalletStatus.Unavailable)
@@ -92,6 +94,12 @@ export const useSdkLifecycle = (
   const refreshingRef = useRef(false)
   const pendingRefreshRef = useRef(false)
   const rawTxOffsetRef = useRef(0)
+  /**
+   * The leeway only feeds the SDK config at connect time, so hold it in a ref:
+   * a remote-config change must not tear down and reconnect the live wallet.
+   */
+  const depositClaimLeewayRef = useRef(selfCustodialDepositClaimLeewayVbyte)
+  depositClaimLeewayRef.current = selfCustodialDepositClaimLeewayVbyte
   const { schedule: scheduleBackoffRetry, reset: resetBackoff } =
     useBackoffRetry(RECONNECT_BACKOFF_MS)
 
@@ -183,11 +191,12 @@ export const useSdkLifecycle = (
     const accountId = activeSelfCustodialAccountId
 
     const connectAndListen = async (mnemonic: string) => {
-      const connectedSdk = await initSdk(
+      const connectedSdk = await initSdk({
         mnemonic,
-        storageDirFor(accountId, network),
+        storageDir: storageDirFor(accountId, network),
         network,
-      )
+        leewaySatPerVbyte: depositClaimLeewayRef.current,
+      })
       if (abortRef.current || !mounted) {
         await teardownSdk(connectedSdk, null)
         return

--- a/app/self-custodial/probe-account-wallets.ts
+++ b/app/self-custodial/probe-account-wallets.ts
@@ -38,13 +38,19 @@ const toProbeFailed = (err: unknown): ProbeAccountWalletsResult => ({
 export const probeSelfCustodialAccountWallets = async (
   accountId: string,
   network: Network,
+  leewaySatPerVbyte: number,
 ): Promise<ProbeAccountWalletsResult> => {
   const mnemonic = await KeyStoreWrapper.getMnemonicForAccount(accountId)
   if (!mnemonic) return { status: ProbeAccountWalletsStatus.NoMnemonic }
 
   let sdk: BreezSdkInterface | undefined
   try {
-    sdk = await initSdk(mnemonic, storageDirFor(accountId, network), network)
+    sdk = await initSdk({
+      mnemonic,
+      storageDir: storageDirFor(accountId, network),
+      network,
+      leewaySatPerVbyte,
+    })
     const snapshot = await getSelfCustodialWalletSnapshot(sdk)
     return { status: ProbeAccountWalletsStatus.Ok, wallets: snapshot.wallets }
   } catch (err) {


### PR DESCRIPTION
## Problem

Self-custodial (Spark) on-chain deposit claims failed with "Network fees are too high to claim (N sats required)", even on large deposits where the required fee was worth a few cents. The app never passed a max fee, so the Breez/Spark SDK applied its conservative default cap (`Rate { satPerVbyte: 1 }`), which sits below the real on-chain claim fee. Both the automatic background claim and the manual "Claim now" fell to this too-low default, leaving funds stuck as unclaimed deposits.

## Fix

Two layers, following the Breez guidance for on-chain claims:

- **Automatic claims** — `createSdkConfig` now sets `config.maxDepositClaimFee = MaxFee.NetworkRecommended({ leewaySatPerVbyte })`, tracking the network-recommended rate plus a small leeway, so background claims succeed at normal fees.
- **Manual "Claim now"** — passes `maxFeeSats: deposit.requiredFeeSats`, so an explicit claim overrides the cap with the exact fee the SDK reported as required.

## Remote-configurable leeway (single source of truth)

The leeway is a Firebase Remote Config flag `selfCustodialDepositClaimLeewayVbyte` (number, default `1`), wired through the standard feature-flags convention and consumed via `useRemoteConfig()`. There is no hardcoded fee constant in the SDK bridge: all three connect paths (live wallet, delete-probe, restore) read the remote value and thread it into `initSdk` (required parameter). The default is registered via `setDefaults`, so it also acts as the fail-safe when the key is absent.

Two robustness details:
- The leeway is clamped to a non-negative integer (`Math.max(0, Math.trunc())`) before `BigInt()`, so a fractional or invalid remote value can never throw and break the wallet connect.
- The live wallet reads the leeway through a ref, so a remote-config change never forces an SDK teardown/reconnect (no balance/tx flash).

## Comparison with Breez `glow-web` (reference wallet)

Cross-checked against Breez's official reference implementation ([breez/glow-web](https://github.com/breez/glow-web)):

- **Manual claim matches exactly** — glow-web uses `{ type: 'fixed', amount: requiredFeeSats }`; we use the same (`MaxFee.Fixed(requiredFeeSats)`).
- **Auto-claim default is deliberately different (better for a consumer app)** — glow-web defaults to `Rate 1` (the same too-low value) and relies on a per-user fee settings UI plus the manual override. Blink Mobile has no such settings screen, so we default the automatic path to `NetworkRecommended`, which tracks the real network fee and lets claims succeed without user intervention. The remote-config flag provides central tuning in place of glow-web's per-user setting.
- **Defensive validation of the fee value** — glow-web validates the (untrusted, persisted) fee before using it; our `Math.trunc`/clamp guard defends the same class of risk on the (untrusted, remote) value.

## Testing

- `initSdk` config shape (`NetworkRecommended` + leeway), provided leeway, fractional truncation, negative clamp.
- Manual claim passes `maxFeeSats`; success and still-exceeds paths.
- Leeway threaded through probe and restore; live wallet does not reconnect when only the leeway changes.
- Full affected suite green; typecheck and lint clean.

## Deploy note

Create the Firebase Remote Config key `selfCustodialDepositClaimLeewayVbyte` (number, default `1`). The app ships the default, so it works without the key; raise it to add fee headroom.

Device-validated: an on-chain deposit that arrived while the app was closed was auto-claimed on the next app open, with no manual action.