### PR TITLE
feat(self-custodial): force converting the blocked stable-token balance to bitcoin


### DIFF
--- a/__tests__/components/custom-modal.spec.tsx
+++ b/__tests__/components/custom-modal.spec.tsx
@@ -29,10 +29,12 @@ jest.mock("react-native-modal", () => {
     children,
     isVisible,
     onBackdropPress,
+    onBackButtonPress,
   }: {
     children: React.ReactNode
     isVisible: boolean
     onBackdropPress?: () => void
+    onBackButtonPress?: () => void
   }) =>
     isVisible
       ? ReactNs.createElement(
@@ -41,6 +43,10 @@ jest.mock("react-native-modal", () => {
           ReactNs.createElement(RN.Pressable, {
             testID: "backdrop",
             onPress: onBackdropPress,
+          }),
+          ReactNs.createElement(RN.Pressable, {
+            testID: "back-button",
+            onPress: onBackButtonPress,
           }),
           children,
         )
@@ -102,6 +108,28 @@ describe("CustomModal", () => {
     )
 
     fireEvent.press(getByTestId("backdrop"))
+
+    expect(toggleModal).not.toHaveBeenCalled()
+  })
+
+  it("closes on the Android back button by default", () => {
+    const toggleModal = jest.fn()
+    const { getByTestId } = render(
+      <CustomModal {...baseProps} toggleModal={toggleModal} />,
+    )
+
+    fireEvent.press(getByTestId("back-button"))
+
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores the Android back button when not dismissable", () => {
+    const toggleModal = jest.fn()
+    const { getByTestId } = render(
+      <CustomModal {...baseProps} toggleModal={toggleModal} dismissable={false} />,
+    )
+
+    fireEvent.press(getByTestId("back-button"))
 
     expect(toggleModal).not.toHaveBeenCalled()
   })

--- a/__tests__/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.spec.tsx
+++ b/__tests__/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.spec.tsx
@@ -1,0 +1,165 @@
+import React from "react"
+import { fireEvent, render } from "@testing-library/react-native"
+
+import TypesafeI18n from "@app/i18n/i18n-react"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { toUsdMoneyAmount } from "@app/types/amounts"
+import { ThemeProvider } from "@rn-vui/themed"
+
+const mockFormatMoneyAmount = jest.fn(
+  ({
+    moneyAmount,
+    isApproximate,
+  }: {
+    moneyAmount: { amount: number; currency: string }
+    isApproximate?: boolean
+  }) => `${isApproximate ? "~ " : ""}${moneyAmount.currency}:${moneyAmount.amount}`,
+)
+
+const mockConvertMoneyAmount = jest.fn((_moneyAmount: unknown, toCurrency: string) => ({
+  amount: 129184,
+  currency: toCurrency,
+  currencyCode: toCurrency,
+}))
+let mockConvertReady = true
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
+}))
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({
+    convertMoneyAmount: mockConvertReady ? mockConvertMoneyAmount : undefined,
+  }),
+}))
+
+const mockModalRender = jest.fn()
+
+jest.mock("react-native-modal", () => {
+  const ReactNs = jest.requireActual<typeof import("react")>("react")
+  const RN = jest.requireActual<typeof import("react-native")>("react-native")
+  const MockModal = (props: { children: React.ReactNode; isVisible: boolean }) => {
+    mockModalRender(props)
+    return props.isVisible ? ReactNs.createElement(RN.View, null, props.children) : null
+  }
+  return { __esModule: true, default: MockModal }
+})
+
+import { ConvertToBtcModalUI } from "@app/components/usd-convert-to-btc-modal"
+
+loadLocale("en")
+
+const usdBalance = toUsdMoneyAmount(10001) // $100.01
+
+const wrap = (ui: React.ReactElement) => (
+  <ThemeProvider>
+    <TypesafeI18n locale="en">{ui}</TypesafeI18n>
+  </ThemeProvider>
+)
+
+type OptionalProps = {
+  isVisible?: boolean
+  toggleModal?: () => void
+  onConvert?: () => void
+  loading?: boolean
+  dismissable?: boolean
+  errorMessage?: string
+}
+
+const renderUI = (props?: OptionalProps) =>
+  render(
+    wrap(
+      <ConvertToBtcModalUI
+        isVisible={props?.isVisible ?? true}
+        toggleModal={props?.toggleModal ?? jest.fn()}
+        usdWalletBalance={usdBalance}
+        onConvert={props?.onConvert ?? jest.fn()}
+        loading={props?.loading ?? false}
+        dismissable={props?.dismissable}
+        errorMessage={props?.errorMessage}
+      />,
+    ),
+  )
+
+describe("ConvertToBtcModalUI", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConvertReady = true
+  })
+
+  it("renders the title, body and both amount rows", () => {
+    const { getByText } = renderUI()
+
+    expect(getByText("Dollar Balance is not available in your region")).toBeTruthy()
+    expect(getByText("Transfer from Dollar Balance to Bitcoin Balance")).toBeTruthy()
+    expect(getByText("You have")).toBeTruthy()
+    expect(getByText("You get")).toBeTruthy()
+  })
+
+  it("shows the exact balance and the approximate bitcoin estimate", () => {
+    const { getByText } = renderUI()
+
+    expect(mockFormatMoneyAmount).toHaveBeenCalledWith({ moneyAmount: usdBalance })
+    expect(getByText("USD:10001")).toBeTruthy()
+    expect(getByText("~ BTC:129184")).toBeTruthy()
+  })
+
+  it("hides the bitcoin estimate while the price conversion is unavailable", () => {
+    mockConvertReady = false
+    const { getByText, queryByText } = renderUI()
+
+    expect(getByText("You get")).toBeTruthy()
+    expect(queryByText("~ BTC:129184")).toBeNull()
+  })
+
+  it("shows the warning icon", () => {
+    const { getByTestId } = renderUI()
+
+    expect(getByTestId("icon-warning")).toBeTruthy()
+  })
+
+  it("forwards the visibility to the modal", () => {
+    renderUI({ isVisible: false })
+
+    expect(mockModalRender).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: false }),
+    )
+  })
+
+  it("calls onConvert when Transfer is pressed", () => {
+    const onConvert = jest.fn()
+    const { getByText } = renderUI({ onConvert })
+
+    fireEvent.press(getByText("Transfer"))
+
+    expect(onConvert).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables Transfer while loading", () => {
+    const { queryByText, getByRole } = renderUI({ loading: true })
+
+    expect(queryByText("Transfer")).toBeNull()
+    expect(getByRole("button", { disabled: true })).toBeTruthy()
+  })
+
+  it("renders the error box when an error message is provided", () => {
+    const { getByText } = renderUI({ errorMessage: "Insufficient balance" })
+
+    expect(getByText("Insufficient balance")).toBeTruthy()
+  })
+
+  it("is locked by default: no close icon", () => {
+    const { queryByTestId } = renderUI()
+
+    expect(queryByTestId("icon-close")).toBeNull()
+  })
+
+  it("shows the close icon and closes through it when dismissable", () => {
+    const toggleModal = jest.fn()
+    const { getByTestId } = renderUI({ dismissable: true, toggleModal })
+
+    fireEvent.press(getByTestId("icon-close"))
+
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+  })
+})

--- a/__tests__/components/usd-convert-to-btc-modal/usd-convert-to-btc-modal.spec.tsx
+++ b/__tests__/components/usd-convert-to-btc-modal/usd-convert-to-btc-modal.spec.tsx
@@ -8,13 +8,8 @@ import { toUsdMoneyAmount } from "@app/types/amounts"
 import { ThemeProvider } from "@rn-vui/themed"
 
 const mockFormatMoneyAmount = jest.fn(
-  ({
-    moneyAmount,
-    isApproximate,
-  }: {
-    moneyAmount: { amount: number; currency: string }
-    isApproximate?: boolean
-  }) => `${isApproximate ? "~ " : ""}${moneyAmount.currency}:${moneyAmount.amount}`,
+  ({ moneyAmount }: { moneyAmount: { amount: number; currency: string } }) =>
+    `${moneyAmount.currency}:${moneyAmount.amount}`,
 )
 
 const mockConvertMoneyAmount = jest.fn((_moneyAmount: unknown, toCurrency: string) => ({
@@ -91,44 +86,16 @@ describe("UsdConvertToBtcModal", () => {
     })
   })
 
-  it("renders the title and body", () => {
-    const { getByText } = renderModal()
-
-    expect(getByText("Dollar Balance is not available in your region")).toBeTruthy()
-    expect(getByText("Transfer from Dollar Balance to Bitcoin Balance")).toBeTruthy()
-  })
-
-  it("renders the You have and You get labels", () => {
-    const { getByText } = renderModal()
-
-    expect(getByText("You have")).toBeTruthy()
-    expect(getByText("You get")).toBeTruthy()
-  })
-
-  it("shows the USD wallet balance as the You have value (not approximate)", () => {
-    const { getByText } = renderModal()
-
-    expect(mockFormatMoneyAmount).toHaveBeenCalledWith({ moneyAmount: usdBalance })
-    expect(getByText("USD:10001")).toBeTruthy()
-  })
-
-  it("converts the balance to BTC and renders it as an approximate You get value", () => {
-    const { getByText } = renderModal()
-
-    expect(mockConvertMoneyAmount).toHaveBeenCalledWith(usdBalance, WalletCurrency.Btc)
-    expect(mockFormatMoneyAmount).toHaveBeenCalledWith({
-      moneyAmount: { amount: 129184, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-      isApproximate: true,
-    })
-    expect(getByText("~ BTC:129184")).toBeTruthy()
-  })
-
-  it("triggers the conversion when Transfer is pressed", () => {
+  it("converts the full balance between the account's own wallets on Transfer", () => {
     const { getByText } = renderModal()
 
     fireEvent.press(getByText("Transfer"))
 
-    expect(mockExecute).toHaveBeenCalledTimes(1)
+    expect(mockExecute).toHaveBeenCalledWith({
+      fromWallet: { id: "usd-wallet-id", currency: WalletCurrency.Usd },
+      toWallet: { id: "btc-wallet-id", currency: WalletCurrency.Btc },
+      fromAmount: usdBalance.amount,
+    })
   })
 
   it("renders the error box when the conversion reports an error", () => {
@@ -141,18 +108,6 @@ describe("UsdConvertToBtcModal", () => {
     const { getByText } = renderModal()
 
     expect(getByText("Insufficient balance")).toBeTruthy()
-  })
-
-  it("renders nothing when isVisible is false", () => {
-    const { queryByText } = renderModal({ isVisible: false })
-
-    expect(queryByText("Dollar Balance is not available in your region")).toBeNull()
-  })
-
-  it("shows the warning icon", () => {
-    const { getByTestId } = renderModal()
-
-    expect(getByTestId("icon-warning")).toBeTruthy()
   })
 
   it("cannot be dismissed: it renders no close icon", () => {

--- a/__tests__/hooks/use-device-location.spec.ts
+++ b/__tests__/hooks/use-device-location.spec.ts
@@ -16,7 +16,7 @@ jest.mock("libphonenumber-js/mobile", () => ({
 
 const mockResolveIpCountryCode = jest.fn()
 jest.mock("@app/utils/ip-country-lookup", () => ({
-  resolveIpCountryCode: (...args: unknown[]) => mockResolveIpCountryCode(...args),
+  resolveIpCountryCodeCached: (...args: unknown[]) => mockResolveIpCountryCode(...args),
 }))
 
 jest.mock("@app/utils/log-error", () => ({

--- a/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
@@ -2,106 +2,108 @@ import { act, renderHook } from "@testing-library/react-native"
 
 import { useDollarBalanceForcedConversion } from "@app/hooks/use-dollar-balance-forced-conversion"
 
+type Params = Parameters<typeof useDollarBalanceForcedConversion>[0]
+
+const baseParams: Params = {
+  accountId: "account-a",
+  isRestricted: true,
+  usdWalletBalance: 5000,
+  minimumBalance: 1,
+  isFocused: true,
+}
+
+const renderTrigger = (initial: Partial<Params> = {}) =>
+  renderHook(
+    (overrides: Partial<Params>) =>
+      useDollarBalanceForcedConversion({ ...baseParams, ...overrides }),
+    { initialProps: initial },
+  )
+
 describe("useDollarBalanceForcedConversion", () => {
-  it("opens the convert modal when restricted and the balance is positive", () => {
-    const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({
-        accountId: "account-a",
-        isRestricted: true,
-        usdWalletBalance: 5000,
-      }),
-    )
+  it("opens the convert modal when restricted and the balance is convertible", () => {
+    const { result } = renderTrigger()
 
     expect(result.current.isConvertModalVisible).toBe(true)
   })
 
   it("does not open when the account is not restricted", () => {
-    const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({
-        accountId: "account-a",
-        isRestricted: false,
-        usdWalletBalance: 5000,
-      }),
-    )
+    const { result } = renderTrigger({ isRestricted: false })
 
     expect(result.current.isConvertModalVisible).toBe(false)
   })
 
   it("does not open when the restricted account has no balance", () => {
-    const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({
-        accountId: "account-a",
-        isRestricted: true,
-        usdWalletBalance: 0,
-      }),
-    )
+    const { result } = renderTrigger({ usdWalletBalance: 0 })
 
     expect(result.current.isConvertModalVisible).toBe(false)
   })
 
-  it("stays closed after the user dismisses it while still restricted", () => {
-    const { result, rerender } = renderHook(
-      ({ balance }: { balance: number }) =>
-        useDollarBalanceForcedConversion({
-          accountId: "account-a",
-          isRestricted: true,
-          usdWalletBalance: balance,
-        }),
-      { initialProps: { balance: 5000 } },
-    )
+  it("does not open while the conversion minimum is still unknown", () => {
+    const { result } = renderTrigger({ minimumBalance: null })
+
+    expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
+  it("does not open for a balance below the conversion minimum", () => {
+    const { result } = renderTrigger({ minimumBalance: 300, usdWalletBalance: 200 })
+
+    expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
+  it("opens once the balance reaches the conversion minimum", () => {
+    const { result, rerender } = renderTrigger({
+      minimumBalance: 300,
+      usdWalletBalance: 200,
+    })
+    expect(result.current.isConvertModalVisible).toBe(false)
+
+    rerender({ minimumBalance: 300, usdWalletBalance: 300 })
+    expect(result.current.isConvertModalVisible).toBe(true)
+  })
+
+  it("stays closed after the user dismisses it while the screen stays focused", () => {
+    const { result, rerender } = renderTrigger()
     expect(result.current.isConvertModalVisible).toBe(true)
 
     act(() => result.current.closeConvertModal())
     expect(result.current.isConvertModalVisible).toBe(false)
 
-    rerender({ balance: 5000 })
+    rerender({})
     expect(result.current.isConvertModalVisible).toBe(false)
   })
 
-  it("re-opens when a positive balance arrives after being zero", () => {
-    const { result, rerender } = renderHook(
-      ({ balance }: { balance: number }) =>
-        useDollarBalanceForcedConversion({
-          accountId: "account-a",
-          isRestricted: true,
-          usdWalletBalance: balance,
-        }),
-      { initialProps: { balance: 0 } },
-    )
+  it("re-opens when the screen regains focus after a dismissal", () => {
+    const { result, rerender } = renderTrigger()
+    act(() => result.current.closeConvertModal())
     expect(result.current.isConvertModalVisible).toBe(false)
 
-    rerender({ balance: 5000 })
+    rerender({ isFocused: false })
+    expect(result.current.isConvertModalVisible).toBe(false)
+
+    rerender({ isFocused: true })
+    expect(result.current.isConvertModalVisible).toBe(true)
+  })
+
+  it("re-opens when a convertible balance arrives after being zero", () => {
+    const { result, rerender } = renderTrigger({ usdWalletBalance: 0 })
+    expect(result.current.isConvertModalVisible).toBe(false)
+
+    rerender({ usdWalletBalance: 5000 })
     expect(result.current.isConvertModalVisible).toBe(true)
   })
 
   it("stays closed after a successful conversion zeroes the balance", () => {
-    const { result, rerender } = renderHook(
-      ({ balance }: { balance: number }) =>
-        useDollarBalanceForcedConversion({
-          accountId: "account-a",
-          isRestricted: true,
-          usdWalletBalance: balance,
-        }),
-      { initialProps: { balance: 5000 } },
-    )
+    const { result, rerender } = renderTrigger()
     expect(result.current.isConvertModalVisible).toBe(true)
 
     act(() => result.current.closeConvertModal())
-    rerender({ balance: 0 })
+    rerender({ usdWalletBalance: 0 })
 
     expect(result.current.isConvertModalVisible).toBe(false)
   })
 
   it("closes when switching to an account that is not restricted", () => {
-    const { result, rerender } = renderHook(
-      ({ accountId, isRestricted }: { accountId: string; isRestricted: boolean }) =>
-        useDollarBalanceForcedConversion({
-          accountId,
-          isRestricted,
-          usdWalletBalance: 5000,
-        }),
-      { initialProps: { accountId: "account-a", isRestricted: true } },
-    )
+    const { result, rerender } = renderTrigger()
     expect(result.current.isConvertModalVisible).toBe(true)
 
     rerender({ accountId: "account-b", isRestricted: false })
@@ -109,15 +111,7 @@ describe("useDollarBalanceForcedConversion", () => {
   })
 
   it("re-opens for a new account that is itself restricted with a balance", () => {
-    const { result, rerender } = renderHook(
-      ({ accountId }: { accountId: string }) =>
-        useDollarBalanceForcedConversion({
-          accountId,
-          isRestricted: true,
-          usdWalletBalance: 5000,
-        }),
-      { initialProps: { accountId: "account-a" } },
-    )
+    const { result, rerender } = renderTrigger()
     act(() => result.current.closeConvertModal())
     expect(result.current.isConvertModalVisible).toBe(false)
 

--- a/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
@@ -5,7 +5,11 @@ import { useDollarBalanceForcedConversion } from "@app/hooks/use-dollar-balance-
 describe("useDollarBalanceForcedConversion", () => {
   it("opens the convert modal when restricted and the balance is positive", () => {
     const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({ isRestricted: true, usdWalletBalance: 5000 }),
+      useDollarBalanceForcedConversion({
+        accountId: "account-a",
+        isRestricted: true,
+        usdWalletBalance: 5000,
+      }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(true)
@@ -13,7 +17,11 @@ describe("useDollarBalanceForcedConversion", () => {
 
   it("does not open when the account is not restricted", () => {
     const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({ isRestricted: false, usdWalletBalance: 5000 }),
+      useDollarBalanceForcedConversion({
+        accountId: "account-a",
+        isRestricted: false,
+        usdWalletBalance: 5000,
+      }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(false)
@@ -21,7 +29,11 @@ describe("useDollarBalanceForcedConversion", () => {
 
   it("does not open when the restricted account has no balance", () => {
     const { result } = renderHook(() =>
-      useDollarBalanceForcedConversion({ isRestricted: true, usdWalletBalance: 0 }),
+      useDollarBalanceForcedConversion({
+        accountId: "account-a",
+        isRestricted: true,
+        usdWalletBalance: 0,
+      }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(false)
@@ -31,6 +43,7 @@ describe("useDollarBalanceForcedConversion", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
         useDollarBalanceForcedConversion({
+          accountId: "account-a",
           isRestricted: true,
           usdWalletBalance: balance,
         }),
@@ -49,6 +62,7 @@ describe("useDollarBalanceForcedConversion", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
         useDollarBalanceForcedConversion({
+          accountId: "account-a",
           isRestricted: true,
           usdWalletBalance: balance,
         }),
@@ -64,6 +78,7 @@ describe("useDollarBalanceForcedConversion", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
         useDollarBalanceForcedConversion({
+          accountId: "account-a",
           isRestricted: true,
           usdWalletBalance: balance,
         }),
@@ -75,5 +90,38 @@ describe("useDollarBalanceForcedConversion", () => {
     rerender({ balance: 0 })
 
     expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
+  it("closes when switching to an account that is not restricted", () => {
+    const { result, rerender } = renderHook(
+      ({ accountId, isRestricted }: { accountId: string; isRestricted: boolean }) =>
+        useDollarBalanceForcedConversion({
+          accountId,
+          isRestricted,
+          usdWalletBalance: 5000,
+        }),
+      { initialProps: { accountId: "account-a", isRestricted: true } },
+    )
+    expect(result.current.isConvertModalVisible).toBe(true)
+
+    rerender({ accountId: "account-b", isRestricted: false })
+    expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
+  it("re-opens for a new account that is itself restricted with a balance", () => {
+    const { result, rerender } = renderHook(
+      ({ accountId }: { accountId: string }) =>
+        useDollarBalanceForcedConversion({
+          accountId,
+          isRestricted: true,
+          usdWalletBalance: 5000,
+        }),
+      { initialProps: { accountId: "account-a" } },
+    )
+    act(() => result.current.closeConvertModal())
+    expect(result.current.isConvertModalVisible).toBe(false)
+
+    rerender({ accountId: "account-b" })
+    expect(result.current.isConvertModalVisible).toBe(true)
   })
 })

--- a/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
@@ -1,11 +1,11 @@
 import { act, renderHook } from "@testing-library/react-native"
 
-import { useStablesatsForcedConversion } from "@app/hooks/use-stablesats-forced-conversion"
+import { useDollarBalanceForcedConversion } from "@app/hooks/use-dollar-balance-forced-conversion"
 
-describe("useStablesatsForcedConversion", () => {
+describe("useDollarBalanceForcedConversion", () => {
   it("opens the convert modal when restricted and the balance is positive", () => {
     const { result } = renderHook(() =>
-      useStablesatsForcedConversion({ isRestricted: true, usdWalletBalance: 5000 }),
+      useDollarBalanceForcedConversion({ isRestricted: true, usdWalletBalance: 5000 }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(true)
@@ -13,7 +13,7 @@ describe("useStablesatsForcedConversion", () => {
 
   it("does not open when the account is not restricted", () => {
     const { result } = renderHook(() =>
-      useStablesatsForcedConversion({ isRestricted: false, usdWalletBalance: 5000 }),
+      useDollarBalanceForcedConversion({ isRestricted: false, usdWalletBalance: 5000 }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(false)
@@ -21,7 +21,7 @@ describe("useStablesatsForcedConversion", () => {
 
   it("does not open when the restricted account has no balance", () => {
     const { result } = renderHook(() =>
-      useStablesatsForcedConversion({ isRestricted: true, usdWalletBalance: 0 }),
+      useDollarBalanceForcedConversion({ isRestricted: true, usdWalletBalance: 0 }),
     )
 
     expect(result.current.isConvertModalVisible).toBe(false)
@@ -30,7 +30,10 @@ describe("useStablesatsForcedConversion", () => {
   it("stays closed after the user dismisses it while still restricted", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
-        useStablesatsForcedConversion({ isRestricted: true, usdWalletBalance: balance }),
+        useDollarBalanceForcedConversion({
+          isRestricted: true,
+          usdWalletBalance: balance,
+        }),
       { initialProps: { balance: 5000 } },
     )
     expect(result.current.isConvertModalVisible).toBe(true)
@@ -45,7 +48,10 @@ describe("useStablesatsForcedConversion", () => {
   it("re-opens when a positive balance arrives after being zero", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
-        useStablesatsForcedConversion({ isRestricted: true, usdWalletBalance: balance }),
+        useDollarBalanceForcedConversion({
+          isRestricted: true,
+          usdWalletBalance: balance,
+        }),
       { initialProps: { balance: 0 } },
     )
     expect(result.current.isConvertModalVisible).toBe(false)
@@ -57,7 +63,10 @@ describe("useStablesatsForcedConversion", () => {
   it("stays closed after a successful conversion zeroes the balance", () => {
     const { result, rerender } = renderHook(
       ({ balance }: { balance: number }) =>
-        useStablesatsForcedConversion({ isRestricted: true, usdWalletBalance: balance }),
+        useDollarBalanceForcedConversion({
+          isRestricted: true,
+          usdWalletBalance: balance,
+        }),
       { initialProps: { balance: 5000 } },
     )
     expect(result.current.isConvertModalVisible).toBe(true)

--- a/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-forced-conversion.spec.ts
@@ -102,6 +102,28 @@ describe("useDollarBalanceForcedConversion", () => {
     expect(result.current.isConvertModalVisible).toBe(false)
   })
 
+  it("closes an open modal once the balance stops being convertible", () => {
+    const { result, rerender } = renderTrigger()
+    expect(result.current.isConvertModalVisible).toBe(true)
+
+    rerender({ usdWalletBalance: 0 })
+    expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
+  it("self-heals a stale focus re-open when the refetched balance arrives at zero", () => {
+    const { result, rerender } = renderTrigger()
+    act(() => result.current.closeConvertModal())
+
+    /** Refocusing between the success-close and the balance refetch re-opens
+     *  the modal on the stale balance; the refetch must close it again. */
+    rerender({ isFocused: false })
+    rerender({ isFocused: true })
+    expect(result.current.isConvertModalVisible).toBe(true)
+
+    rerender({ usdWalletBalance: 0 })
+    expect(result.current.isConvertModalVisible).toBe(false)
+  })
+
   it("closes when switching to an account that is not restricted", () => {
     const { result, rerender } = renderTrigger()
     expect(result.current.isConvertModalVisible).toBe(true)

--- a/__tests__/screens/conversion-flow/conversion-confirmation.spec.tsx
+++ b/__tests__/screens/conversion-flow/conversion-confirmation.spec.tsx
@@ -152,10 +152,10 @@ jest.mock("@app/screens/conversion-flow/hooks/self-custodial/use-conversion", ()
 }))
 
 jest.mock("@app/components/atomic/galoy-slider-button/galoy-slider-button", () => {
-  type Props = { onSwipe: () => void; initialText: string }
+  type Props = { onSwipe: () => void; initialText: string; disabled?: boolean }
 
-  const MockGaloySliderButton = ({ onSwipe, initialText }: Props) => (
-    <TouchableOpacity onPress={onSwipe}>
+  const MockGaloySliderButton = ({ onSwipe, initialText, disabled }: Props) => (
+    <TouchableOpacity onPress={onSwipe} disabled={disabled}>
       <Text>{initialText}</Text>
     </TouchableOpacity>
   )
@@ -561,6 +561,100 @@ describe("conversion-confirmation-screen — self-custodial submit path", () => 
       expect(executeMock).toHaveBeenCalledTimes(1)
     })
     expect(dispatchMock).not.toHaveBeenCalled()
+  })
+
+  it("retries the quote on swipe after a quote error instead of executing", async () => {
+    const executeMock = jest.fn()
+    const requoteMock = jest.fn()
+    mockSelfCustodialConversion.mockReturnValue({
+      isQuoting: false,
+      hasQuoteError: true,
+      feeText: "",
+      adjustmentText: null,
+      canExecute: false,
+      loading: false,
+      execute: executeMock,
+      requote: requoteMock,
+    })
+
+    const route = {
+      key: "conversionConfirmation",
+      name: "conversionConfirmation",
+      params: {
+        fromWalletCurrency: WalletCurrency.Btc,
+        moneyAmount: {
+          amount: 10000,
+          currency: WalletCurrency.Btc,
+          currencyCode: WalletCurrency.Btc,
+        },
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <ConversionConfirmationScreen route={route} />
+      </ContextForScreen>,
+    )
+
+    fireEvent.press(
+      screen.getByText(
+        LL.ConversionConfirmationScreen.transferButtonText({
+          fromWallet: LL.common.bitcoin(),
+          toWallet: LL.common.dollar(),
+        }),
+      ),
+    )
+
+    await waitFor(() => {
+      expect(requoteMock).toHaveBeenCalledTimes(1)
+    })
+    expect(executeMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps the slider disabled while the quote is still pending", () => {
+    const executeMock = jest.fn()
+    const requoteMock = jest.fn()
+    mockSelfCustodialConversion.mockReturnValue({
+      isQuoting: true,
+      hasQuoteError: false,
+      feeText: "",
+      adjustmentText: null,
+      canExecute: false,
+      loading: false,
+      execute: executeMock,
+      requote: requoteMock,
+    })
+
+    const route = {
+      key: "conversionConfirmation",
+      name: "conversionConfirmation",
+      params: {
+        fromWalletCurrency: WalletCurrency.Btc,
+        moneyAmount: {
+          amount: 10000,
+          currency: WalletCurrency.Btc,
+          currencyCode: WalletCurrency.Btc,
+        },
+      },
+    } as const
+
+    render(
+      <ContextForScreen>
+        <ConversionConfirmationScreen route={route} />
+      </ContextForScreen>,
+    )
+
+    fireEvent.press(
+      screen.getByText(
+        LL.ConversionConfirmationScreen.transferButtonText({
+          fromWallet: LL.common.bitcoin(),
+          toWallet: LL.common.dollar(),
+        }),
+      ),
+    )
+
+    expect(executeMock).not.toHaveBeenCalled()
+    expect(requoteMock).not.toHaveBeenCalled()
   })
 
   it("renders nothing while the wallets are unavailable", () => {

--- a/__tests__/screens/conversion-flow/self-custodial/use-conversion.spec.ts
+++ b/__tests__/screens/conversion-flow/self-custodial/use-conversion.spec.ts
@@ -11,12 +11,16 @@ const mockConvertMoneyAmount = jest.fn()
 const mockOnSuccess = jest.fn()
 const mockRecordError = jest.fn()
 
+let mockConvertReady = true
+
 jest.mock("@app/hooks/use-payments", () => ({
   usePayments: () => ({ getConversionQuote: mockGetQuote }),
 }))
 
 jest.mock("@app/hooks/use-price-conversion", () => ({
-  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount }),
+  usePriceConversion: () => ({
+    convertMoneyAmount: mockConvertReady ? mockConvertMoneyAmount : undefined,
+  }),
 }))
 
 jest.mock("@app/hooks/use-display-currency", () => ({
@@ -68,12 +72,24 @@ const makeQuote = (
 describe("useSelfCustodialConversion", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockConvertReady = true
     mockConvertMoneyAmount.mockImplementation(
       (amount: { amount: number }, currency: WalletCurrency) =>
         currency === WalletCurrency.Btc
           ? toBtcMoneyAmount(amount.amount * 100)
           : toUsdMoneyAmount(amount.amount),
     )
+  })
+
+  it("stays idle without error while enabled but the price feed is unavailable", async () => {
+    mockConvertReady = false
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+
+    await waitFor(() => expect(result.current.isQuoting).toBe(false))
+    expect(result.current.hasQuoteError).toBe(false)
+    expect(result.current.canExecute).toBe(false)
+    expect(mockGetQuote).not.toHaveBeenCalled()
   })
 
   it("stays idle when enabled is false and does not call getQuote", async () => {
@@ -237,6 +253,107 @@ describe("useSelfCustodialConversion", () => {
       setTimeout(resolve, 600)
     })
     expect(mockGetQuote).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-quotes after a failed execute so the retry never replays a stale quote", async () => {
+    const failingExecute = jest.fn().mockResolvedValue({
+      status: PaymentResultStatus.Failed,
+      errors: [{ message: "SDK boom" }],
+    })
+    const succeedingExecute = jest
+      .fn()
+      .mockResolvedValue({ status: PaymentResultStatus.Success })
+    mockGetQuote
+      .mockResolvedValueOnce(makeQuote({ execute: failingExecute }))
+      .mockResolvedValueOnce(makeQuote({ execute: succeedingExecute }))
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    await act(async () => {
+      await result.current.execute()
+    })
+
+    expect(result.current.errorMessage).toBe("SDK boom")
+    await waitFor(() => expect(mockGetQuote).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    await act(async () => {
+      await result.current.execute()
+    })
+
+    expect(failingExecute).toHaveBeenCalledTimes(1)
+    expect(succeedingExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a second execute() while the first is still in flight", async () => {
+    const execute = jest.fn().mockResolvedValue({ status: PaymentResultStatus.Success })
+    mockGetQuote.mockResolvedValue(makeQuote({ execute }))
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    await act(async () => {
+      await Promise.all([result.current.execute(), result.current.execute()])
+    })
+
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps loading until the awaited onSuccess settles", async () => {
+    let resolveSuccess: () => void
+    mockOnSuccess.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSuccess = resolve
+      }),
+    )
+    mockGetQuote.mockResolvedValue(makeQuote())
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    let executePromise: Promise<unknown> = Promise.resolve()
+    act(() => {
+      executePromise = result.current.execute()
+    })
+
+    await waitFor(() => expect(mockOnSuccess).toHaveBeenCalledTimes(1))
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      resolveSuccess!()
+      await executePromise
+    })
+
+    expect(result.current.loading).toBe(false)
+  })
+
+  it("requote() stays put while the price feed is unavailable", async () => {
+    mockConvertReady = false
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.isQuoting).toBe(false))
+
+    act(() => {
+      result.current.requote()
+    })
+
+    expect(mockGetQuote).not.toHaveBeenCalled()
+  })
+
+  it("requote() fetches a fresh quote after a quote error", async () => {
+    mockGetQuote.mockRejectedValueOnce(new Error("quote down"))
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.hasQuoteError).toBe(true))
+
+    mockGetQuote.mockResolvedValue(makeQuote())
+    act(() => {
+      result.current.requote()
+    })
+
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+    expect(mockGetQuote).toHaveBeenCalledTimes(2)
   })
 
   it("re-quotes when moneyAmount changes and execute() runs the latest quote", async () => {

--- a/__tests__/screens/conversion-flow/self-custodial/use-conversion.spec.ts
+++ b/__tests__/screens/conversion-flow/self-custodial/use-conversion.spec.ts
@@ -286,6 +286,64 @@ describe("useSelfCustodialConversion", () => {
     expect(succeedingExecute).toHaveBeenCalledTimes(1)
   })
 
+  it("re-quotes the live amount when the balance changed while the conversion was in flight", async () => {
+    let rejectExecute: (err: Error) => void
+    const hangingExecute = jest.fn().mockImplementation(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectExecute = reject
+        }),
+    )
+    mockGetQuote.mockResolvedValue(makeQuote({ execute: hangingExecute }))
+
+    const { result, rerender } = renderHook(
+      (params: typeof defaultParams) => useSelfCustodialConversion(params),
+      { initialProps: defaultParams },
+    )
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    let executePromise: Promise<unknown> = Promise.resolve()
+    act(() => {
+      executePromise = result.current.execute()
+    })
+
+    rerender({ ...defaultParams, moneyAmount: toUsdMoneyAmount(700) })
+    await waitFor(() => expect(mockGetQuote).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      rejectExecute!(new Error("conversion failed"))
+      await executePromise
+    })
+
+    /** The failure re-quote must pin the live 700-cent amount, not the
+     *  press-time 500-cent one. */
+    await waitFor(() => expect(mockGetQuote).toHaveBeenCalledTimes(3))
+    expect(mockGetQuote).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        fromAmount: expect.objectContaining({ amount: 70000 }),
+      }),
+    )
+  })
+
+  it("execute() surfaces a generic error and re-quotes when the SDK throws a non-Error", async () => {
+    const execute = jest.fn().mockRejectedValue("string failure")
+    mockGetQuote.mockResolvedValue(makeQuote({ execute }))
+
+    const { result } = renderHook(() => useSelfCustodialConversion(defaultParams))
+    await waitFor(() => expect(result.current.canExecute).toBe(true))
+
+    await act(async () => {
+      await result.current.execute()
+    })
+
+    expect(result.current.errorMessage).toBe("Generic error")
+    expect(mockRecordError).toHaveBeenCalledWith(expect.any(Error))
+    expect(ReactNativeHapticFeedback.trigger).toHaveBeenCalledWith("notificationError", {
+      ignoreAndroidSystemSettings: true,
+    })
+    expect(mockOnSuccess).not.toHaveBeenCalled()
+  })
+
   it("ignores a second execute() while the first is still in flight", async () => {
     const execute = jest.fn().mockResolvedValue({ status: PaymentResultStatus.Success })
     mockGetQuote.mockResolvedValue(makeQuote({ execute }))

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.integration.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.integration.spec.tsx
@@ -1,0 +1,172 @@
+import React from "react"
+import { fireEvent, render, waitFor } from "@testing-library/react-native"
+
+import TypesafeI18n from "@app/i18n/i18n-react"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
+import { PaymentResultStatus } from "@app/types/payment"
+import { ThemeProvider } from "@rn-vui/themed"
+
+const mockGetConversionQuote = jest.fn()
+
+jest.mock("@app/hooks/use-payments", () => ({
+  usePayments: () => ({ getConversionQuote: mockGetConversionQuote }),
+}))
+
+const mockConvertMoneyAmount = jest.fn(
+  (moneyAmount: { amount: number }, currency: string) =>
+    currency === "BTC"
+      ? toBtcMoneyAmount(moneyAmount.amount * 100)
+      : toUsdMoneyAmount(moneyAmount.amount),
+)
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount }),
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: ({ moneyAmount }: { moneyAmount: { amount: number } }) =>
+      `$${(moneyAmount.amount / 100).toFixed(2)}`,
+  }),
+}))
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => ({ isReady: true }),
+}))
+
+const mockDeactivateStableBalance = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  ...jest.requireActual("@app/self-custodial/bridge"),
+  deactivateStableBalance: (...args: readonly unknown[]) =>
+    mockDeactivateStableBalance(...args),
+}))
+
+const mockRefreshWallets = jest.fn()
+const mockRefreshStableBalanceActive = jest.fn()
+
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => ({
+    sdk: { id: "sdk" },
+    refreshWallets: mockRefreshWallets,
+    refreshStableBalanceActive: mockRefreshStableBalanceActive,
+  }),
+}))
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: jest.fn(),
+}))
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: jest.fn(),
+}))
+
+jest.mock("@app/utils/analytics", () => ({
+  logConversionAttempt: jest.fn(),
+  logConversionResult: jest.fn(),
+}))
+
+jest.mock("react-native-modal", () => {
+  const ReactNs = jest.requireActual<typeof import("react")>("react")
+  const RN = jest.requireActual<typeof import("react-native")>("react-native")
+  const MockModal = ({
+    children,
+    isVisible,
+  }: {
+    children: React.ReactNode
+    isVisible: boolean
+  }) => (isVisible ? ReactNs.createElement(RN.View, null, children) : null)
+  return { __esModule: true, default: MockModal }
+})
+
+import { StableTokenConvertToBtcModal } from "@app/screens/conversion-flow/stable-token-convert-to-btc-modal"
+
+loadLocale("en")
+
+const usdBalance = toUsdMoneyAmount(10001) // $100.01
+
+const wrap = (ui: React.ReactElement) => (
+  <ThemeProvider>
+    <TypesafeI18n locale="en">{ui}</TypesafeI18n>
+  </ThemeProvider>
+)
+
+const renderModal = (toggleModal: () => void = jest.fn()) =>
+  render(
+    wrap(
+      <StableTokenConvertToBtcModal
+        isVisible={true}
+        toggleModal={toggleModal}
+        usdWalletBalance={usdBalance}
+      />,
+    ),
+  )
+
+describe("StableTokenConvertToBtcModal through the real conversion pipeline", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeactivateStableBalance.mockResolvedValue(undefined)
+    mockRefreshWallets.mockResolvedValue(undefined)
+    mockRefreshStableBalanceActive.mockResolvedValue(undefined)
+  })
+
+  it("quotes, converts on Transfer, then closes, deactivates and refreshes in order", async () => {
+    const quoteExecute = jest
+      .fn()
+      .mockResolvedValue({ status: PaymentResultStatus.Success })
+    mockGetConversionQuote.mockResolvedValue({
+      feeAmount: toUsdMoneyAmount(5),
+      execute: quoteExecute,
+    })
+    const toggleModal = jest.fn()
+    const { getByText } = renderModal(toggleModal)
+
+    await waitFor(() => expect(getByText("Transfer")).toBeTruthy())
+
+    fireEvent.press(getByText("Transfer"))
+
+    await waitFor(() => expect(quoteExecute).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(mockRefreshWallets).toHaveBeenCalledTimes(1))
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+    expect(mockDeactivateStableBalance).toHaveBeenCalledTimes(1)
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+
+    const closeOrder = toggleModal.mock.invocationCallOrder[0]
+    const deactivateOrder = mockDeactivateStableBalance.mock.invocationCallOrder[0]
+    const refreshOrder = mockRefreshWallets.mock.invocationCallOrder[0]
+    expect(closeOrder).toBeLessThan(deactivateOrder)
+    expect(deactivateOrder).toBeLessThan(refreshOrder)
+  })
+
+  it("surfaces a failed quote with an escape hatch, retries and converts with the fresh quote", async () => {
+    mockGetConversionQuote.mockRejectedValueOnce(new Error("quote down"))
+    const toggleModal = jest.fn()
+    const { getByText, getByTestId, queryByText } = renderModal(toggleModal)
+
+    await waitFor(() =>
+      expect(getByText("There was an error.\nPlease try again later.")).toBeTruthy(),
+    )
+    expect(getByTestId("icon-close")).toBeTruthy()
+
+    const quoteExecute = jest
+      .fn()
+      .mockResolvedValue({ status: PaymentResultStatus.Success })
+    mockGetConversionQuote.mockResolvedValue({
+      feeAmount: toUsdMoneyAmount(5),
+      execute: quoteExecute,
+    })
+
+    fireEvent.press(getByText("Transfer"))
+
+    await waitFor(() => expect(mockGetConversionQuote).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(queryByText("There was an error.\nPlease try again later.")).toBeNull(),
+    )
+
+    fireEvent.press(getByText("Transfer"))
+
+    await waitFor(() => expect(quoteExecute).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(toggleModal).toHaveBeenCalledTimes(1))
+  })
+})

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.integration.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.integration.spec.tsx
@@ -99,6 +99,7 @@ const renderModal = (toggleModal: () => void = jest.fn()) =>
         isVisible={true}
         toggleModal={toggleModal}
         usdWalletBalance={usdBalance}
+        conversionMinimum={null}
       />,
     ),
   )

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
@@ -117,13 +117,18 @@ const wrap = (ui: React.ReactElement) => (
   </ThemeProvider>
 )
 
-const renderModal = (props?: { toggleModal?: () => void; isVisible?: boolean }) =>
+const renderModal = (props?: {
+  toggleModal?: () => void
+  isVisible?: boolean
+  conversionMinimum?: number | null
+}) =>
   render(
     wrap(
       <StableTokenConvertToBtcModal
         isVisible={props?.isVisible ?? true}
         toggleModal={props?.toggleModal ?? jest.fn()}
         usdWalletBalance={usdBalance}
+        conversionMinimum={props?.conversionMinimum ?? null}
       />,
     ),
   )
@@ -186,6 +191,7 @@ describe("StableTokenConvertToBtcModal", () => {
           isVisible={true}
           toggleModal={jest.fn()}
           usdWalletBalance={toUsdMoneyAmount(0)}
+          conversionMinimum={null}
         />,
       ),
     )
@@ -204,13 +210,13 @@ describe("StableTokenConvertToBtcModal", () => {
     expect(mockRequote).not.toHaveBeenCalled()
   })
 
-  it("stays busy but escapable while no quote is executable yet", () => {
+  it("stays busy and locked while no quote is executable yet, so the forced conversion cannot be skipped", () => {
     mockConversionState.canExecute = false
     mockConversionState.hasQuoteError = false
-    const { queryByText, getByTestId } = renderModal()
+    const { queryByText, queryByTestId } = renderModal()
 
     expect(queryByText("Transfer")).toBeNull()
-    expect(getByTestId("icon-close")).toBeTruthy()
+    expect(queryByTestId("icon-close")).toBeNull()
   })
 
   it("shows the conversion in progress while executing", () => {
@@ -234,10 +240,26 @@ describe("StableTokenConvertToBtcModal", () => {
     expect(mockExecute).not.toHaveBeenCalled()
   })
 
-  it("locks the modal only once the conversion is executable", () => {
+  it("locks the modal while the quote has not failed", () => {
     const { queryByTestId } = renderModal()
 
     expect(queryByTestId("icon-close")).toBeNull()
+  })
+
+  it("shows the minimum transfer amount when the quote fails below the minimum", () => {
+    mockConversionState.hasQuoteError = true
+    mockConversionState.canExecute = false
+    const { getByText } = renderModal({ conversionMinimum: 20000 })
+
+    expect(getByText("Minimum transfer: USD:20000")).toBeTruthy()
+  })
+
+  it("keeps the generic quote error when the balance meets the minimum", () => {
+    mockConversionState.hasQuoteError = true
+    mockConversionState.canExecute = false
+    const { getByText } = renderModal({ conversionMinimum: 500 })
+
+    expect(getByText("There was an error.\nPlease try again later.")).toBeTruthy()
   })
 
   it("prefers the execution error over the quote error", () => {

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { act, fireEvent, render } from "@testing-library/react-native"
 
 import TypesafeI18n from "@app/i18n/i18n-react"
+import { i18nObject } from "@app/i18n/i18n-util"
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { toUsdMoneyAmount } from "@app/types/amounts"
 import { ThemeProvider } from "@rn-vui/themed"
@@ -21,19 +22,17 @@ const mockConvertMoneyAmount = jest.fn((_moneyAmount: unknown, toCurrency: strin
   currency: toCurrency,
   currencyCode: toCurrency,
 }))
-let mockConvertReady = true
 
 jest.mock("@app/hooks/use-display-currency", () => ({
   useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
 }))
 
 jest.mock("@app/hooks/use-price-conversion", () => ({
-  usePriceConversion: () => ({
-    convertMoneyAmount: mockConvertReady ? mockConvertMoneyAmount : undefined,
-  }),
+  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount }),
 }))
 
 const mockExecute = jest.fn()
+const mockRequote = jest.fn()
 type ConversionParams = { onSuccess: () => Promise<void> }
 let mockConversionState: {
   isQuoting: boolean
@@ -41,6 +40,7 @@ let mockConversionState: {
   feeText: string
   canExecute: boolean
   execute: jest.Mock
+  requote: jest.Mock
   loading: boolean
   errorMessage?: string
 }
@@ -51,6 +51,12 @@ const mockUseSelfCustodialConversion = jest.fn(
 jest.mock("@app/screens/conversion-flow/hooks/self-custodial/use-conversion", () => ({
   useSelfCustodialConversion: (params: ConversionParams) =>
     mockUseSelfCustodialConversion(params),
+}))
+
+let mockIsWalletReady = true
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => ({ isReady: mockIsWalletReady }),
 }))
 
 const mockDeactivateStableBalance = jest.fn()
@@ -78,6 +84,12 @@ const mockReportError = jest.fn()
 
 jest.mock("@app/utils/error-logging", () => ({
   reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
+const mockToastShow = jest.fn()
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (...args: readonly unknown[]) => mockToastShow(...args),
 }))
 
 jest.mock("react-native-modal", () => {
@@ -123,28 +135,20 @@ describe("StableTokenConvertToBtcModal", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockHasSdk = true
-    mockConvertReady = true
+    mockIsWalletReady = true
     mockConversionState = {
       isQuoting: false,
       hasQuoteError: false,
       feeText: "",
       canExecute: true,
       execute: mockExecute,
+      requote: mockRequote,
       loading: false,
       errorMessage: undefined,
     }
     mockDeactivateStableBalance.mockResolvedValue(undefined)
     mockRefreshWallets.mockResolvedValue(undefined)
     mockRefreshStableBalanceActive.mockResolvedValue(undefined)
-  })
-
-  it("renders the title, body and both amount rows", () => {
-    const { getByText } = renderModal()
-
-    expect(getByText("Dollar Balance is not available in your region")).toBeTruthy()
-    expect(getByText("Transfer from Dollar Balance to Bitcoin Balance")).toBeTruthy()
-    expect(getByText("USD:10001")).toBeTruthy()
-    expect(getByText("~ BTC:129184")).toBeTruthy()
   })
 
   it("wires the full balance into the conversion-flow pipeline", () => {
@@ -166,21 +170,47 @@ describe("StableTokenConvertToBtcModal", () => {
     )
   })
 
+  it("waits for the wallet startup sync before quoting", () => {
+    mockIsWalletReady = false
+    renderModal()
+
+    expect(mockUseSelfCustodialConversion).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    )
+  })
+
+  it("does not quote a transient zero balance", () => {
+    render(
+      wrap(
+        <StableTokenConvertToBtcModal
+          isVisible={true}
+          toggleModal={jest.fn()}
+          usdWalletBalance={toUsdMoneyAmount(0)}
+        />,
+      ),
+    )
+
+    expect(mockUseSelfCustodialConversion).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    )
+  })
+
   it("executes the conversion when Transfer is pressed", () => {
     const { getByText } = renderModal()
 
     fireEvent.press(getByText("Transfer"))
 
     expect(mockExecute).toHaveBeenCalledTimes(1)
+    expect(mockRequote).not.toHaveBeenCalled()
   })
 
-  it("keeps Transfer disabled until the quote is ready", () => {
+  it("stays busy but escapable while no quote is executable yet", () => {
     mockConversionState.canExecute = false
-    const { getByText } = renderModal()
+    mockConversionState.hasQuoteError = false
+    const { queryByText, getByTestId } = renderModal()
 
-    fireEvent.press(getByText("Transfer"))
-
-    expect(mockExecute).not.toHaveBeenCalled()
+    expect(queryByText("Transfer")).toBeNull()
+    expect(getByTestId("icon-close")).toBeTruthy()
   })
 
   it("shows the conversion in progress while executing", () => {
@@ -190,20 +220,24 @@ describe("StableTokenConvertToBtcModal", () => {
     expect(queryByText("Transfer")).toBeNull()
   })
 
-  it("shows the quote in progress while it loads", () => {
-    mockConversionState.isQuoting = true
-    mockConversionState.canExecute = false
-    const { queryByText } = renderModal()
-
-    expect(queryByText("Transfer")).toBeNull()
-  })
-
-  it("surfaces a generic error when the quote fails, instead of a silent dead end", () => {
+  it("recovers from a failed quote: shows the error, allows dismissing and retries", () => {
     mockConversionState.hasQuoteError = true
     mockConversionState.canExecute = false
-    const { getByText } = renderModal()
+    const { getByText, getByTestId } = renderModal()
 
     expect(getByText("There was an error.\nPlease try again later.")).toBeTruthy()
+    expect(getByTestId("icon-close")).toBeTruthy()
+
+    fireEvent.press(getByText("Transfer"))
+
+    expect(mockRequote).toHaveBeenCalledTimes(1)
+    expect(mockExecute).not.toHaveBeenCalled()
+  })
+
+  it("locks the modal only once the conversion is executable", () => {
+    const { queryByTestId } = renderModal()
+
+    expect(queryByTestId("icon-close")).toBeNull()
   })
 
   it("prefers the execution error over the quote error", () => {
@@ -215,29 +249,25 @@ describe("StableTokenConvertToBtcModal", () => {
     expect(queryByText("There was an error.\nPlease try again later.")).toBeNull()
   })
 
-  it("ignores a second press while the conversion is in flight", () => {
-    const { getByText } = renderModal()
-    const transferButton = getByText("Transfer")
-
-    fireEvent.press(transferButton)
-    fireEvent.press(transferButton)
-
-    expect(mockExecute).toHaveBeenCalledTimes(1)
-  })
-
-  it("deactivates the stable balance, refreshes and closes after the conversion succeeds", async () => {
+  it("closes before deactivating and refreshing after the conversion succeeds", async () => {
     const toggleModal = jest.fn()
     renderModal({ toggleModal })
 
     await act(async () => capturedOnSuccess()())
 
+    expect(toggleModal).toHaveBeenCalledTimes(1)
     expect(mockDeactivateStableBalance).toHaveBeenCalledWith(mockSdk)
     expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
     expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
-    expect(toggleModal).toHaveBeenCalledTimes(1)
+
+    const closeOrder = toggleModal.mock.invocationCallOrder[0]
+    const deactivateOrder = mockDeactivateStableBalance.mock.invocationCallOrder[0]
+    const refreshOrder = mockRefreshWallets.mock.invocationCallOrder[0]
+    expect(closeOrder).toBeLessThan(deactivateOrder)
+    expect(deactivateOrder).toBeLessThan(refreshOrder)
   })
 
-  it("still closes when the deactivation fails, because the funds already moved", async () => {
+  it("warns with a toast and still refreshes when the deactivation fails", async () => {
     mockDeactivateStableBalance.mockRejectedValue(new Error("deactivate failed"))
     const toggleModal = jest.fn()
     renderModal({ toggleModal })
@@ -245,13 +275,20 @@ describe("StableTokenConvertToBtcModal", () => {
     await act(async () => capturedOnSuccess()())
 
     expect(toggleModal).toHaveBeenCalledTimes(1)
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    const toastMessage = mockToastShow.mock.calls[0][0].message
+    expect(toastMessage(i18nObject("en"))).toBe(
+      "Could not update Stable Balance. Please try again.",
+    )
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
       "Stable token forced conversion deactivate",
       expect.any(Error),
     )
   })
 
-  it("still closes when only the refresh fails", async () => {
+  it("only reports when the refresh fails, because the modal already closed", async () => {
     mockRefreshWallets.mockRejectedValue(new Error("refresh failed"))
     const toggleModal = jest.fn()
     renderModal({ toggleModal })
@@ -265,21 +302,7 @@ describe("StableTokenConvertToBtcModal", () => {
     )
   })
 
-  it("reports instead of rejecting when closing the modal throws", async () => {
-    const toggleModal = jest.fn(() => {
-      throw new Error("close failed")
-    })
-    renderModal({ toggleModal })
-
-    await act(async () => capturedOnSuccess()())
-
-    expect(mockReportError).toHaveBeenCalledWith(
-      "Stable token forced conversion close",
-      expect.any(Error),
-    )
-  })
-
-  it("skips the deactivation without a connected SDK but still refreshes and closes", async () => {
+  it("skips the deactivation without a connected SDK but still closes and refreshes", async () => {
     mockHasSdk = false
     const toggleModal = jest.fn()
     renderModal({ toggleModal })
@@ -287,34 +310,7 @@ describe("StableTokenConvertToBtcModal", () => {
     await act(async () => capturedOnSuccess()())
 
     expect(mockDeactivateStableBalance).not.toHaveBeenCalled()
-    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
     expect(toggleModal).toHaveBeenCalledTimes(1)
-  })
-
-  it("renders the error box when the conversion reports an error", () => {
-    mockConversionState.errorMessage = "Insufficient balance"
-    const { getByText } = renderModal()
-
-    expect(getByText("Insufficient balance")).toBeTruthy()
-  })
-
-  it("renders nothing when isVisible is false", () => {
-    const { queryByText } = renderModal({ isVisible: false })
-
-    expect(queryByText("Dollar Balance is not available in your region")).toBeNull()
-  })
-
-  it("hides the You get estimate while the price conversion is unavailable", () => {
-    mockConvertReady = false
-    const { getByText, queryByText } = renderModal()
-
-    expect(getByText("You get")).toBeTruthy()
-    expect(queryByText("~ BTC:129184")).toBeNull()
-  })
-
-  it("cannot be dismissed: it renders no close icon", () => {
-    const { queryByTestId } = renderModal()
-
-    expect(queryByTestId("icon-close")).toBeNull()
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
@@ -1,0 +1,320 @@
+import React from "react"
+import { act, fireEvent, render } from "@testing-library/react-native"
+
+import TypesafeI18n from "@app/i18n/i18n-react"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { toUsdMoneyAmount } from "@app/types/amounts"
+import { ThemeProvider } from "@rn-vui/themed"
+
+const mockFormatMoneyAmount = jest.fn(
+  ({
+    moneyAmount,
+    isApproximate,
+  }: {
+    moneyAmount: { amount: number; currency: string }
+    isApproximate?: boolean
+  }) => `${isApproximate ? "~ " : ""}${moneyAmount.currency}:${moneyAmount.amount}`,
+)
+
+const mockConvertMoneyAmount = jest.fn((_moneyAmount: unknown, toCurrency: string) => ({
+  amount: 129184,
+  currency: toCurrency,
+  currencyCode: toCurrency,
+}))
+let mockConvertReady = true
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
+}))
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({
+    convertMoneyAmount: mockConvertReady ? mockConvertMoneyAmount : undefined,
+  }),
+}))
+
+const mockExecute = jest.fn()
+type ConversionParams = { onSuccess: () => Promise<void> }
+let mockConversionState: {
+  isQuoting: boolean
+  hasQuoteError: boolean
+  feeText: string
+  canExecute: boolean
+  execute: jest.Mock
+  loading: boolean
+  errorMessage?: string
+}
+const mockUseSelfCustodialConversion = jest.fn(
+  (_params: ConversionParams) => mockConversionState,
+)
+
+jest.mock("@app/screens/conversion-flow/hooks/self-custodial/use-conversion", () => ({
+  useSelfCustodialConversion: (params: ConversionParams) =>
+    mockUseSelfCustodialConversion(params),
+}))
+
+const mockDeactivateStableBalance = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  ...jest.requireActual("@app/self-custodial/bridge"),
+  deactivateStableBalance: (...args: readonly unknown[]) =>
+    mockDeactivateStableBalance(...args),
+}))
+
+const mockSdk = { id: "sdk" }
+const mockRefreshWallets = jest.fn()
+const mockRefreshStableBalanceActive = jest.fn()
+let mockHasSdk = true
+
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => ({
+    sdk: mockHasSdk ? mockSdk : null,
+    refreshWallets: mockRefreshWallets,
+    refreshStableBalanceActive: mockRefreshStableBalanceActive,
+  }),
+}))
+
+const mockReportError = jest.fn()
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
+jest.mock("react-native-modal", () => {
+  const ReactNs = jest.requireActual<typeof import("react")>("react")
+  const RN = jest.requireActual<typeof import("react-native")>("react-native")
+  const MockModal = ({
+    children,
+    isVisible,
+  }: {
+    children: React.ReactNode
+    isVisible: boolean
+  }) => (isVisible ? ReactNs.createElement(RN.View, null, children) : null)
+  return { __esModule: true, default: MockModal }
+})
+
+import { StableTokenConvertToBtcModal } from "@app/screens/conversion-flow/stable-token-convert-to-btc-modal"
+
+loadLocale("en")
+
+const usdBalance = toUsdMoneyAmount(10001) // $100.01
+
+const wrap = (ui: React.ReactElement) => (
+  <ThemeProvider>
+    <TypesafeI18n locale="en">{ui}</TypesafeI18n>
+  </ThemeProvider>
+)
+
+const renderModal = (props?: { toggleModal?: () => void; isVisible?: boolean }) =>
+  render(
+    wrap(
+      <StableTokenConvertToBtcModal
+        isVisible={props?.isVisible ?? true}
+        toggleModal={props?.toggleModal ?? jest.fn()}
+        usdWalletBalance={usdBalance}
+      />,
+    ),
+  )
+
+const capturedOnSuccess = (): (() => Promise<void>) =>
+  mockUseSelfCustodialConversion.mock.calls[0][0].onSuccess
+
+describe("StableTokenConvertToBtcModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockHasSdk = true
+    mockConvertReady = true
+    mockConversionState = {
+      isQuoting: false,
+      hasQuoteError: false,
+      feeText: "",
+      canExecute: true,
+      execute: mockExecute,
+      loading: false,
+      errorMessage: undefined,
+    }
+    mockDeactivateStableBalance.mockResolvedValue(undefined)
+    mockRefreshWallets.mockResolvedValue(undefined)
+    mockRefreshStableBalanceActive.mockResolvedValue(undefined)
+  })
+
+  it("renders the title, body and both amount rows", () => {
+    const { getByText } = renderModal()
+
+    expect(getByText("Dollar Balance is not available in your region")).toBeTruthy()
+    expect(getByText("Transfer from Dollar Balance to Bitcoin Balance")).toBeTruthy()
+    expect(getByText("USD:10001")).toBeTruthy()
+    expect(getByText("~ BTC:129184")).toBeTruthy()
+  })
+
+  it("wires the full balance into the conversion-flow pipeline", () => {
+    renderModal()
+
+    expect(mockUseSelfCustodialConversion).toHaveBeenCalledWith({
+      fromCurrency: "USD",
+      moneyAmount: usdBalance,
+      enabled: true,
+      onSuccess: expect.any(Function),
+    })
+  })
+
+  it("only quotes while the modal is visible", () => {
+    renderModal({ isVisible: false })
+
+    expect(mockUseSelfCustodialConversion).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    )
+  })
+
+  it("executes the conversion when Transfer is pressed", () => {
+    const { getByText } = renderModal()
+
+    fireEvent.press(getByText("Transfer"))
+
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps Transfer disabled until the quote is ready", () => {
+    mockConversionState.canExecute = false
+    const { getByText } = renderModal()
+
+    fireEvent.press(getByText("Transfer"))
+
+    expect(mockExecute).not.toHaveBeenCalled()
+  })
+
+  it("shows the conversion in progress while executing", () => {
+    mockConversionState.loading = true
+    const { queryByText } = renderModal()
+
+    expect(queryByText("Transfer")).toBeNull()
+  })
+
+  it("shows the quote in progress while it loads", () => {
+    mockConversionState.isQuoting = true
+    mockConversionState.canExecute = false
+    const { queryByText } = renderModal()
+
+    expect(queryByText("Transfer")).toBeNull()
+  })
+
+  it("surfaces a generic error when the quote fails, instead of a silent dead end", () => {
+    mockConversionState.hasQuoteError = true
+    mockConversionState.canExecute = false
+    const { getByText } = renderModal()
+
+    expect(getByText("There was an error.\nPlease try again later.")).toBeTruthy()
+  })
+
+  it("prefers the execution error over the quote error", () => {
+    mockConversionState.hasQuoteError = true
+    mockConversionState.errorMessage = "Insufficient balance"
+    const { getByText, queryByText } = renderModal()
+
+    expect(getByText("Insufficient balance")).toBeTruthy()
+    expect(queryByText("There was an error.\nPlease try again later.")).toBeNull()
+  })
+
+  it("ignores a second press while the conversion is in flight", () => {
+    const { getByText } = renderModal()
+    const transferButton = getByText("Transfer")
+
+    fireEvent.press(transferButton)
+    fireEvent.press(transferButton)
+
+    expect(mockExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it("deactivates the stable balance, refreshes and closes after the conversion succeeds", async () => {
+    const toggleModal = jest.fn()
+    renderModal({ toggleModal })
+
+    await act(async () => capturedOnSuccess()())
+
+    expect(mockDeactivateStableBalance).toHaveBeenCalledWith(mockSdk)
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+  })
+
+  it("still closes when the deactivation fails, because the funds already moved", async () => {
+    mockDeactivateStableBalance.mockRejectedValue(new Error("deactivate failed"))
+    const toggleModal = jest.fn()
+    renderModal({ toggleModal })
+
+    await act(async () => capturedOnSuccess()())
+
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable token forced conversion deactivate",
+      expect.any(Error),
+    )
+  })
+
+  it("still closes when only the refresh fails", async () => {
+    mockRefreshWallets.mockRejectedValue(new Error("refresh failed"))
+    const toggleModal = jest.fn()
+    renderModal({ toggleModal })
+
+    await act(async () => capturedOnSuccess()())
+
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable token forced conversion refresh",
+      expect.any(Error),
+    )
+  })
+
+  it("reports instead of rejecting when closing the modal throws", async () => {
+    const toggleModal = jest.fn(() => {
+      throw new Error("close failed")
+    })
+    renderModal({ toggleModal })
+
+    await act(async () => capturedOnSuccess()())
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable token forced conversion close",
+      expect.any(Error),
+    )
+  })
+
+  it("skips the deactivation without a connected SDK but still refreshes and closes", async () => {
+    mockHasSdk = false
+    const toggleModal = jest.fn()
+    renderModal({ toggleModal })
+
+    await act(async () => capturedOnSuccess()())
+
+    expect(mockDeactivateStableBalance).not.toHaveBeenCalled()
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+    expect(toggleModal).toHaveBeenCalledTimes(1)
+  })
+
+  it("renders the error box when the conversion reports an error", () => {
+    mockConversionState.errorMessage = "Insufficient balance"
+    const { getByText } = renderModal()
+
+    expect(getByText("Insufficient balance")).toBeTruthy()
+  })
+
+  it("renders nothing when isVisible is false", () => {
+    const { queryByText } = renderModal({ isVisible: false })
+
+    expect(queryByText("Dollar Balance is not available in your region")).toBeNull()
+  })
+
+  it("hides the You get estimate while the price conversion is unavailable", () => {
+    mockConvertReady = false
+    const { getByText, queryByText } = renderModal()
+
+    expect(getByText("You get")).toBeTruthy()
+    expect(queryByText("~ BTC:129184")).toBeNull()
+  })
+
+  it("cannot be dismissed: it renders no close icon", () => {
+    const { queryByTestId } = renderModal()
+
+    expect(queryByTestId("icon-close")).toBeNull()
+  })
+})

--- a/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
+++ b/__tests__/screens/conversion-flow/stable-token-convert-to-btc-modal.spec.tsx
@@ -283,7 +283,7 @@ describe("StableTokenConvertToBtcModal", () => {
     expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
     expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
-      "Stable token forced conversion deactivate",
+      "Stable Balance deactivate",
       expect.any(Error),
     )
   })
@@ -297,12 +297,12 @@ describe("StableTokenConvertToBtcModal", () => {
 
     expect(toggleModal).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
-      "Stable token forced conversion refresh",
+      "Stable Balance refresh",
       expect.any(Error),
     )
   })
 
-  it("skips the deactivation without a connected SDK but still closes and refreshes", async () => {
+  it("skips the deactivation and refresh without a connected SDK but still closes", async () => {
     mockHasSdk = false
     const toggleModal = jest.fn()
     renderModal({ toggleModal })
@@ -311,6 +311,6 @@ describe("StableTokenConvertToBtcModal", () => {
 
     expect(mockDeactivateStableBalance).not.toHaveBeenCalled()
     expect(toggleModal).toHaveBeenCalledTimes(1)
-    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -101,8 +101,8 @@ jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
   useDollarBalanceRestrictionSync: () => undefined,
 }))
 
-jest.mock("@app/hooks/use-stablesats-forced-conversion", () => ({
-  useStablesatsForcedConversion: ({
+jest.mock("@app/hooks/use-dollar-balance-forced-conversion", () => ({
+  useDollarBalanceForcedConversion: ({
     isRestricted,
     usdWalletBalance,
   }: {
@@ -144,6 +144,27 @@ jest.mock("@app/components/usd-convert-to-btc-modal", () => {
         ? ReactActual.createElement(
             View,
             { testID: "convert-modal" },
+            ReactActual.createElement(Text, null, String(usdWalletBalance.amount)),
+          )
+        : null,
+  }
+})
+
+jest.mock("@app/screens/conversion-flow", () => {
+  const ReactActual = jest.requireActual("react")
+  const { View, Text } = jest.requireActual("react-native")
+  return {
+    StableTokenConvertToBtcModal: ({
+      isVisible,
+      usdWalletBalance,
+    }: {
+      isVisible: boolean
+      usdWalletBalance: { amount: number }
+    }) =>
+      isVisible
+        ? ReactActual.createElement(
+            View,
+            { testID: "sc-convert-modal" },
             ReactActual.createElement(Text, null, String(usdWalletBalance.amount)),
           )
         : null,
@@ -547,7 +568,7 @@ describe("HomeScreen", () => {
       usdBalance: 5000,
     })
 
-    const { findByTestId, getByText } = render(
+    const { findByTestId, getByText, queryByTestId } = render(
       <ContextForScreen>
         <HomeScreen />
       </ContextForScreen>,
@@ -555,6 +576,7 @@ describe("HomeScreen", () => {
 
     expect(await findByTestId("convert-modal")).toBeTruthy()
     expect(getByText("5000")).toBeTruthy()
+    expect(queryByTestId("sc-convert-modal")).toBeNull()
 
     await flushEffects()
   })
@@ -579,7 +601,7 @@ describe("HomeScreen", () => {
     expect(queryByTestId("convert-modal")).toBeNull()
   })
 
-  it("shows the dollar-balance restriction modal and skips forced conversion for self-custodial", async () => {
+  it("forces the self-custodial conversion when a restricted account holds a stable-token balance", async () => {
     mockDollarBalanceRestrictedOverride = true
     mockActiveWalletOverride = {
       wallets: [
@@ -609,7 +631,53 @@ describe("HomeScreen", () => {
       usdBalance: 5000,
     })
 
-    const { getByTestId, queryByTestId } = render(
+    const { findByTestId, getByTestId, getByText, queryByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    expect(await findByTestId("sc-convert-modal")).toBeTruthy()
+    expect(getByText("5000")).toBeTruthy()
+    expect(queryByTestId("convert-modal")).toBeNull()
+    expect(getByTestId("dollar-balance-restriction-modal")).toBeTruthy()
+
+    await flushEffects()
+
+    mockActiveWalletOverride = null
+  })
+
+  it("does not force the self-custodial conversion without a stable-token balance", async () => {
+    mockDollarBalanceRestrictedOverride = true
+    mockActiveWalletOverride = {
+      wallets: [
+        {
+          id: "btc-1",
+          walletCurrency: "BTC",
+          balance: { amount: 1000, currency: "BTC", currencyCode: "BTC" },
+          transactions: [],
+        },
+        {
+          id: "usd-1",
+          walletCurrency: "USD",
+          balance: { amount: 0, currency: "USD", currencyCode: "USD" },
+          transactions: [],
+        },
+      ],
+      status: "ready",
+      accountType: "self-custodial",
+      isReady: true,
+      isSelfCustodial: true,
+      needsBackendAuth: false,
+    }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    const { queryByTestId } = render(
       <ContextForScreen>
         <HomeScreen />
       </ContextForScreen>,
@@ -617,8 +685,7 @@ describe("HomeScreen", () => {
 
     await flushEffects()
 
-    expect(getByTestId("dollar-balance-restriction-modal")).toBeTruthy()
-    expect(queryByTestId("convert-modal")).toBeNull()
+    expect(queryByTestId("sc-convert-modal")).toBeNull()
 
     mockActiveWalletOverride = null
   })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -690,6 +690,40 @@ describe("HomeScreen", () => {
     mockActiveWalletOverride = null
   })
 
+  it("shows neither convert modal in the account-switch window, while the SDK still connects", async () => {
+    mockDollarBalanceRestrictedOverride = true
+    /** Right after switching to self-custodial: the restriction already applies
+     *  the self-custodial policy (accountType) but the SDK has not connected yet
+     *  (isSelfCustodial false), and the custodial query data is still cached. */
+    mockActiveWalletOverride = {
+      wallets: [],
+      status: "unavailable",
+      accountType: "self-custodial",
+      isReady: false,
+      isSelfCustodial: false,
+      needsBackendAuth: false,
+    }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 5000,
+    })
+
+    const { queryByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(queryByTestId("convert-modal")).toBeNull()
+    expect(queryByTestId("sc-convert-modal")).toBeNull()
+
+    mockActiveWalletOverride = null
+  })
+
   it("opens the dollar-balance restriction modal from the disabled transfer button", async () => {
     mockDollarBalanceRestrictedOverride = true
     mockActiveWalletOverride = {

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -150,7 +150,7 @@ jest.mock("@app/components/usd-convert-to-btc-modal", () => {
   }
 })
 
-jest.mock("@app/screens/conversion-flow", () => {
+jest.mock("@app/screens/conversion-flow/stable-token-convert-to-btc-modal", () => {
   const ReactActual = jest.requireActual("react")
   const { View, Text } = jest.requireActual("react-native")
   return {

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -13,6 +13,7 @@ import {
   Network,
 } from "@app/graphql/generated"
 import { mockCurrencyList } from "@app/graphql/mocks"
+import { ConvertDirection } from "@app/types/payment"
 
 let currentMocks: MockedResponse[] = []
 
@@ -101,17 +102,29 @@ jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
   useDollarBalanceRestrictionSync: () => undefined,
 }))
 
+type ForcedConversionParams = {
+  isRestricted: boolean
+  usdWalletBalance: number
+  minimumBalance: number | null
+}
+let mockForcedConversionParams: ForcedConversionParams | null = null
+
 jest.mock("@app/hooks/use-dollar-balance-forced-conversion", () => ({
-  useDollarBalanceForcedConversion: ({
-    isRestricted,
-    usdWalletBalance,
-  }: {
-    isRestricted: boolean
-    usdWalletBalance: number
-  }) => ({
-    isConvertModalVisible: isRestricted && usdWalletBalance > 0,
-    closeConvertModal: jest.fn(),
-  }),
+  useDollarBalanceForcedConversion: (params: ForcedConversionParams) => {
+    mockForcedConversionParams = params
+    return {
+      isConvertModalVisible: params.isRestricted && params.usdWalletBalance > 0,
+      closeConvertModal: jest.fn(),
+    }
+  },
+}))
+
+const mockUseNonCustodialConversionLimits = jest.fn()
+
+jest.mock("@app/self-custodial/hooks", () => ({
+  ...jest.requireActual("@app/self-custodial/hooks"),
+  useNonCustodialConversionLimits: (direction: string | undefined) =>
+    mockUseNonCustodialConversionLimits(direction),
 }))
 
 jest.mock("@app/components/dollar-balance-restriction-modal", () => {
@@ -491,6 +504,28 @@ const androidCases: ConvertButtonCase[] = [
   },
 ]
 
+const selfCustodialReadyWalletOverride = (usdBalance: number) => ({
+  wallets: [
+    {
+      id: "btc-1",
+      walletCurrency: "BTC",
+      balance: { amount: 1000, currency: "BTC", currencyCode: "BTC" },
+      transactions: [],
+    },
+    {
+      id: "usd-1",
+      walletCurrency: "USD",
+      balance: { amount: usdBalance, currency: "USD", currencyCode: "USD" },
+      transactions: [],
+    },
+  ],
+  status: "ready",
+  accountType: "self-custodial",
+  isReady: true,
+  isSelfCustodial: true,
+  needsBackendAuth: false,
+})
+
 describe("HomeScreen", () => {
   beforeEach(() => {
     currentMocks = []
@@ -498,7 +533,13 @@ describe("HomeScreen", () => {
     mockDollarBalanceRestrictedOverride = false
     mockTransferBlockedOverride = false
     mockDollarBalanceModalVisible = false
+    mockForcedConversionParams = null
     jest.clearAllMocks()
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: null,
+      loading: false,
+      error: null,
+    })
   })
 
   it("renders home screen for custodial user", async () => {
@@ -721,6 +762,64 @@ describe("HomeScreen", () => {
     expect(queryByTestId("convert-modal")).toBeNull()
     expect(queryByTestId("sc-convert-modal")).toBeNull()
 
+    mockActiveWalletOverride = null
+  })
+
+  it("treats a self-custodial limits response without a minimum as any positive cent", async () => {
+    mockDollarBalanceRestrictedOverride = true
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: { minFromAmount: null, minToAmount: null },
+      loading: false,
+      error: null,
+    })
+    mockActiveWalletOverride = selfCustodialReadyWalletOverride(5000)
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 5000,
+    })
+
+    render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(mockUseNonCustodialConversionLimits).toHaveBeenLastCalledWith(
+      ConvertDirection.UsdToBtc,
+    )
+    /** Mirrors the bridge: a null `minFromAmount` means "no minimum, allow",
+     *  so the forced-conversion trigger must not read it as "unknown". */
+    expect(mockForcedConversionParams?.minimumBalance).toBe(1)
+
+    mockActiveWalletOverride = null
+  })
+
+  it("skips the limits fetch while the home screen is unfocused", async () => {
+    mockIsFocused = false
+    mockDollarBalanceRestrictedOverride = true
+    mockActiveWalletOverride = selfCustodialReadyWalletOverride(5000)
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 5000,
+    })
+
+    render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    expect(mockUseNonCustodialConversionLimits).toHaveBeenLastCalledWith(undefined)
+
+    mockIsFocused = true
     mockActiveWalletOverride = null
   })
 

--- a/__tests__/screens/stable-balance-settings-screen.spec.tsx
+++ b/__tests__/screens/stable-balance-settings-screen.spec.tsx
@@ -373,8 +373,10 @@ describe("StableBalanceSettingsScreen", () => {
       expect(mockRecordError).toHaveBeenCalledWith(failure)
       expect(mockToastShow).toHaveBeenCalledTimes(1)
     })
-    expect(mockRefresh).not.toHaveBeenCalled()
-    expect(mockRefreshStableBalanceActive).not.toHaveBeenCalled()
+    /** The refresh still runs after a failed deactivation, re-syncing the
+     *  switch with the source of truth. */
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
 
     await flushEffects()
   })

--- a/__tests__/screens/stable-balance-settings-screen.spec.tsx
+++ b/__tests__/screens/stable-balance-settings-screen.spec.tsx
@@ -39,6 +39,10 @@ jest.mock("@react-native-firebase/crashlytics", () => ({
   default: () => ({ recordError: mockRecordError }),
 }))
 
+jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
+  useDollarBalanceRestricted: () => false,
+}))
+
 jest.mock("@app/utils/toast", () => ({
   toastShow: (...args: unknown[]) => mockToastShow(...args),
 }))

--- a/__tests__/screens/stable-balance-settings-screen/use-stable-balance-toggle.spec.ts
+++ b/__tests__/screens/stable-balance-settings-screen/use-stable-balance-toggle.spec.ts
@@ -135,6 +135,23 @@ describe("useStableBalanceToggle", () => {
     expect(mockToastShow).not.toHaveBeenCalled()
   })
 
+  it("resyncs the switch and toasts when the deactivation fails", async () => {
+    mockDeactivateStableBalance.mockRejectedValue(new Error("deactivate failed"))
+    const { result } = renderToggle({ isStableBalanceActive: true })
+    const initialSwitchKey = result.current.switchKey
+
+    await act(async () => {
+      await result.current.apply(false)
+    })
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable Balance deactivate",
+      expect.any(Error),
+    )
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    expect(result.current.switchKey).toBe(initialSwitchKey + 1)
+  })
+
   it("reports and resyncs the switch when the toggle fails", async () => {
     mockActivateStableBalance.mockRejectedValue(new Error("toggle failed"))
     const { result } = renderToggle()

--- a/__tests__/screens/stable-balance-settings-screen/use-stable-balance-toggle.spec.ts
+++ b/__tests__/screens/stable-balance-settings-screen/use-stable-balance-toggle.spec.ts
@@ -1,0 +1,156 @@
+import { act, renderHook } from "@testing-library/react-native"
+
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { useStableBalanceToggle } from "@app/screens/stable-balance-settings-screen/hooks/use-stable-balance-toggle"
+
+const mockActivateStableBalance = jest.fn()
+const mockDeactivateStableBalance = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  ...jest.requireActual("@app/self-custodial/bridge"),
+  activateStableBalance: (...args: readonly unknown[]) =>
+    mockActivateStableBalance(...args),
+  deactivateStableBalance: (...args: readonly unknown[]) =>
+    mockDeactivateStableBalance(...args),
+}))
+
+let mockIsDollarBalanceRestricted = false
+
+jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
+  useDollarBalanceRestricted: () => mockIsDollarBalanceRestricted,
+}))
+
+const mockLogActivated = jest.fn()
+
+jest.mock("@app/self-custodial/analytics", () => ({
+  logSelfCustodialStableBalanceActivated: (...args: readonly unknown[]) =>
+    mockLogActivated(...args),
+}))
+
+const mockReportError = jest.fn()
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
+const mockToastShow = jest.fn()
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (...args: readonly unknown[]) => mockToastShow(...args),
+}))
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+const mockSdk = { id: "sdk" } as never
+const mockRefreshWallets = jest.fn()
+const mockRefreshStableBalanceActive = jest.fn()
+
+const renderToggle = (overrides?: {
+  isStableBalanceActive?: boolean
+  sdk?: typeof mockSdk | null
+}) =>
+  renderHook(() =>
+    useStableBalanceToggle({
+      sdk: overrides?.sdk === undefined ? mockSdk : overrides.sdk,
+      isStableBalanceActive: overrides?.isStableBalanceActive ?? false,
+      refreshWallets: mockRefreshWallets,
+      refreshStableBalanceActive: mockRefreshStableBalanceActive,
+      LL,
+    }),
+  )
+
+describe("useStableBalanceToggle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockIsDollarBalanceRestricted = false
+    mockActivateStableBalance.mockResolvedValue(undefined)
+    mockDeactivateStableBalance.mockResolvedValue(undefined)
+    mockRefreshWallets.mockResolvedValue(undefined)
+    mockRefreshStableBalanceActive.mockResolvedValue(undefined)
+  })
+
+  it("activates the stable balance and refreshes the wallet state", async () => {
+    const { result } = renderToggle()
+
+    await act(async () => {
+      await result.current.apply(true)
+    })
+
+    expect(mockActivateStableBalance).toHaveBeenCalledTimes(1)
+    expect(mockLogActivated).toHaveBeenCalledTimes(1)
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+  })
+
+  it("deactivates the stable balance without the activation analytics", async () => {
+    const { result } = renderToggle({ isStableBalanceActive: true })
+
+    await act(async () => {
+      await result.current.apply(false)
+    })
+
+    expect(mockDeactivateStableBalance).toHaveBeenCalledTimes(1)
+    expect(mockLogActivated).not.toHaveBeenCalled()
+  })
+
+  it("blocks the activation for restricted regions with a toast and snaps the switch back", async () => {
+    mockIsDollarBalanceRestricted = true
+    const { result } = renderToggle()
+    const initialSwitchKey = result.current.switchKey
+
+    await act(async () => {
+      await result.current.apply(true)
+    })
+
+    expect(mockActivateStableBalance).not.toHaveBeenCalled()
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    const blockedMessage = mockToastShow.mock.calls[0][0].message
+    expect(blockedMessage(LL)).toBe("Dollar Balance is not available in your region")
+    expect(result.current.switchKey).toBe(initialSwitchKey + 1)
+    expect(mockRefreshWallets).not.toHaveBeenCalled()
+  })
+
+  it("still allows deactivating while restricted, so an active balance can be freed", async () => {
+    mockIsDollarBalanceRestricted = true
+    const { result } = renderToggle({ isStableBalanceActive: true })
+
+    await act(async () => {
+      await result.current.apply(false)
+    })
+
+    expect(mockDeactivateStableBalance).toHaveBeenCalledTimes(1)
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
+  it("does nothing without a connected SDK", async () => {
+    const { result } = renderToggle({ sdk: null })
+
+    await act(async () => {
+      await result.current.apply(true)
+    })
+
+    expect(mockActivateStableBalance).not.toHaveBeenCalled()
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+
+  it("reports and resyncs the switch when the toggle fails", async () => {
+    mockActivateStableBalance.mockRejectedValue(new Error("toggle failed"))
+    const { result } = renderToggle()
+    const initialSwitchKey = result.current.switchKey
+
+    await act(async () => {
+      await result.current.apply(true)
+    })
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable Balance toggle",
+      expect.any(Error),
+    )
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    const failureMessage = mockToastShow.mock.calls[0][0].message
+    expect(failureMessage(LL)).toBe("Could not update Stable Balance. Please try again.")
+    expect(result.current.switchKey).toBe(initialSwitchKey + 1)
+  })
+})

--- a/__tests__/self-custodial/stable-balance.spec.ts
+++ b/__tests__/self-custodial/stable-balance.spec.ts
@@ -1,0 +1,85 @@
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+import { deactivateStableBalanceAndRefresh } from "@app/self-custodial/stable-balance"
+
+const mockDeactivateStableBalance = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  ...jest.requireActual("@app/self-custodial/bridge"),
+  deactivateStableBalance: (...args: readonly unknown[]) =>
+    mockDeactivateStableBalance(...args),
+}))
+
+const mockReportError = jest.fn()
+
+jest.mock("@app/utils/error-logging", () => ({
+  reportError: (...args: readonly unknown[]) => mockReportError(...args),
+}))
+
+const mockToastShow = jest.fn()
+
+jest.mock("@app/utils/toast", () => ({
+  toastShow: (...args: readonly unknown[]) => mockToastShow(...args),
+}))
+
+loadLocale("en")
+const LL = i18nObject("en")
+
+const mockSdk = { id: "sdk" } as never
+const mockRefreshWallets = jest.fn()
+const mockRefreshStableBalanceActive = jest.fn()
+
+const run = () =>
+  deactivateStableBalanceAndRefresh({
+    sdk: mockSdk,
+    refreshWallets: mockRefreshWallets,
+    refreshStableBalanceActive: mockRefreshStableBalanceActive,
+    LL,
+  })
+
+describe("deactivateStableBalanceAndRefresh", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockDeactivateStableBalance.mockResolvedValue(undefined)
+    mockRefreshWallets.mockResolvedValue(undefined)
+    mockRefreshStableBalanceActive.mockResolvedValue(undefined)
+  })
+
+  it("deactivates, refreshes and resolves true", async () => {
+    await expect(run()).resolves.toBe(true)
+
+    expect(mockDeactivateStableBalance).toHaveBeenCalledWith(mockSdk)
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+    expect(mockToastShow).not.toHaveBeenCalled()
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it("toasts and reports a failed deactivation but still refreshes", async () => {
+    mockDeactivateStableBalance.mockRejectedValue(new Error("deactivate failed"))
+
+    await expect(run()).resolves.toBe(false)
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable Balance deactivate",
+      expect.any(Error),
+    )
+    expect(mockToastShow).toHaveBeenCalledTimes(1)
+    const toastMessage = mockToastShow.mock.calls[0][0].message
+    expect(toastMessage(LL)).toBe("Could not update Stable Balance. Please try again.")
+    expect(mockRefreshStableBalanceActive).toHaveBeenCalledTimes(1)
+    expect(mockRefreshWallets).toHaveBeenCalledTimes(1)
+  })
+
+  it("only reports when the refresh fails after a successful deactivation", async () => {
+    mockRefreshWallets.mockRejectedValue(new Error("refresh failed"))
+
+    await expect(run()).resolves.toBe(true)
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      "Stable Balance refresh",
+      expect.any(Error),
+    )
+    expect(mockToastShow).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -6,6 +6,7 @@ import {
   IpLookupAdapter,
   DEFAULT_ADAPTERS,
   resolveIpCountryCode,
+  resolveIpCountryCodeCached,
 } from "@app/utils/ip-country-lookup"
 
 jest.mock("axios")
@@ -75,6 +76,37 @@ describe("resolveIpCountryCode", () => {
   it("returns undefined with an empty adapter list", async () => {
     const result = await resolveIpCountryCode([])
     expect(result).toBeUndefined()
+  })
+})
+
+describe("resolveIpCountryCodeCached", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mutableConfig.GEO_IPIFY_API_KEY = ""
+    mutableConfig.IPINFO_API_KEY = ""
+    mutableConfig.PROXYCHECK_API_KEY = ""
+    mutableConfig.IPAPI_API_KEY = ""
+  })
+
+  /** One sequential test: the cache is module state, so the phases (failure
+   *  retries, concurrent dedupe, cached reuse) must run in a known order. */
+  it("shares one lookup per session, retrying failures and caching successes", async () => {
+    mockedAxios.get.mockRejectedValue(new Error("offline"))
+    await expect(resolveIpCountryCodeCached()).resolves.toBeUndefined()
+
+    mockedAxios.get.mockReset()
+    mockedAxios.get.mockResolvedValue({ data: { country: "DE" } })
+    const [first, second] = await Promise.all([
+      resolveIpCountryCodeCached(),
+      resolveIpCountryCodeCached(),
+    ])
+    expect(first).toBe("DE")
+    expect(second).toBe("DE")
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+
+    mockedAxios.get.mockClear()
+    await expect(resolveIpCountryCodeCached()).resolves.toBe("DE")
+    expect(mockedAxios.get).not.toHaveBeenCalled()
   })
 })
 

--- a/app/components/custom-modal/custom-modal.tsx
+++ b/app/components/custom-modal/custom-modal.tsx
@@ -88,6 +88,7 @@ const CustomModal: React.FC<CustomModalProps> = ({
       backdropTransitionOutTiming={0}
       avoidKeyboard={true}
       onBackdropPress={dismissable ? toggleModal : undefined}
+      onBackButtonPress={dismissable ? toggleModal : undefined}
     >
       <View style={styles.container}>
         <View style={styles.headerContainer}>

--- a/app/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.tsx
+++ b/app/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.tsx
@@ -1,0 +1,72 @@
+import * as React from "react"
+import { View } from "react-native"
+
+import { GaloyErrorBox } from "@app/components/atomic/galoy-error-box"
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { UsdMoneyAmount } from "@app/types/amounts"
+import { makeStyles, useTheme } from "@rn-vui/themed"
+
+import CustomModal from "../custom-modal/custom-modal"
+
+import { UsdConvertAmountRows } from "./usd-convert-amount-rows"
+
+type Props = {
+  isVisible: boolean
+  toggleModal: () => void
+  usdWalletBalance: UsdMoneyAmount
+  onConvert: () => void
+  loading: boolean
+  disabled?: boolean
+  errorMessage?: string
+}
+
+export const ConvertToBtcModalUI: React.FC<Props> = ({
+  isVisible,
+  toggleModal,
+  usdWalletBalance,
+  onConvert,
+  loading,
+  disabled = false,
+  errorMessage,
+}) => {
+  const { LL } = useI18nContext()
+  const {
+    theme: { colors },
+  } = useTheme()
+  const styles = useStyles()
+
+  const isConvertDisabled = loading || disabled
+
+  return (
+    <CustomModal
+      isVisible={isVisible}
+      toggleModal={toggleModal}
+      image={<GaloyIcon name="warning" size={80} color={colors.primary} />}
+      title={LL.ConvertDollarToBitcoinModal.title()}
+      titleMaxWidth="100%"
+      body={
+        <>
+          <UsdConvertAmountRows usdWalletBalance={usdWalletBalance} />
+          {errorMessage ? (
+            <View style={styles.errorContainer}>
+              <GaloyErrorBox errorMessage={errorMessage} />
+            </View>
+          ) : null}
+        </>
+      }
+      primaryButtonTitle={LL.ConversionDetailsScreen.transfer()}
+      primaryButtonOnPress={onConvert}
+      primaryButtonLoading={loading}
+      primaryButtonDisabled={isConvertDisabled}
+      showCloseIconButton={false}
+      dismissable={false}
+    />
+  )
+}
+
+const useStyles = makeStyles(() => ({
+  errorContainer: {
+    marginTop: 16,
+  },
+}))

--- a/app/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.tsx
+++ b/app/components/usd-convert-to-btc-modal/convert-to-btc-modal-ui.tsx
@@ -17,7 +17,7 @@ type Props = {
   usdWalletBalance: UsdMoneyAmount
   onConvert: () => void
   loading: boolean
-  disabled?: boolean
+  dismissable?: boolean
   errorMessage?: string
 }
 
@@ -27,7 +27,7 @@ export const ConvertToBtcModalUI: React.FC<Props> = ({
   usdWalletBalance,
   onConvert,
   loading,
-  disabled = false,
+  dismissable = false,
   errorMessage,
 }) => {
   const { LL } = useI18nContext()
@@ -35,8 +35,6 @@ export const ConvertToBtcModalUI: React.FC<Props> = ({
     theme: { colors },
   } = useTheme()
   const styles = useStyles()
-
-  const isConvertDisabled = loading || disabled
 
   return (
     <CustomModal
@@ -58,9 +56,9 @@ export const ConvertToBtcModalUI: React.FC<Props> = ({
       primaryButtonTitle={LL.ConversionDetailsScreen.transfer()}
       primaryButtonOnPress={onConvert}
       primaryButtonLoading={loading}
-      primaryButtonDisabled={isConvertDisabled}
-      showCloseIconButton={false}
-      dismissable={false}
+      primaryButtonDisabled={loading}
+      showCloseIconButton={dismissable}
+      dismissable={dismissable}
     />
   )
 }

--- a/app/components/usd-convert-to-btc-modal/index.ts
+++ b/app/components/usd-convert-to-btc-modal/index.ts
@@ -1,1 +1,2 @@
 export { UsdConvertToBtcModal } from "./usd-convert-to-btc-modal"
+export { ConvertToBtcModalUI } from "./convert-to-btc-modal-ui"

--- a/app/components/usd-convert-to-btc-modal/usd-convert-to-btc-modal.tsx
+++ b/app/components/usd-convert-to-btc-modal/usd-convert-to-btc-modal.tsx
@@ -1,17 +1,10 @@
 import * as React from "react"
-import { View } from "react-native"
 
-import { GaloyErrorBox } from "@app/components/atomic/galoy-error-box"
-import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { WalletCurrency } from "@app/graphql/generated"
 import { useIntraLedgerConversion } from "@app/hooks/use-intra-ledger-conversion"
-import { useI18nContext } from "@app/i18n/i18n-react"
 import { UsdMoneyAmount } from "@app/types/amounts"
-import { makeStyles, useTheme } from "@rn-vui/themed"
 
-import CustomModal from "../custom-modal/custom-modal"
-
-import { UsdConvertAmountRows } from "./usd-convert-amount-rows"
+import { ConvertToBtcModalUI } from "./convert-to-btc-modal-ui"
 
 type Props = {
   isVisible: boolean
@@ -28,12 +21,6 @@ export const UsdConvertToBtcModal: React.FC<Props> = ({
   usdWalletId,
   btcWalletId,
 }) => {
-  const { LL } = useI18nContext()
-  const {
-    theme: { colors },
-  } = useTheme()
-  const styles = useStyles()
-
   const { execute, loading, errorMessage } = useIntraLedgerConversion({
     onSuccess: toggleModal,
   })
@@ -46,34 +33,13 @@ export const UsdConvertToBtcModal: React.FC<Props> = ({
     })
 
   return (
-    <CustomModal
+    <ConvertToBtcModalUI
       isVisible={isVisible}
       toggleModal={toggleModal}
-      image={<GaloyIcon name="warning" size={80} color={colors.primary} />}
-      title={LL.ConvertDollarToBitcoinModal.title()}
-      titleMaxWidth="100%"
-      body={
-        <>
-          <UsdConvertAmountRows usdWalletBalance={usdWalletBalance} />
-          {errorMessage ? (
-            <View style={styles.errorContainer}>
-              <GaloyErrorBox errorMessage={errorMessage} />
-            </View>
-          ) : null}
-        </>
-      }
-      primaryButtonTitle={LL.ConversionDetailsScreen.transfer()}
-      primaryButtonOnPress={convertBalance}
-      primaryButtonLoading={loading}
-      primaryButtonDisabled={loading}
-      showCloseIconButton={false}
-      dismissable={false}
+      usdWalletBalance={usdWalletBalance}
+      onConvert={convertBalance}
+      loading={loading}
+      errorMessage={errorMessage}
     />
   )
 }
-
-const useStyles = makeStyles(() => ({
-  errorContainer: {
-    marginTop: 16,
-  },
-}))

--- a/app/hooks/use-device-location.ts
+++ b/app/hooks/use-device-location.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react"
 import { useApolloClient } from "@apollo/client"
 import { updateCountryCode } from "@app/graphql/client-only-query"
 import { useCountryCodeQuery, useSettingsScreenQuery } from "@app/graphql/generated"
-import { resolveIpCountryCode } from "@app/utils/ip-country-lookup"
+import { resolveIpCountryCodeCached } from "@app/utils/ip-country-lookup"
 import { logError } from "@app/utils/log-error"
 
 const DEFAULT_COUNTRY_CODE: CountryCode = "SV"
@@ -92,7 +92,7 @@ const useDeviceLocation = (): DeviceLocation => {
     setSource(LocationSource.Ip)
     const getLocation = async () => {
       const cached = data.countryCode as CountryCode | undefined
-      const ipCountryCode = await resolveIpCountryCode()
+      const ipCountryCode = await resolveIpCountryCodeCached()
       if (ipCountryCode) {
         setCountryCode(ipCountryCode)
         setDetectionFailed(false)
@@ -120,7 +120,7 @@ export const useIpCountryCode = (enabled: boolean): CountryCode | undefined => {
   useEffect(() => {
     if (!enabled) return undefined
     let active = true
-    resolveIpCountryCode().then((code) => {
+    resolveIpCountryCodeCached().then((code) => {
       if (active && code) setIpCountryCode(code)
     })
     return () => {

--- a/app/hooks/use-dollar-balance-forced-conversion.ts
+++ b/app/hooks/use-dollar-balance-forced-conversion.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from "react"
 
 /**
  * State mirror, not derived: closes on success immediately, before the balance
- * refetches to zero.
+ * refetches to zero. The latch still drops once the balance stops being
+ * convertible, so a stale re-open cannot outlive the refetch.
  */
 export const useDollarBalanceForcedConversion = ({
   accountId,
@@ -31,9 +32,16 @@ export const useDollarBalanceForcedConversion = ({
 
   /** `accountId` re-arms the trigger after the reset above; `isFocused` re-arms
    *  it after a manual close (possible only on a failed quote), so closing is
-   *  never final: the next visit to the home screen retries. */
+   *  never final: the next visit to the home screen retries. Losing the
+   *  convertible balance closes the latch, because a focus re-open can race the
+   *  post-conversion refetch and resurrect the modal on a stale balance; without
+   *  the close it would stay locked on funds that no longer exist. */
   useEffect(() => {
-    if (hasConvertibleBalance && isFocused) setIsConvertModalVisible(true)
+    if (!hasConvertibleBalance) {
+      setIsConvertModalVisible(false)
+      return
+    }
+    if (isFocused) setIsConvertModalVisible(true)
   }, [accountId, hasConvertibleBalance, isFocused])
 
   const closeConvertModal = useCallback(() => setIsConvertModalVisible(false), [])

--- a/app/hooks/use-dollar-balance-forced-conversion.ts
+++ b/app/hooks/use-dollar-balance-forced-conversion.ts
@@ -5,18 +5,28 @@ import { useCallback, useEffect, useState } from "react"
  * refetches to zero.
  */
 export const useDollarBalanceForcedConversion = ({
+  accountId,
   isRestricted,
   usdWalletBalance,
 }: {
+  accountId: string | undefined
   isRestricted: boolean
   usdWalletBalance: number
 }): { isConvertModalVisible: boolean; closeConvertModal: () => void } => {
   const [isConvertModalVisible, setIsConvertModalVisible] = useState(false)
   const hasConvertibleBalance = isRestricted && usdWalletBalance > 0
 
+  /** The home screen survives account switches, so a latch set by one account
+   *  must not leak the modal into the next one. */
+  useEffect(() => {
+    setIsConvertModalVisible(false)
+  }, [accountId])
+
+  /** `accountId` re-arms the trigger after the reset above, so an account that
+   *  is itself restricted with a positive balance still opens its own modal. */
   useEffect(() => {
     if (hasConvertibleBalance) setIsConvertModalVisible(true)
-  }, [hasConvertibleBalance])
+  }, [accountId, hasConvertibleBalance])
 
   const closeConvertModal = useCallback(() => setIsConvertModalVisible(false), [])
 

--- a/app/hooks/use-dollar-balance-forced-conversion.ts
+++ b/app/hooks/use-dollar-balance-forced-conversion.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react"
  * State mirror, not derived: closes on success immediately, before the balance
  * refetches to zero.
  */
-export const useStablesatsForcedConversion = ({
+export const useDollarBalanceForcedConversion = ({
   isRestricted,
   usdWalletBalance,
 }: {

--- a/app/hooks/use-dollar-balance-forced-conversion.ts
+++ b/app/hooks/use-dollar-balance-forced-conversion.ts
@@ -8,13 +8,20 @@ export const useDollarBalanceForcedConversion = ({
   accountId,
   isRestricted,
   usdWalletBalance,
+  minimumBalance,
+  isFocused,
 }: {
   accountId: string | undefined
   isRestricted: boolean
   usdWalletBalance: number
+  /** null while unknown: a quote cannot succeed before the conversion minimum
+   *  resolves, so the trigger stays closed instead of opening a doomed modal. */
+  minimumBalance: number | null
+  isFocused: boolean
 }): { isConvertModalVisible: boolean; closeConvertModal: () => void } => {
   const [isConvertModalVisible, setIsConvertModalVisible] = useState(false)
-  const hasConvertibleBalance = isRestricted && usdWalletBalance > 0
+  const hasConvertibleBalance =
+    isRestricted && minimumBalance !== null && usdWalletBalance >= minimumBalance
 
   /** The home screen survives account switches, so a latch set by one account
    *  must not leak the modal into the next one. */
@@ -22,11 +29,12 @@ export const useDollarBalanceForcedConversion = ({
     setIsConvertModalVisible(false)
   }, [accountId])
 
-  /** `accountId` re-arms the trigger after the reset above, so an account that
-   *  is itself restricted with a positive balance still opens its own modal. */
+  /** `accountId` re-arms the trigger after the reset above; `isFocused` re-arms
+   *  it after a manual close (possible only on a failed quote), so closing is
+   *  never final: the next visit to the home screen retries. */
   useEffect(() => {
-    if (hasConvertibleBalance) setIsConvertModalVisible(true)
-  }, [accountId, hasConvertibleBalance])
+    if (hasConvertibleBalance && isFocused) setIsConvertModalVisible(true)
+  }, [accountId, hasConvertibleBalance, isFocused])
 
   const closeConvertModal = useCallback(() => setIsConvertModalVisible(false), [])
 

--- a/app/screens/conversion-flow/conversion-confirmation-screen.tsx
+++ b/app/screens/conversion-flow/conversion-confirmation-screen.tsx
@@ -161,6 +161,12 @@ export const ConversionConfirmationScreen: React.FC<Props> = ({ route }) => {
 
   const payWallet = async () => {
     if (isSelfCustodial) {
+      /** A failed conversion invalidates the pinned quote, so the next swipe
+       *  retries the quote instead of stranding a permanently disabled slider. */
+      if (nonCustodialConversion.hasQuoteError) {
+        nonCustodialConversion.requote()
+        return
+      }
       await nonCustodialConversion.execute()
       return
     }
@@ -172,6 +178,13 @@ export const ConversionConfirmationScreen: React.FC<Props> = ({ route }) => {
   }
 
   const visibleErrorMessage = activeConversion.errorMessage
+
+  const isSelfCustodialQuotePending =
+    isSelfCustodial &&
+    !nonCustodialConversion.canExecute &&
+    !nonCustodialConversion.hasQuoteError
+
+  const isSliderDisabled = isLoading || isSelfCustodialQuotePending
 
   return (
     <Screen>
@@ -252,9 +265,7 @@ export const ConversionConfirmationScreen: React.FC<Props> = ({ route }) => {
             })}
             loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
             onSwipe={payWallet}
-            disabled={
-              isLoading || (isSelfCustodial && !nonCustodialConversion.canExecute)
-            }
+            disabled={isSliderDisabled}
           />
         </View>
       </PanGestureHandler>

--- a/app/screens/conversion-flow/hooks/self-custodial/use-conversion.ts
+++ b/app/screens/conversion-flow/hooks/self-custodial/use-conversion.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
-import crashlytics from "@react-native-firebase/crashlytics"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { PaymentSendResult, WalletCurrency } from "@app/graphql/generated"
 import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
@@ -12,6 +11,7 @@ import {
   type ConvertParams,
 } from "@app/types/payment"
 import { logConversionAttempt, logConversionResult } from "@app/utils/analytics"
+import { reportError } from "@app/utils/error-logging"
 import { triggerHapticFeedback } from "@app/utils/helper"
 
 import { buildConvertParams } from "../../build-convert-params"
@@ -70,10 +70,19 @@ export const useSelfCustodialConversion = ({
     }
   }, [quote, snapshotParams, liveQuoteParams])
 
-  /** Cloning gives the params a fresh identity, which re-runs the quote fetch. */
-  const requote = useCallback(() => {
-    setSnapshotParams(liveQuoteParams ? { ...liveQuoteParams } : null)
+  const liveQuoteParamsRef = useRef(liveQuoteParams)
+  useEffect(() => {
+    liveQuoteParamsRef.current = liveQuoteParams
   }, [liveQuoteParams])
+
+  /** Cloning gives the params a fresh identity, which re-runs the quote fetch.
+   *  Reads through a ref because `execute` captures this callback at press time:
+   *  if the balance changes while the conversion is in flight, the retry must
+   *  re-pin the live amount, not the one from the press-time render. */
+  const requote = useCallback(() => {
+    const live = liveQuoteParamsRef.current
+    setSnapshotParams(live ? { ...live } : null)
+  }, [])
 
   const execute = () =>
     guard.run(async () => {
@@ -114,12 +123,10 @@ export const useSelfCustodialConversion = ({
         setErrorMessage(result.errors?.[0]?.message ?? LL.errors.generic())
         triggerHapticFeedback("notificationError")
       } catch (err) {
-        if (err instanceof Error) {
-          crashlytics().recordError(err)
-          requote()
-          setErrorMessage(err.message)
-          triggerHapticFeedback("notificationError")
-        }
+        reportError("Self-custodial conversion execute", err)
+        requote()
+        setErrorMessage(err instanceof Error ? err.message : LL.errors.generic())
+        triggerHapticFeedback("notificationError")
       } finally {
         setLoading(false)
       }

--- a/app/screens/conversion-flow/hooks/self-custodial/use-conversion.ts
+++ b/app/screens/conversion-flow/hooks/self-custodial/use-conversion.ts
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import crashlytics from "@react-native-firebase/crashlytics"
 
 import { PaymentSendResult, WalletCurrency } from "@app/graphql/generated"
+import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
 import { usePriceConversion } from "@app/hooks/use-price-conversion"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { type MoneyAmount, type WalletOrDisplayCurrency } from "@app/types/amounts"
@@ -21,7 +22,7 @@ type Params = {
   fromCurrency: WalletCurrency
   moneyAmount: MoneyAmount<WalletOrDisplayCurrency>
   enabled: boolean
-  onSuccess: () => void
+  onSuccess: () => void | Promise<void>
 }
 
 export type SelfCustodialConversionFlow = {
@@ -30,6 +31,7 @@ export type SelfCustodialConversionFlow = {
   feeText: string
   canExecute: boolean
   execute: () => Promise<void>
+  requote: () => void
   loading: boolean
   errorMessage?: string
 }
@@ -42,6 +44,7 @@ export const useSelfCustodialConversion = ({
 }: Params): SelfCustodialConversionFlow => {
   const { convertMoneyAmount } = usePriceConversion()
   const { LL } = useI18nContext()
+  const guard = useInFlightGuard()
   const [loading, setLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | undefined>()
 
@@ -67,49 +70,60 @@ export const useSelfCustodialConversion = ({
     }
   }, [quote, snapshotParams, liveQuoteParams])
 
-  const execute = async () => {
-    setLoading(true)
-    setErrorMessage(undefined)
+  /** Cloning gives the params a fresh identity, which re-runs the quote fetch. */
+  const requote = useCallback(() => {
+    setSnapshotParams(liveQuoteParams ? { ...liveQuoteParams } : null)
+  }, [liveQuoteParams])
 
-    try {
-      if (!quote) {
-        setErrorMessage(LL.errors.generic())
+  const execute = () =>
+    guard.run(async () => {
+      setLoading(true)
+      setErrorMessage(undefined)
+
+      try {
+        if (!quote) {
+          setErrorMessage(LL.errors.generic())
+          triggerHapticFeedback("notificationError")
+          return
+        }
+
+        logConversionAttempt({
+          sendingWallet: fromCurrency,
+          receivingWallet: oppositeWalletCurrency(fromCurrency),
+        })
+
+        const result = await quote.execute()
+        const isSuccess = result.status === PaymentResultStatus.Success
+
+        logConversionResult({
+          sendingWallet: fromCurrency,
+          receivingWallet: oppositeWalletCurrency(fromCurrency),
+          paymentStatus: isSuccess
+            ? PaymentSendResult.Success
+            : PaymentSendResult.Failure,
+        })
+
+        if (isSuccess) {
+          triggerHapticFeedback("notificationSuccess")
+          await onSuccess()
+          return
+        }
+
+        /** A failed execute invalidates the pinned quote, so the retry re-quotes. */
+        requote()
+        setErrorMessage(result.errors?.[0]?.message ?? LL.errors.generic())
         triggerHapticFeedback("notificationError")
-        return
+      } catch (err) {
+        if (err instanceof Error) {
+          crashlytics().recordError(err)
+          requote()
+          setErrorMessage(err.message)
+          triggerHapticFeedback("notificationError")
+        }
+      } finally {
+        setLoading(false)
       }
-
-      logConversionAttempt({
-        sendingWallet: fromCurrency,
-        receivingWallet: oppositeWalletCurrency(fromCurrency),
-      })
-
-      const result = await quote.execute()
-      const isSuccess = result.status === PaymentResultStatus.Success
-
-      logConversionResult({
-        sendingWallet: fromCurrency,
-        receivingWallet: oppositeWalletCurrency(fromCurrency),
-        paymentStatus: isSuccess ? PaymentSendResult.Success : PaymentSendResult.Failure,
-      })
-
-      if (isSuccess) {
-        triggerHapticFeedback("notificationSuccess")
-        onSuccess()
-        return
-      }
-
-      setErrorMessage(result.errors?.[0]?.message ?? LL.errors.generic())
-      triggerHapticFeedback("notificationError")
-    } catch (err) {
-      if (err instanceof Error) {
-        crashlytics().recordError(err)
-        setErrorMessage(err.message)
-        triggerHapticFeedback("notificationError")
-      }
-    } finally {
-      setLoading(false)
-    }
-  }
+    })
 
   return {
     isQuoting,
@@ -117,6 +131,7 @@ export const useSelfCustodialConversion = ({
     feeText,
     canExecute: quote !== null,
     execute,
+    requote,
     loading,
     errorMessage,
   }

--- a/app/screens/conversion-flow/index.ts
+++ b/app/screens/conversion-flow/index.ts
@@ -1,3 +1,4 @@
 export * from "./conversion-details-screen"
 export * from "./conversion-confirmation-screen"
 export * from "./conversion-success-screen"
+export { StableTokenConvertToBtcModal } from "./stable-token-convert-to-btc-modal"

--- a/app/screens/conversion-flow/index.ts
+++ b/app/screens/conversion-flow/index.ts
@@ -1,4 +1,3 @@
 export * from "./conversion-details-screen"
 export * from "./conversion-confirmation-screen"
 export * from "./conversion-success-screen"
-export { StableTokenConvertToBtcModal } from "./stable-token-convert-to-btc-modal"

--- a/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
+++ b/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
@@ -1,0 +1,81 @@
+import * as React from "react"
+import { useState } from "react"
+
+import { ConvertToBtcModalUI } from "@app/components/usd-convert-to-btc-modal"
+import { WalletCurrency } from "@app/graphql/generated"
+import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { deactivateStableBalance } from "@app/self-custodial/bridge"
+import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+import { UsdMoneyAmount } from "@app/types/amounts"
+import { reportError } from "@app/utils/error-logging"
+
+import { useSelfCustodialConversion } from "./hooks/self-custodial/use-conversion"
+
+type Props = {
+  isVisible: boolean
+  toggleModal: () => void
+  usdWalletBalance: UsdMoneyAmount
+}
+
+/** Converts the full stable-token balance through the same quote/execute pipeline as
+ *  the conversion flow, then deactivates Stable Balance so future receives stay in
+ *  bitcoin instead of re-trapping into the restricted balance. */
+export const StableTokenConvertToBtcModal: React.FC<Props> = ({
+  isVisible,
+  toggleModal,
+  usdWalletBalance,
+}) => {
+  const { LL } = useI18nContext()
+  const { sdk, refreshWallets, refreshStableBalanceActive } = useSelfCustodialWallet()
+  const guard = useInFlightGuard()
+  const [isFinishing, setIsFinishing] = useState(false)
+
+  /** The funds already moved, so deactivation or refresh failures must not keep the
+   *  user blocked behind the non-dismissable modal. */
+  const stopRetrappingAndClose = async () => {
+    setIsFinishing(true)
+    try {
+      if (sdk) {
+        await deactivateStableBalance(sdk).catch((err) =>
+          reportError("Stable token forced conversion deactivate", err),
+        )
+      }
+      await Promise.all([refreshStableBalanceActive(), refreshWallets()]).catch((err) =>
+        reportError("Stable token forced conversion refresh", err),
+      )
+      toggleModal()
+    } catch (err) {
+      reportError("Stable token forced conversion close", err)
+    } finally {
+      setIsFinishing(false)
+    }
+  }
+
+  const { isQuoting, hasQuoteError, canExecute, execute, loading, errorMessage } =
+    useSelfCustodialConversion({
+      fromCurrency: WalletCurrency.Usd,
+      moneyAmount: usdWalletBalance,
+      enabled: isVisible,
+      onSuccess: stopRetrappingAndClose,
+    })
+
+  const convertBalance = () => guard.run(execute)
+
+  /** A failed quote in a non-dismissable modal must still tell the user something. */
+  const quoteFailedMessage = hasQuoteError ? LL.errors.generic() : undefined
+  const displayedErrorMessage = errorMessage ?? quoteFailedMessage
+  const isBusy = loading || isFinishing || isQuoting
+
+  return (
+    <ConvertToBtcModalUI
+      isVisible={isVisible}
+      toggleModal={toggleModal}
+      usdWalletBalance={usdWalletBalance}
+      onConvert={convertBalance}
+      loading={isBusy}
+      disabled={!canExecute}
+      errorMessage={displayedErrorMessage}
+    />
+  )
+}

--- a/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
+++ b/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
@@ -4,11 +4,9 @@ import { ConvertToBtcModalUI } from "@app/components/usd-convert-to-btc-modal"
 import { WalletCurrency } from "@app/graphql/generated"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { deactivateStableBalance } from "@app/self-custodial/bridge"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+import { deactivateStableBalanceAndRefresh } from "@app/self-custodial/stable-balance"
 import { UsdMoneyAmount } from "@app/types/amounts"
-import { reportError } from "@app/utils/error-logging"
-import { toastShow } from "@app/utils/toast"
 
 import { useSelfCustodialConversion } from "./hooks/self-custodial/use-conversion"
 
@@ -34,19 +32,13 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
    *  zero the amount and fire a useless re-quote behind a modal reporting success. */
   const stopRetrappingAndClose = async () => {
     toggleModal()
-    if (sdk) {
-      await deactivateStableBalance(sdk).catch((err) => {
-        reportError("Stable token forced conversion deactivate", err)
-        toastShow({
-          message: (tr) => tr.StableBalance.toggleFailedToast(),
-          LL,
-          type: "error",
-        })
-      })
-    }
-    await Promise.all([refreshStableBalanceActive(), refreshWallets()]).catch((err) =>
-      reportError("Stable token forced conversion refresh", err),
-    )
+    if (!sdk) return
+    await deactivateStableBalanceAndRefresh({
+      sdk,
+      refreshWallets,
+      refreshStableBalanceActive,
+      LL,
+    })
   }
 
   /** Quoting waits for the wallet to finish its startup sync AND for a settled

--- a/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
+++ b/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
@@ -1,14 +1,14 @@
 import * as React from "react"
-import { useState } from "react"
 
 import { ConvertToBtcModalUI } from "@app/components/usd-convert-to-btc-modal"
 import { WalletCurrency } from "@app/graphql/generated"
-import { useInFlightGuard } from "@app/hooks/use-in-flight-guard"
+import { useActiveWallet } from "@app/hooks/use-active-wallet"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { deactivateStableBalance } from "@app/self-custodial/bridge"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { UsdMoneyAmount } from "@app/types/amounts"
 import { reportError } from "@app/utils/error-logging"
+import { toastShow } from "@app/utils/toast"
 
 import { useSelfCustodialConversion } from "./hooks/self-custodial/use-conversion"
 
@@ -27,45 +27,49 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
   usdWalletBalance,
 }) => {
   const { LL } = useI18nContext()
+  const { isReady } = useActiveWallet()
   const { sdk, refreshWallets, refreshStableBalanceActive } = useSelfCustodialWallet()
-  const guard = useInFlightGuard()
-  const [isFinishing, setIsFinishing] = useState(false)
 
-  /** The funds already moved, so deactivation or refresh failures must not keep the
-   *  user blocked behind the non-dismissable modal. */
+  /** Closes first: the funds already moved, and refreshing while still visible would
+   *  zero the amount and fire a useless re-quote behind a modal reporting success. */
   const stopRetrappingAndClose = async () => {
-    setIsFinishing(true)
-    try {
-      if (sdk) {
-        await deactivateStableBalance(sdk).catch((err) =>
-          reportError("Stable token forced conversion deactivate", err),
-        )
-      }
-      await Promise.all([refreshStableBalanceActive(), refreshWallets()]).catch((err) =>
-        reportError("Stable token forced conversion refresh", err),
-      )
-      toggleModal()
-    } catch (err) {
-      reportError("Stable token forced conversion close", err)
-    } finally {
-      setIsFinishing(false)
+    toggleModal()
+    if (sdk) {
+      await deactivateStableBalance(sdk).catch((err) => {
+        reportError("Stable token forced conversion deactivate", err)
+        toastShow({
+          message: (tr) => tr.StableBalance.toggleFailedToast(),
+          LL,
+          type: "error",
+        })
+      })
     }
+    await Promise.all([refreshStableBalanceActive(), refreshWallets()]).catch((err) =>
+      reportError("Stable token forced conversion refresh", err),
+    )
   }
 
-  const { isQuoting, hasQuoteError, canExecute, execute, loading, errorMessage } =
+  /** Quoting waits for the wallet to finish its startup sync AND for a settled
+   *  positive balance: the modal opens right at launch, where a transient zero
+   *  balance would fire a below-minimum quote that fails and flashes an error. */
+  const hasConvertibleBalance = usdWalletBalance.amount > 0
+  const canQuote = isVisible && isReady && hasConvertibleBalance
+
+  const { hasQuoteError, canExecute, execute, requote, loading, errorMessage } =
     useSelfCustodialConversion({
       fromCurrency: WalletCurrency.Usd,
       moneyAmount: usdWalletBalance,
-      enabled: isVisible,
+      enabled: canQuote,
       onSuccess: stopRetrappingAndClose,
     })
 
-  const convertBalance = () => guard.run(execute)
-
-  /** A failed quote in a non-dismissable modal must still tell the user something. */
+  /** On a failed quote the button turns into a retry, and the modal only locks while
+   *  a conversion is actually executable, so no unquotable state strands the user. */
+  const convertBalance = hasQuoteError ? requote : execute
   const quoteFailedMessage = hasQuoteError ? LL.errors.generic() : undefined
   const displayedErrorMessage = errorMessage ?? quoteFailedMessage
-  const isBusy = loading || isFinishing || isQuoting
+  const isAwaitingQuote = !canExecute && !hasQuoteError
+  const isBusy = loading || isAwaitingQuote
 
   return (
     <ConvertToBtcModalUI
@@ -74,7 +78,7 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
       usdWalletBalance={usdWalletBalance}
       onConvert={convertBalance}
       loading={isBusy}
-      disabled={!canExecute}
+      dismissable={!canExecute}
       errorMessage={displayedErrorMessage}
     />
   )

--- a/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
+++ b/app/screens/conversion-flow/stable-token-convert-to-btc-modal.tsx
@@ -3,10 +3,11 @@ import * as React from "react"
 import { ConvertToBtcModalUI } from "@app/components/usd-convert-to-btc-modal"
 import { WalletCurrency } from "@app/graphql/generated"
 import { useActiveWallet } from "@app/hooks/use-active-wallet"
+import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 import { deactivateStableBalanceAndRefresh } from "@app/self-custodial/stable-balance"
-import { UsdMoneyAmount } from "@app/types/amounts"
+import { toUsdMoneyAmount, UsdMoneyAmount } from "@app/types/amounts"
 
 import { useSelfCustodialConversion } from "./hooks/self-custodial/use-conversion"
 
@@ -14,6 +15,7 @@ type Props = {
   isVisible: boolean
   toggleModal: () => void
   usdWalletBalance: UsdMoneyAmount
+  conversionMinimum: number | null
 }
 
 /** Converts the full stable-token balance through the same quote/execute pipeline as
@@ -23,8 +25,10 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
   isVisible,
   toggleModal,
   usdWalletBalance,
+  conversionMinimum,
 }) => {
   const { LL } = useI18nContext()
+  const { formatMoneyAmount } = useDisplayCurrency()
   const { isReady } = useActiveWallet()
   const { sdk, refreshWallets, refreshStableBalanceActive } = useSelfCustodialWallet()
 
@@ -55,10 +59,25 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
       onSuccess: stopRetrappingAndClose,
     })
 
-  /** On a failed quote the button turns into a retry, and the modal only locks while
-   *  a conversion is actually executable, so no unquotable state strands the user. */
+  /** On a failed quote the button turns into a retry and the modal becomes
+   *  escapable; everywhere else it stays locked, so the forced conversion cannot
+   *  be skipped while the first quote loads. Closing is never final: the home
+   *  trigger re-opens the modal next time the screen gains focus. */
   const convertBalance = hasQuoteError ? requote : execute
-  const quoteFailedMessage = hasQuoteError ? LL.errors.generic() : undefined
+
+  /** The home trigger already gates on the conversion minimum, but the balance
+   *  can shrink while the modal is open; an honest minimum beats a generic error
+   *  in that residual case. */
+  const isBelowConversionMinimum =
+    conversionMinimum !== null && usdWalletBalance.amount < conversionMinimum
+  const belowMinimumMessage = isBelowConversionMinimum
+    ? LL.StableBalance.minimumConversion({
+        amount: formatMoneyAmount({ moneyAmount: toUsdMoneyAmount(conversionMinimum) }),
+      })
+    : undefined
+  const quoteFailedMessage = hasQuoteError
+    ? belowMinimumMessage ?? LL.errors.generic()
+    : undefined
   const displayedErrorMessage = errorMessage ?? quoteFailedMessage
   const isAwaitingQuote = !canExecute && !hasQuoteError
   const isBusy = loading || isAwaitingQuote
@@ -70,7 +89,7 @@ export const StableTokenConvertToBtcModal: React.FC<Props> = ({
       usdWalletBalance={usdWalletBalance}
       onConvert={convertBalance}
       loading={isBusy}
-      dismissable={!canExecute}
+      dismissable={hasQuoteError}
       errorMessage={displayedErrorMessage}
     />
   )

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -87,8 +87,9 @@ import { useLevel } from "@app/graphql/level-context"
 
 const TransactionCountToTriggerSetDefaultAccountModal = 1
 const UPGRADE_MODAL_INITIAL_DELAY_MS = 1500
-/** Custodial intraledger conversions have no pool minimum: any positive cent converts. */
-const CUSTODIAL_MINIMUM_CONVERTIBLE_BALANCE = 1
+/** Floor for conversions without a pool minimum (custodial intraledger always,
+ *  self-custodial when the SDK reports none): any positive cent converts. */
+const ANY_POSITIVE_CENT_MINIMUM = 1
 
 gql`
   query homeAuthed {
@@ -400,17 +401,26 @@ export const HomeScreen: React.FC = () => {
   )
 
   /** The limits fetch only runs when a forced conversion is actually on the
-   *  table (the hook skips entirely on an undefined direction). Below the Breez
-   *  pool minimum the trigger stays closed: the bridge rejects below-minimum
-   *  conversions, so the modal would nag with a retry that can never succeed. */
+   *  table (the hook skips entirely on an undefined direction), and gating on
+   *  focus re-runs it on each home visit, so one failed fetch cannot mute the
+   *  trigger for the whole session. Below the Breez pool minimum the trigger
+   *  stays closed: the bridge rejects below-minimum conversions, so the modal
+   *  would nag with a retry that can never succeed. */
   const shouldCheckConversionMinimum =
-    !isCustodialAccount && isDollarBalanceRestricted && restrictedUsdWalletBalance > 0
+    !isCustodialAccount &&
+    isDollarBalanceRestricted &&
+    restrictedUsdWalletBalance > 0 &&
+    isFocused
   const { limits: stableTokenConversionLimits } = useNonCustodialConversionLimits(
     shouldCheckConversionMinimum ? ConvertDirection.UsdToBtc : undefined,
   )
-  const stableTokenConversionMinimum = stableTokenConversionLimits?.minFromAmount ?? null
+  /** A fetched limits response without a minimum means "none": mirror the bridge
+   *  (`checkConversionMinimum`), which lets any positive amount through. */
+  const stableTokenConversionMinimum = stableTokenConversionLimits
+    ? stableTokenConversionLimits.minFromAmount ?? ANY_POSITIVE_CENT_MINIMUM
+    : null
   const minimumConvertibleBalance = isCustodialAccount
-    ? CUSTODIAL_MINIMUM_CONVERTIBLE_BALANCE
+    ? ANY_POSITIVE_CENT_MINIMUM
     : stableTokenConversionMinimum
 
   const { isConvertModalVisible, closeConvertModal } = useDollarBalanceForcedConversion({

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -24,7 +24,7 @@ import { BalanceHeader, useTotalBalance } from "@app/components/balance-header"
 import { BalanceMode, useBalanceMode } from "@app/hooks/use-balance-mode"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
-import { StableTokenConvertToBtcModal } from "@app/screens/conversion-flow"
+import { StableTokenConvertToBtcModal } from "@app/screens/conversion-flow/stable-token-convert-to-btc-modal"
 import { TrialAccountLimitsModal } from "@app/components/upgrade-account-modal"
 import SlideUpHandle from "@app/components/slide-up-handle"
 import { Screen } from "@app/components/screen"
@@ -386,6 +386,14 @@ export const HomeScreen: React.FC = () => {
     usdWalletBalance: restrictedUsdWalletBalance,
   })
 
+  /** Each account type renders its own convert modal; the guards keep them exclusive
+   *  locally instead of relying on the skipped custodial query staying empty. */
+  const custodialConvertWallets =
+    !isSelfCustodial && restrictedUsdWallet && restrictedBtcWallet
+      ? { usdWalletId: restrictedUsdWallet.id, btcWalletId: restrictedBtcWallet.id }
+      : null
+  const shouldShowStableTokenConvertModal = isSelfCustodial && isConvertModalVisible
+
   const closeUpgradeModal = () => setIsUpgradeModalVisible(false)
   const closeRestrictionModal = () => setIsRestrictionModalVisible(false)
   const openUpgradeModal = React.useCallback(() => {
@@ -595,16 +603,16 @@ export const HomeScreen: React.FC = () => {
         isVisible={isRestrictionModalVisible}
         toggleModal={closeRestrictionModal}
       />
-      {restrictedUsdWallet && restrictedBtcWallet && (
+      {custodialConvertWallets && (
         <UsdConvertToBtcModal
           isVisible={isConvertModalVisible}
           toggleModal={closeConvertModal}
           usdWalletBalance={restrictedUsdMoneyAmount}
-          usdWalletId={restrictedUsdWallet.id}
-          btcWalletId={restrictedBtcWallet.id}
+          usdWalletId={custodialConvertWallets.usdWalletId}
+          btcWalletId={custodialConvertWallets.btcWalletId}
         />
       )}
-      {isSelfCustodial && (
+      {shouldShowStableTokenConvertModal && (
         <StableTokenConvertToBtcModal
           isVisible={isConvertModalVisible}
           toggleModal={closeConvertModal}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -54,7 +54,9 @@ import {
   useTransferBlockedSync,
 } from "@app/hooks/use-transfer-blocked"
 import { useSelfCustodialNetworkMismatchToast } from "@app/self-custodial/hooks/use-network-mismatch-toast"
+import { useNonCustodialConversionLimits } from "@app/self-custodial/hooks"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
+import { ConvertDirection } from "@app/types/payment"
 import { useBackupNudgeState } from "@app/hooks/use-backup-nudge-state"
 import { getErrorMessages } from "@app/graphql/utils"
 import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"
@@ -85,6 +87,8 @@ import { useLevel } from "@app/graphql/level-context"
 
 const TransactionCountToTriggerSetDefaultAccountModal = 1
 const UPGRADE_MODAL_INITIAL_DELAY_MS = 1500
+/** Custodial intraledger conversions have no pool minimum: any positive cent converts. */
+const CUSTODIAL_MINIMUM_CONVERTIBLE_BALANCE = 1
 
 gql`
   query homeAuthed {
@@ -395,10 +399,26 @@ export const HomeScreen: React.FC = () => {
     [restrictedUsdWalletBalance],
   )
 
+  /** The limits fetch only runs when a forced conversion is actually on the
+   *  table (the hook skips entirely on an undefined direction). Below the Breez
+   *  pool minimum the trigger stays closed: the bridge rejects below-minimum
+   *  conversions, so the modal would nag with a retry that can never succeed. */
+  const shouldCheckConversionMinimum =
+    !isCustodialAccount && isDollarBalanceRestricted && restrictedUsdWalletBalance > 0
+  const { limits: stableTokenConversionLimits } = useNonCustodialConversionLimits(
+    shouldCheckConversionMinimum ? ConvertDirection.UsdToBtc : undefined,
+  )
+  const stableTokenConversionMinimum = stableTokenConversionLimits?.minFromAmount ?? null
+  const minimumConvertibleBalance = isCustodialAccount
+    ? CUSTODIAL_MINIMUM_CONVERTIBLE_BALANCE
+    : stableTokenConversionMinimum
+
   const { isConvertModalVisible, closeConvertModal } = useDollarBalanceForcedConversion({
     accountId: activeAccount?.id,
     isRestricted: isDollarBalanceRestricted,
     usdWalletBalance: restrictedUsdWalletBalance,
+    minimumBalance: minimumConvertibleBalance,
+    isFocused,
   })
 
   /** Each account type renders its own convert modal; the guards keep them exclusive
@@ -632,6 +652,7 @@ export const HomeScreen: React.FC = () => {
           isVisible={isConvertModalVisible}
           toggleModal={closeConvertModal}
           usdWalletBalance={restrictedUsdMoneyAmount}
+          conversionMinimum={stableTokenConversionMinimum}
         />
       )}
       <View style={styles.balanceContainer}>

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -78,7 +78,9 @@ import {
   useHomeUnauthedQuery,
   useRealtimePriceQuery,
   useSettingsScreenQuery,
+  WalletCurrency,
 } from "@app/graphql/generated"
+import { AccountType } from "@app/types/wallet"
 import { useLevel } from "@app/graphql/level-context"
 
 const TransactionCountToTriggerSetDefaultAccountModal = 1
@@ -196,7 +198,7 @@ export const HomeScreen: React.FC = () => {
     isStableBalanceActive,
     lightningAddress: selfCustodialLightningAddress,
   } = useSelfCustodialWallet()
-  const { accounts } = useAccountRegistry()
+  const { accounts, activeAccount } = useAccountRegistry()
   const hasMultipleAccounts = accounts.length > 1
   const { stableBalanceEnabled } = useFeatureFlags()
   const { mode: balanceMode, toggleMode: toggleBalanceMode } = useBalanceMode()
@@ -373,8 +375,20 @@ export const HomeScreen: React.FC = () => {
 
   const restrictedUsdWallet = getUsdWallet(dataAuthed?.me?.defaultAccount?.wallets)
   const restrictedBtcWallet = getBtcWallet(dataAuthed?.me?.defaultAccount?.wallets)
-  /** `wallets` resolves per account type, so this balance covers both variants. */
-  const restrictedUsdWalletBalance = getUsdWallet(wallets)?.balance ?? 0
+  /** Balance and restriction policy must resolve for the SAME account type: right
+   *  after switching to self-custodial the SDK is still connecting (so
+   *  `isSelfCustodial` is false) while the restriction already applies the
+   *  self-custodial policy; reading the cached custodial balance in that window
+   *  would trigger the previous account's modal. */
+  const isCustodialAccount = activeWallet.accountType === AccountType.Custodial
+  const selfCustodialUsdWallet = activeWallet.wallets.find(
+    (w) => w.walletCurrency === WalletCurrency.Usd,
+  )
+  const custodialUsdWalletBalance = restrictedUsdWallet?.balance ?? 0
+  const selfCustodialUsdWalletBalance = selfCustodialUsdWallet?.balance.amount ?? 0
+  const restrictedUsdWalletBalance = isCustodialAccount
+    ? custodialUsdWalletBalance
+    : selfCustodialUsdWalletBalance
   /** Memoized so the self-custodial quote does not refire on unrelated re-renders. */
   const restrictedUsdMoneyAmount = useMemo(
     () => toUsdMoneyAmount(restrictedUsdWalletBalance),
@@ -382,6 +396,7 @@ export const HomeScreen: React.FC = () => {
   )
 
   const { isConvertModalVisible, closeConvertModal } = useDollarBalanceForcedConversion({
+    accountId: activeAccount?.id,
     isRestricted: isDollarBalanceRestricted,
     usdWalletBalance: restrictedUsdWalletBalance,
   })
@@ -389,7 +404,7 @@ export const HomeScreen: React.FC = () => {
   /** Each account type renders its own convert modal; the guards keep them exclusive
    *  locally instead of relying on the skipped custodial query staying empty. */
   const custodialConvertWallets =
-    !isSelfCustodial && restrictedUsdWallet && restrictedBtcWallet
+    isCustodialAccount && restrictedUsdWallet && restrictedBtcWallet
       ? { usdWalletId: restrictedUsdWallet.id, btcWalletId: restrictedBtcWallet.id }
       : null
   const shouldShowStableTokenConvertModal = isSelfCustodial && isConvertModalVisible

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -24,7 +24,7 @@ import { BalanceHeader, useTotalBalance } from "@app/components/balance-header"
 import { BalanceMode, useBalanceMode } from "@app/hooks/use-balance-mode"
 import { useDisplayCurrency } from "@app/hooks/use-display-currency"
 import { toBtcMoneyAmount, toUsdMoneyAmount } from "@app/types/amounts"
-import { AccountType } from "@app/types/wallet"
+import { StableTokenConvertToBtcModal } from "@app/screens/conversion-flow"
 import { TrialAccountLimitsModal } from "@app/components/upgrade-account-modal"
 import SlideUpHandle from "@app/components/slide-up-handle"
 import { Screen } from "@app/components/screen"
@@ -48,7 +48,7 @@ import {
   useDollarBalanceRestricted,
   useDollarBalanceRestrictionSync,
 } from "@app/hooks/use-dollar-balance-restricted"
-import { useStablesatsForcedConversion } from "@app/hooks/use-stablesats-forced-conversion"
+import { useDollarBalanceForcedConversion } from "@app/hooks/use-dollar-balance-forced-conversion"
 import {
   useTransferBlocked,
   useTransferBlockedSync,
@@ -189,7 +189,7 @@ export const HomeScreen: React.FC = () => {
 
   const isAuthed = useIsAuthed()
   const activeWallet = useActiveWallet()
-  const { isSelfCustodial, accountType } = activeWallet
+  const { isSelfCustodial } = activeWallet
   useSelfCustodialNetworkMismatchToast()
   const {
     refreshWallets: refreshSelfCustodialWallets,
@@ -373,10 +373,16 @@ export const HomeScreen: React.FC = () => {
 
   const restrictedUsdWallet = getUsdWallet(dataAuthed?.me?.defaultAccount?.wallets)
   const restrictedBtcWallet = getBtcWallet(dataAuthed?.me?.defaultAccount?.wallets)
-  const restrictedUsdWalletBalance = restrictedUsdWallet?.balance ?? 0
+  /** `wallets` resolves per account type, so this balance covers both variants. */
+  const restrictedUsdWalletBalance = getUsdWallet(wallets)?.balance ?? 0
+  /** Memoized so the self-custodial quote does not refire on unrelated re-renders. */
+  const restrictedUsdMoneyAmount = useMemo(
+    () => toUsdMoneyAmount(restrictedUsdWalletBalance),
+    [restrictedUsdWalletBalance],
+  )
 
-  const { isConvertModalVisible, closeConvertModal } = useStablesatsForcedConversion({
-    isRestricted: isDollarBalanceRestricted && accountType === AccountType.Custodial,
+  const { isConvertModalVisible, closeConvertModal } = useDollarBalanceForcedConversion({
+    isRestricted: isDollarBalanceRestricted,
     usdWalletBalance: restrictedUsdWalletBalance,
   })
 
@@ -593,9 +599,16 @@ export const HomeScreen: React.FC = () => {
         <UsdConvertToBtcModal
           isVisible={isConvertModalVisible}
           toggleModal={closeConvertModal}
-          usdWalletBalance={toUsdMoneyAmount(restrictedUsdWalletBalance)}
+          usdWalletBalance={restrictedUsdMoneyAmount}
           usdWalletId={restrictedUsdWallet.id}
           btcWalletId={restrictedBtcWallet.id}
+        />
+      )}
+      {isSelfCustodial && (
+        <StableTokenConvertToBtcModal
+          isVisible={isConvertModalVisible}
+          toggleModal={closeConvertModal}
+          usdWalletBalance={restrictedUsdMoneyAmount}
         />
       )}
       <View style={styles.balanceContainer}>

--- a/app/screens/stable-balance-settings-screen/hooks/use-stable-balance-toggle.ts
+++ b/app/screens/stable-balance-settings-screen/hooks/use-stable-balance-toggle.ts
@@ -4,11 +4,9 @@ import type { BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 
 import { useDollarBalanceRestricted } from "@app/hooks/use-dollar-balance-restricted"
 import { logSelfCustodialStableBalanceActivated } from "@app/self-custodial/analytics"
-import {
-  activateStableBalance,
-  deactivateStableBalance,
-} from "@app/self-custodial/bridge"
+import { activateStableBalance } from "@app/self-custodial/bridge"
 import { SparkToken } from "@app/self-custodial/config"
+import { deactivateStableBalanceAndRefresh } from "@app/self-custodial/stable-balance"
 import type { TranslationFunctions } from "@app/i18n/i18n-types"
 import { reportError } from "@app/utils/error-logging"
 import { toastShow } from "@app/utils/toast"
@@ -66,11 +64,17 @@ export const useStableBalanceToggle = ({
         if (activate) {
           await activateStableBalance(sdk, SparkToken.Label)
           logSelfCustodialStableBalanceActivated({ label: SparkToken.Label })
+          await refreshStableBalanceActive()
+          await refreshWallets()
         } else {
-          await deactivateStableBalance(sdk)
+          const deactivated = await deactivateStableBalanceAndRefresh({
+            sdk,
+            refreshWallets,
+            refreshStableBalanceActive,
+            LL,
+          })
+          if (!deactivated) resyncSwitch()
         }
-        await refreshStableBalanceActive()
-        await refreshWallets()
       } catch (err) {
         reportError("Stable Balance toggle", err)
         toastShow({

--- a/app/screens/stable-balance-settings-screen/hooks/use-stable-balance-toggle.ts
+++ b/app/screens/stable-balance-settings-screen/hooks/use-stable-balance-toggle.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react"
 
 import type { BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
 
+import { useDollarBalanceRestricted } from "@app/hooks/use-dollar-balance-restricted"
 import { logSelfCustodialStableBalanceActivated } from "@app/self-custodial/analytics"
 import {
   activateStableBalance,
@@ -35,6 +36,7 @@ export const useStableBalanceToggle = ({
   refreshStableBalanceActive,
   LL,
 }: Params): StableBalanceToggleControls => {
+  const isDollarBalanceRestricted = useDollarBalanceRestricted()
   const [busy, setBusy] = useState(false)
   const [pendingValue, setPendingValue] = useState<boolean | null>(null)
   const [switchKey, setSwitchKey] = useState(0)
@@ -44,6 +46,20 @@ export const useStableBalanceToggle = ({
   const apply = useCallback(
     async (activate: boolean) => {
       if (!sdk || busy) return
+
+      /** Activation is region-gated or a restricted user could loop fee-paying
+       *  conversions: activate, auto-convert to the token, get force-converted back.
+       *  Deactivation stays allowed so an already-active balance can be freed. */
+      const isActivationBlocked = activate && isDollarBalanceRestricted
+      if (isActivationBlocked) {
+        toastShow({
+          message: (tr) => tr.DollarBalanceRestriction.modalTitle(),
+          LL,
+          type: "error",
+        })
+        resyncSwitch()
+        return
+      }
       setBusy(true)
       setPendingValue(activate)
       try {
@@ -68,7 +84,15 @@ export const useStableBalanceToggle = ({
         setPendingValue(null)
       }
     },
-    [sdk, busy, refreshStableBalanceActive, refreshWallets, LL, resyncSwitch],
+    [
+      sdk,
+      busy,
+      isDollarBalanceRestricted,
+      refreshStableBalanceActive,
+      refreshWallets,
+      LL,
+      resyncSwitch,
+    ],
   )
 
   return {

--- a/app/self-custodial/stable-balance.ts
+++ b/app/self-custodial/stable-balance.ts
@@ -1,0 +1,46 @@
+import type { BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
+import type { TranslationFunctions } from "@app/i18n/i18n-types"
+import { reportError } from "@app/utils/error-logging"
+import { toastShow } from "@app/utils/toast"
+
+import { deactivateStableBalance } from "./bridge"
+
+type DeactivateStableBalanceAndRefreshParams = {
+  sdk: BreezSdkInterface
+  refreshWallets: () => Promise<void>
+  refreshStableBalanceActive: () => Promise<void>
+  LL: TranslationFunctions
+}
+
+/**
+ * Single "switch Stable Balance off and refresh" routine shared by the settings
+ * toggle and the forced-conversion modal. A failed deactivation is reported and
+ * toasted, but the refresh still runs: the caller may have just moved funds, so
+ * the balances changed regardless. A failed refresh is only reported, because
+ * the state refetches later anyway. Returns whether the deactivation succeeded
+ * so callers can resync their UI.
+ */
+export const deactivateStableBalanceAndRefresh = async ({
+  sdk,
+  refreshWallets,
+  refreshStableBalanceActive,
+  LL,
+}: DeactivateStableBalanceAndRefreshParams): Promise<boolean> => {
+  const deactivated = await deactivateStableBalance(sdk).then(
+    () => true,
+    (err) => {
+      reportError("Stable Balance deactivate", err)
+      toastShow({
+        message: (tr) => tr.StableBalance.toggleFailedToast(),
+        LL,
+        type: "error",
+      })
+      return false
+    },
+  )
+  await Promise.all([refreshStableBalanceActive(), refreshWallets()]).catch((err) =>
+    reportError("Stable Balance refresh", err),
+  )
+  return deactivated
+}

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -88,3 +88,21 @@ export const resolveIpCountryCode = async (
   }
   return undefined
 }
+
+/**
+ * One shared lookup per app session: the device's country rarely changes
+ * mid-session and several screens mount hooks that need it, so the external
+ * services are hit once instead of once per mount. A failed lookup is not
+ * cached, so a later mount can retry (e.g. the app started offline).
+ */
+let sharedLookup: Promise<CountryCode | undefined> | null = null
+
+export const resolveIpCountryCodeCached = (): Promise<CountryCode | undefined> => {
+  if (!sharedLookup) {
+    sharedLookup = resolveIpCountryCode().then((countryCode) => {
+      if (!countryCode) sharedLookup = null
+      return countryCode
+    })
+  }
+  return sharedLookup
+}


### PR DESCRIPTION
## Summary
When the Dollar Balance feature is region-blocked and a self-custodial user still holds a stable-token balance, the home screen now auto-opens the same forced-conversion modal custodial users already get, so the blocked funds can be moved instead of silently hidden.

## How it works
- The modal converts the **full** USDB balance through the same quote/execute pipeline as the regular conversion flow, and after a successful conversion deactivates Stable Balance so future receives stay in bitcoin instead of re-trapping.
- The custodial modal was split into a shared presentational component + its unchanged container; the custodial behavior is untouched (its spec passes as-is) and the existing conversion flow is untouched.
- The trigger hook was renamed `useStablesatsForcedConversion` → `useDollarBalanceForcedConversion` since it now drives both account types.

Closes blinkbitcoin/blink-wip#956. Per the ticket, HK/VN/KR can be added to `selfCustodialDollarBalanceBlockedCountries` only after this ships.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/9424e327-1c02-4031-808d-02624c8427c5" />

