### PR TITLE
fix(location): resolve the ipinfo country lookup via the /me endpoint


### DIFF
--- a/__tests__/utils/ip-country-lookup.spec.ts
+++ b/__tests__/utils/ip-country-lookup.spec.ts
@@ -132,7 +132,7 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
     )
   })
 
-  it("uses api.ipinfo.io/lite with Bearer header when IPINFO_API_KEY is set", async () => {
+  it("calls the api.ipinfo.io/lite/me endpoint with the Bearer header when IPINFO_API_KEY is set", async () => {
     mutableConfig.IPINFO_API_KEY = "test-ipinfo-key"
     // eslint-disable-next-line camelcase
     mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
@@ -141,10 +141,23 @@ describe("DEFAULT_ADAPTERS key-gated behaviour", () => {
 
     expect(result).toBe("DE")
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      expect.stringContaining("api.ipinfo.io/lite"),
+      "https://api.ipinfo.io/lite/me",
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: "Bearer test-ipinfo-key" }),
       }),
+    )
+  })
+
+  it("never calls the /lite/ endpoint without the /me segment, which 404s and defaults the country", async () => {
+    mutableConfig.IPINFO_API_KEY = "test-ipinfo-key"
+    // eslint-disable-next-line camelcase
+    mockedAxios.get.mockResolvedValue({ data: { country_code: "DE" } })
+
+    await resolveIpCountryCode(DEFAULT_ADAPTERS)
+
+    expect(mockedAxios.get).not.toHaveBeenCalledWith(
+      "https://api.ipinfo.io/lite/",
+      expect.anything(),
     )
   })
 

--- a/app/utils/ip-country-lookup.ts
+++ b/app/utils/ip-country-lookup.ts
@@ -9,11 +9,13 @@ const DEFAULT_TIMEOUT_MS = 5000
 export type IpLookupAdapter = (timeout: number) => Promise<CountryCode | undefined>
 
 // ipinfoAdapter runs first: free tier available without a key (IPINFO_API_KEY raises rate limits)
-// Authenticated: api.ipinfo.io/lite + Bearer header → field "country_code"
-// Free tier:     ipinfo.io/json (no auth)            → field "country"
+// Authenticated: api.ipinfo.io/lite/me + Bearer header → field "country_code"
+// Free tier:     ipinfo.io/json (no auth)               → field "country"
+// The /me segment is required: api.ipinfo.io/lite/ (no IP) is not a real endpoint and
+// returns a 404, which would drop this adapter and let the country default to a fallback.
 const ipinfoAdapter: IpLookupAdapter = async (timeout) => {
   if (Config.IPINFO_API_KEY) {
-    const { data } = await axios.get("https://api.ipinfo.io/lite/", {
+    const { data } = await axios.get("https://api.ipinfo.io/lite/me", {
       headers: { Authorization: `Bearer ${Config.IPINFO_API_KEY}` },
       timeout,
     })


### PR DESCRIPTION
## Summary

Country detection was resolving to El Salvador for effectively every user, which wrongly disabled the non-custodial Dollar Balance (it treats `SV` as a restricted region). The cause is a broken IP geolocation call, fixed here with a one-line endpoint change.

## Root cause

The authenticated ipinfo adapter requested `https://api.ipinfo.io/lite/` (no IP, no `/me`), which is not a real endpoint:

```
{ "error": "Endpoint not found. Did you mean /lite/me or /lite/8.8.8.8?" }
```

In production builds (where `IPINFO_API_KEY` is set) this adapter always failed, so detection fell through to the free fallback services and, when those were rate-limited/unavailable at scale, to `DEFAULT_COUNTRY_CODE = "SV"` in `use-device-location`. Result: El Salvador for everyone, regardless of their real location.

## Fix

`app/utils/ip-country-lookup.ts`: `api.ipinfo.io/lite/` → `api.ipinfo.io/lite/me` (the caller's-own-IP endpoint). The primary adapter now returns the real country directly, so detection no longer depends on the fragile fallback chain.

## Verification

- `curl` against the old URL returns the 404 error above; `/lite/me` returns the correct `country_code`.
- On device with a VPN in France: with the broken URL, detection fell back to El Salvador; with `/lite/me`, it correctly showed France.
- Unit tests assert the adapter hits `https://api.ipinfo.io/lite/me` exactly and never `/lite/` without the `/me` segment.
