### PR TITLE
fix(mobile): remove "enjoying this app" feedback popup

### DIFF
--- a/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
@@ -19,11 +19,6 @@ import { ContextForScreen, ContextForScreenWithTheme } from "./helper"
 import { Linking, View, ViewStyle } from "react-native"
 import { light, dark } from "@app/rne-theme/colors"
 
-jest.mock("react-native-in-app-review", () => ({
-  isAvailable: () => true,
-  RequestInAppReview: jest.fn(),
-}))
-
 jest.mock("react-native-view-shot", () => {
   return {
     __esModule: true,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react"
-import { View, Alert, ScrollView } from "react-native"
-import InAppReview from "react-native-in-app-review"
+import { View, ScrollView } from "react-native"
 import ViewShot, { type ViewShotRef } from "react-native-view-shot"
 
-import { useApolloClient } from "@apollo/client"
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { Screen } from "@app/components/screen"
 import {
@@ -11,21 +9,15 @@ import {
   SuccessIconAnimation,
 } from "@app/components/success-animation"
 import { SuccessActionComponent } from "@app/components/success-action"
-import { setFeedbackModalShown } from "@app/graphql/client-only-query"
-import {
-  useFeedbackModalShownQuery,
-  useSettingsScreenQuery,
-} from "@app/graphql/generated"
-import { useAppConfig, useScreenshot } from "@app/hooks"
+import { useSettingsScreenQuery } from "@app/graphql/generated"
+import { useScreenshot } from "@app/hooks"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
-import { logAppFeedback } from "@app/utils/analytics"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { testProps } from "../../utils/testProps"
-import { SuggestionModal } from "./suggestion-modal"
 import { PaymentSendCompletedStatus } from "./use-send-payment"
 import LogoLightMode from "@app/assets/logo/blink-logo-light.svg"
 import LogoDarkMode from "@app/assets/logo/app-logo-dark.svg"
@@ -38,7 +30,6 @@ import {
   timeToMempool,
 } from "../transaction-detail-screen/format-time"
 import { GaloyIconButton } from "@app/components/atomic/galoy-icon-button"
-import { GaloyInstance } from "@app/config/galoy-instances"
 import { TranslationFunctions } from "@app/i18n/i18n-types"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { PaymentType } from "@blinkbitcoin/blink-client"
@@ -48,8 +39,6 @@ type StatusProcessed = "SUCCESS" | "PENDING" | "QUEUED"
 interface Props {
   route: RouteProp<RootStackParamList, "sendBitcoinCompleted">
 }
-
-const FEEDBACK_DELAY = 3000
 
 const processStatus = ({
   status,
@@ -90,57 +79,6 @@ const useSuccessMessage = (
 
     return includeUrl ? `${textContent} ${url}`.trim() : textContent
   }, [successAction, preimage])()
-}
-
-const useFeedbackHandler = () => {
-  const client = useApolloClient()
-  const { LL } = useI18nContext()
-  const { appConfig } = useAppConfig()
-  const [showSuggestionModal, setShowSuggestionModal] = useState(false)
-
-  const handleNegativeFeedback = useCallback(() => {
-    logAppFeedback({ isEnjoingApp: false })
-    setShowSuggestionModal(true)
-  }, [])
-
-  const handlePositiveFeedback = useCallback(() => {
-    logAppFeedback({ isEnjoingApp: true })
-    InAppReview.RequestInAppReview()
-  }, [])
-
-  const requestFeedback = useCallback(() => {
-    if (!shouldShowFeedback(appConfig)) return
-
-    if (InAppReview.isAvailable()) {
-      showFeedbackAlert(LL, handleNegativeFeedback, handlePositiveFeedback)
-      setFeedbackModalShown(client, true)
-    }
-  }, [LL, client, appConfig, handleNegativeFeedback, handlePositiveFeedback])
-
-  return { requestFeedback, showSuggestionModal, setShowSuggestionModal }
-}
-
-const shouldShowFeedback = (appConfig: {
-  token: string
-  galoyInstance: GaloyInstance
-}): boolean => {
-  return appConfig && appConfig.galoyInstance.id !== "Local"
-}
-
-const showFeedbackAlert = (
-  LL: TranslationFunctions,
-  onNegative: () => void,
-  onPositive: () => void,
-) => {
-  Alert.alert(
-    "",
-    LL.support.enjoyingApp(),
-    [
-      { text: LL.common.No(), onPress: onNegative },
-      { text: LL.common.yes(), onPress: onPositive },
-    ],
-    { cancelable: true },
-  )
 }
 
 const SuccessIconComponent: React.FC<{
@@ -327,7 +265,6 @@ const SendBitcoinCompletedScreen: React.FC<Props> = ({ route }) => {
     useNavigation<NativeStackNavigationProp<RootStackParamList, "sendBitcoinCompleted">>()
   const { LL } = useI18nContext()
 
-  const feedbackShownData = useFeedbackModalShownQuery()
   const { data } = useSettingsScreenQuery({ fetchPolicy: "cache-first" })
   const { successIconDuration } = useRemoteConfig()
 
@@ -338,23 +275,12 @@ const SendBitcoinCompletedScreen: React.FC<Props> = ({ route }) => {
   const noteMessage = successActionMessage || note?.trim() || ""
   const Logo = mode === "dark" ? LogoDarkMode : LogoLightMode
 
-  const { requestFeedback, showSuggestionModal, setShowSuggestionModal } =
-    useFeedbackHandler()
   const { isTakingScreenshot, captureAndShare } = useScreenshot(viewRef)
 
   useEffect(() => {
     const timer = setTimeout(() => setShowSuccessIcon(false), successIconDuration)
     return () => clearTimeout(timer)
   }, [successIconDuration])
-
-  useEffect(() => {
-    const feedbackModalShown = feedbackShownData?.data?.feedbackModalShown
-
-    if (!feedbackModalShown) {
-      const feedbackTimeout = setTimeout(requestFeedback, FEEDBACK_DELAY)
-      return () => clearTimeout(feedbackTimeout)
-    }
-  }, [feedbackShownData?.data?.feedbackModalShown, requestFeedback])
 
   const handleNavigateHome = () => navigation.navigate("Primary")
 
@@ -408,12 +334,6 @@ const SendBitcoinCompletedScreen: React.FC<Props> = ({ route }) => {
           )}
         </View>
       </ViewShot>
-
-      <SuggestionModal
-        navigation={navigation}
-        showSuggestionModal={showSuggestionModal}
-        setShowSuggestionModal={setShowSuggestionModal}
-      />
     </Screen>
   )
 }


### PR DESCRIPTION
## Problem

After a payment, the send-completed screen fires an "Enjoying the app?" alert (with a 3s delay). It interrupts the user and never actually forwards them to the app store to leave a rating.

## Solution

Remove the feedback-popup wiring from the send-bitcoin-completed screen:
- the delayed `Alert.alert` trigger and its `useEffect`
- the `InAppReview.RequestInAppReview()` call
- the `SuggestionModal` that the "No" branch opened
- the now-unused imports/helpers (`useFeedbackHandler`, `shouldShowFeedback`, `showFeedbackAlert`, `FEEDBACK_DELAY`, `feedbackModalShown` query)

Shared modules (`suggestion-modal`, `analytics.logAppFeedback`, the `FeedbackModalShown` GraphQL query, `react-native-in-app-review`) are left intact since they're still referenced elsewhere (developer screen, stories, generated code). Also removed a now-dead `react-native-in-app-review` jest mock from the screen spec.

Ref blinkbitcoin/blink-wip#923

## Acceptance criteria

- [x] Completing a send never shows the "Enjoying the app?" alert, on any payment type (Lightning, intraledger, on-chain) and regardless of how many payments the user has made before.
- [x] The in-app review prompt is never requested from the send-completed screen.
- [x] The suggestion modal is unreachable from the send-completed screen (its only entry point was the alert's "No" branch).
- [x] Everything else on the send-completed screen is unchanged: success animation and icon, status/arrival-time copy, note and success-action message, share/screenshot button, and the close/back navigation.
- [x] The developer screen's "Rate us" button still works — it calls `InAppReview` directly and never went through the removed helpers.
- [x] Nothing is gated behind a feature flag: the popup is deleted, so it cannot be re-enabled remotely. (Reviewer's D2 note — an "Alert.alert is not called" assertion would be testing deleted code.)

Scope note on the shared modules left in place: after this PR `SuggestionModal` is reachable only from its Storybook story, and `logAppFeedback` has no production callers (only `__tests__/utils/analytics.spec.ts`). They're kept to hold the diff to one screen; deleting them is a follow-up, not part of these criteria.

## Test plan

Automated:
- [x] `yarn tsc:check` — clean
- [x] `eslint` on changed files — clean
- [x] `yarn test __tests__/screens/send-bitcoin-completed-screen.spec.tsx` — 14/14 pass with the `react-native-in-app-review` jest mock removed, i.e. the screen's render path no longer reaches that module

Manual (Android + iOS, shared screen so both platforms):
- [ ] Send a Lightning payment on a non-Local instance (staging/mainnet) → success screen renders, no alert appears within 3s or after
- [ ] Send an intraledger payment → same, no alert
- [ ] Send an on-chain payment → pending/arrival-estimate copy still renders, no alert
- [ ] Repeat a send in the same session and after an app restart → still no alert (the old `feedbackModalShown` "only once" gate is gone along with the popup, so this checks it can't resurface)
- [ ] On the success screen: tap share/screenshot → screenshot still captures; tap close → returns to home
- [ ] Developer screen → feedback/suggestion flow still opens (confirms the shared modules weren't broken)

Upgrade note for QA: users who had already dismissed the feedback prompt see no change; users who had not simply stop seeing it. No migration, no persisted-state cleanup needed — the `feedbackModalShown` client-only query is untouched and just goes unread on this screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
