### PR TITLE
fix(auth): re-apply the app lock when resuming past the grace period

### DIFF
--- a/__tests__/navigation/app-state.spec.tsx
+++ b/__tests__/navigation/app-state.spec.tsx
@@ -165,6 +165,21 @@ describe("AppStateWrapper", () => {
       expect(mockSetAppLocked).not.toHaveBeenCalled()
     })
 
+    it("locks when the clock was wound back to fake a short trip", async () => {
+      /** The trip is measured against the wall clock for want of a monotonic one, so winding
+       *  the clock back would otherwise report a negative stay and slip under the grace
+       *  period. A clock that moved backwards is not trusted, and locks. */
+      renderWrapper()
+      await flushEffects()
+
+      await emitAppState("background")
+      jest.setSystemTime(START_TIME_MS - 60 * 60 * 1000)
+      await emitAppState("active")
+
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+      expect(mockNavigate).toHaveBeenCalledWith("authenticationCheck", { isResume: true })
+    })
+
     it("locks across the ios sequence, which reaches the background through inactive", async () => {
       renderWrapper()
       await flushEffects()

--- a/__tests__/navigation/app-state.spec.tsx
+++ b/__tests__/navigation/app-state.spec.tsx
@@ -1,0 +1,255 @@
+import React from "react"
+import { AppState, AppStateStatus } from "react-native"
+import { render } from "@testing-library/react-native"
+
+import { AppStateWrapper } from "@app/navigation/app-state"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+
+import { flushEffects } from "../helpers/flush-effects"
+
+const mockNavigate = jest.fn()
+const mockSetAppLocked = jest.fn()
+const mockRefetchQueries = jest.fn()
+
+let mockGracePeriodSeconds = 60
+let mockIsAuthed = true
+let mockIsAppLocked = false
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
+jest.mock("@app/navigation/navigation-container-wrapper", () => ({
+  useAuthenticationContext: () => ({
+    isAppLocked: mockIsAppLocked,
+    setAppLocked: mockSetAppLocked,
+  }),
+}))
+
+jest.mock("@app/config/feature-flags-context", () => ({
+  useRemoteConfig: () => ({ appLockGracePeriodSeconds: mockGracePeriodSeconds }),
+}))
+
+jest.mock("@app/graphql/is-authed-context", () => ({
+  useIsAuthed: () => mockIsAuthed,
+}))
+
+jest.mock("@apollo/client", () => ({
+  ...jest.requireActual("@apollo/client"),
+  useApolloClient: () => ({ refetchQueries: mockRefetchQueries }),
+}))
+
+jest.mock("@app/utils/analytics", () => ({
+  logEnterForeground: jest.fn(),
+  logEnterBackground: jest.fn(),
+}))
+
+jest.mock("@app/utils/storage/secureStorage", () => ({
+  __esModule: true,
+  default: {
+    getIsPinEnabled: jest.fn(),
+    getIsBiometricsEnabled: jest.fn(),
+  },
+}))
+
+const mockedKeyStore = jest.mocked(KeyStoreWrapper)
+
+/** Drives the real AppState listener the wrapper subscribes with. */
+let emitAppState: (state: AppStateStatus) => Promise<void>
+
+const START_TIME_MS = 1_790_000_000_000
+const GRACE_PERIOD_SECONDS = 60
+
+const renderWrapper = () => render(<AppStateWrapper />)
+
+const setLock = ({ pin, biometrics }: { pin: boolean; biometrics: boolean }) => {
+  mockedKeyStore.getIsPinEnabled.mockResolvedValue(pin)
+  mockedKeyStore.getIsBiometricsEnabled.mockResolvedValue(biometrics)
+}
+
+/** Sends the app away and brings it back after `secondsAway` of wall clock. */
+const leaveAndReturn = async (secondsAway: number) => {
+  await emitAppState("background")
+  jest.setSystemTime(START_TIME_MS + secondsAway * 1000)
+  await emitAppState("active")
+}
+
+describe("AppStateWrapper", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+    jest.setSystemTime(START_TIME_MS)
+
+    mockGracePeriodSeconds = GRACE_PERIOD_SECONDS
+    mockIsAuthed = true
+    mockIsAppLocked = false
+    setLock({ pin: true, biometrics: false })
+
+    /** Every foreground the suite drives logs, which would bury the run in noise. */
+    jest.spyOn(console, "info").mockImplementation(() => {})
+
+    /** The jest environment leaves this undefined; the wrapper seeds its ref from it. */
+    Object.defineProperty(AppState, "currentState", {
+      configurable: true,
+      value: "active",
+    })
+
+    let listener: (state: AppStateStatus) => void = () => {}
+    jest.spyOn(AppState, "addEventListener").mockImplementation((type, handler) => {
+      if (type === "change") listener = handler as (state: AppStateStatus) => void
+      return { remove: jest.fn() } as ReturnType<typeof AppState.addEventListener>
+    })
+    emitAppState = async (state) => {
+      listener(state)
+      await flushEffects()
+    }
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+    jest.restoreAllMocks()
+  })
+
+  describe("re-locking on resume", () => {
+    it("locks when the app returns after the grace period", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS + 1)
+
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+      expect(mockNavigate).toHaveBeenCalledWith("authenticationCheck", {
+        isResume: true,
+      })
+    })
+
+    it("stays unlocked when the app returns within the grace period", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS - 1)
+
+      expect(mockSetAppLocked).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("locks on biometrics alone, without a PIN", async () => {
+      setLock({ pin: false, biometrics: true })
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS + 1)
+
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+    })
+
+    it("leaves an unprotected account alone, however long it was away", async () => {
+      setLock({ pin: false, biometrics: false })
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS * 100)
+
+      expect(mockSetAppLocked).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("honors a grace period served by the remote config", async () => {
+      mockGracePeriodSeconds = 300
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(120)
+
+      expect(mockSetAppLocked).not.toHaveBeenCalled()
+    })
+
+    it("locks across the ios sequence, which reaches the background through inactive", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await emitAppState("inactive")
+      await emitAppState("background")
+      jest.setSystemTime(START_TIME_MS + (GRACE_PERIOD_SECONDS + 1) * 1000)
+      await emitAppState("active")
+
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("transitions that must not lock", () => {
+    it("ignores a return the app never left for, such as a dismissed call", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await emitAppState("inactive")
+      await emitAppState("active")
+
+      expect(mockSetAppLocked).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("ignores a foreground the app was launched into, having measured no trip away", async () => {
+      /** A process woken straight into the background, by a push notification say, reaches
+       *  the foreground without this instance ever having seen it leave. */
+      Object.defineProperty(AppState, "currentState", {
+        configurable: true,
+        value: "background",
+      })
+      renderWrapper()
+      await flushEffects()
+
+      await emitAppState("active")
+
+      expect(mockSetAppLocked).not.toHaveBeenCalled()
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("leaves a cold start still at its unlock screen alone", async () => {
+      /** The lock is already up and the user has yet to answer it. Raising it again would
+       *  stack a second unlock screen over the first, costing the user two PIN entries. */
+      mockIsAppLocked = true
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS + 1)
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it("does not lock twice for a single trip to the background", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(GRACE_PERIOD_SECONDS + 1)
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+
+      /** A second foreground with no trip away in between: the timestamp is spent. */
+      await emitAppState("active")
+
+      expect(mockSetAppLocked).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("existing foreground behavior", () => {
+    it("refetches the home query when the app returns", async () => {
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(1)
+
+      expect(mockRefetchQueries).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not refetch for a signed-out user", async () => {
+      mockIsAuthed = false
+      renderWrapper()
+      await flushEffects()
+
+      await leaveAndReturn(1)
+
+      expect(mockRefetchQueries).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/screens/authentication-screen/authentication-check-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/authentication-check-screen.spec.tsx
@@ -1,0 +1,149 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import { AuthenticationCheckScreen } from "@app/screens/authentication-screen/authentication-check-screen"
+import { updateDeviceSessionCount } from "@app/graphql/client-only-query"
+import BiometricWrapper from "@app/utils/biometricAuthentication"
+import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+
+import { ContextForScreen } from "../helper"
+import { flushEffects } from "../../helpers/flush-effects"
+
+const mockReplace = jest.fn()
+const mockGoBack = jest.fn()
+const mockSetAppUnlocked = jest.fn()
+
+let mockRouteParams: { isResume?: boolean } | undefined
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ replace: mockReplace, goBack: mockGoBack }),
+  useRoute: () => ({ params: mockRouteParams }),
+}))
+
+jest.mock("@app/navigation/navigation-container-wrapper", () => ({
+  useAuthenticationContext: () => ({ setAppUnlocked: mockSetAppUnlocked }),
+}))
+
+jest.mock("@app/graphql/client-only-query", () => ({
+  updateDeviceSessionCount: jest.fn(),
+}))
+
+jest.mock("@app/utils/biometricAuthentication", () => ({
+  __esModule: true,
+  default: { isSensorAvailable: jest.fn() },
+}))
+
+jest.mock("@app/utils/storage/secureStorage", () => ({
+  __esModule: true,
+  default: {
+    getIsPinEnabled: jest.fn(),
+    getIsBiometricsEnabled: jest.fn(),
+    /** Read by the account registry the screen renders under. */
+    getSessionProfiles: jest.fn().mockResolvedValue([]),
+  },
+}))
+
+const mockedKeyStore = jest.mocked(KeyStoreWrapper)
+const mockedBiometrics = jest.mocked(BiometricWrapper)
+
+const renderScreen = () =>
+  render(
+    <ContextForScreen>
+      <AuthenticationCheckScreen />
+    </ContextForScreen>,
+  )
+
+const setLock = ({
+  pin,
+  biometrics,
+  sensor = true,
+}: {
+  pin: boolean
+  biometrics: boolean
+  sensor?: boolean
+}) => {
+  mockedKeyStore.getIsPinEnabled.mockResolvedValue(pin)
+  mockedKeyStore.getIsBiometricsEnabled.mockResolvedValue(biometrics)
+  mockedBiometrics.isSensorAvailable.mockResolvedValue(sensor)
+}
+
+describe("AuthenticationCheckScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRouteParams = undefined
+    setLock({ pin: true, biometrics: false })
+  })
+
+  describe("carrying the resume flag to the unlock screen", () => {
+    it("marks the biometric screen as a resume", async () => {
+      setLock({ pin: true, biometrics: true })
+      mockRouteParams = { isResume: true }
+      renderScreen()
+      await flushEffects()
+
+      expect(mockReplace).toHaveBeenCalledWith("authentication", {
+        screenPurpose: AuthenticationScreenPurpose.Authenticate,
+        isPinEnabled: true,
+        isResume: true,
+      })
+    })
+
+    it("marks the pin screen as a resume", async () => {
+      mockRouteParams = { isResume: true }
+      renderScreen()
+      await flushEffects()
+
+      expect(mockReplace).toHaveBeenCalledWith("pin", {
+        screenPurpose: PinScreenPurpose.AuthenticatePin,
+        isResume: true,
+      })
+    })
+
+    it("leaves a cold start unmarked", async () => {
+      renderScreen()
+      await flushEffects()
+
+      expect(mockReplace).toHaveBeenCalledWith("pin", {
+        screenPurpose: PinScreenPurpose.AuthenticatePin,
+        isResume: false,
+      })
+    })
+  })
+
+  describe("with no lock configured", () => {
+    it("opens the home screen and counts the session on a cold start", async () => {
+      setLock({ pin: false, biometrics: false })
+      renderScreen()
+      await flushEffects()
+
+      expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+      expect(updateDeviceSessionCount).toHaveBeenCalledTimes(1)
+      expect(mockReplace).toHaveBeenCalledWith("Primary")
+    })
+
+    it("steps back on a resume whose lock was turned off, opening no session", async () => {
+      setLock({ pin: false, biometrics: false })
+      mockRouteParams = { isResume: true }
+      renderScreen()
+      await flushEffects()
+
+      expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+      expect(mockGoBack).toHaveBeenCalledTimes(1)
+      expect(updateDeviceSessionCount).not.toHaveBeenCalled()
+      expect(mockReplace).not.toHaveBeenCalled()
+    })
+  })
+
+  it("keeps the pin screen when the sensor is unavailable, even with biometrics on", async () => {
+    setLock({ pin: true, biometrics: true, sensor: false })
+    renderScreen()
+    await flushEffects()
+
+    expect(mockReplace).toHaveBeenCalledWith("pin", {
+      screenPurpose: PinScreenPurpose.AuthenticatePin,
+      isResume: false,
+    })
+  })
+})

--- a/__tests__/screens/authentication-screen/authentication-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/authentication-screen.spec.tsx
@@ -1,22 +1,32 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
+import { fireEvent, render, screen } from "@testing-library/react-native"
 
 import { AuthenticationScreen } from "@app/screens/authentication-screen/authentication-screen"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import BiometricWrapper from "@app/utils/biometricAuthentication"
-import { AuthenticationScreenPurpose } from "@app/utils/enum"
+import { AuthenticationScreenPurpose, PinScreenPurpose } from "@app/utils/enum"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { RouteProp } from "@react-navigation/native"
 
 import { ContextForScreen } from "../helper"
 import { flushEffects } from "../../helpers/flush-effects"
 
+/** The app loads the catalogue at boot; without it every label renders empty and the
+ *  buttons become indistinguishable. */
+loadLocale("en")
+
 const mockReplace = jest.fn()
 const mockGoBack = jest.fn()
+const mockNavigate = jest.fn()
 const mockSetAppUnlocked = jest.fn()
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useNavigation: () => ({ replace: mockReplace, goBack: mockGoBack }),
+  useNavigation: () => ({
+    replace: mockReplace,
+    goBack: mockGoBack,
+    navigate: mockNavigate,
+  }),
 }))
 
 jest.mock("@app/navigation/navigation-container-wrapper", () => ({
@@ -108,5 +118,36 @@ describe("AuthenticationScreen", () => {
     expect(mockSetAppUnlocked).not.toHaveBeenCalled()
     expect(mockGoBack).not.toHaveBeenCalled()
     expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  describe("falling back to the pin", () => {
+    beforeEach(() => {
+      /** The prompt has to go unanswered, or the screen unlocks before the fallback. */
+      mockedBiometrics.authenticate.mockImplementation(async () => {})
+    })
+
+    it("carries the resume flag along, so the pin steps back too", async () => {
+      renderScreen(true)
+      await flushEffects()
+
+      fireEvent.press(screen.getByLabelText("Use PIN"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("pin", {
+        screenPurpose: PinScreenPurpose.AuthenticatePin,
+        isResume: true,
+      })
+    })
+
+    it("leaves a cold start unmarked", async () => {
+      renderScreen(false)
+      await flushEffects()
+
+      fireEvent.press(screen.getByLabelText("Use PIN"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("pin", {
+        screenPurpose: PinScreenPurpose.AuthenticatePin,
+        isResume: false,
+      })
+    })
   })
 })

--- a/__tests__/screens/authentication-screen/authentication-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/authentication-screen.spec.tsx
@@ -1,0 +1,112 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import { AuthenticationScreen } from "@app/screens/authentication-screen/authentication-screen"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import BiometricWrapper from "@app/utils/biometricAuthentication"
+import { AuthenticationScreenPurpose } from "@app/utils/enum"
+import { RouteProp } from "@react-navigation/native"
+
+import { ContextForScreen } from "../helper"
+import { flushEffects } from "../../helpers/flush-effects"
+
+const mockReplace = jest.fn()
+const mockGoBack = jest.fn()
+const mockSetAppUnlocked = jest.fn()
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ replace: mockReplace, goBack: mockGoBack }),
+}))
+
+jest.mock("@app/navigation/navigation-container-wrapper", () => ({
+  useAuthenticationContext: () => ({ setAppUnlocked: mockSetAppUnlocked }),
+}))
+
+jest.mock("@app/hooks/use-logout", () => ({
+  __esModule: true,
+  default: () => ({ logout: jest.fn() }),
+}))
+
+jest.mock("@app/utils/biometricAuthentication", () => ({
+  __esModule: true,
+  default: { authenticate: jest.fn() },
+}))
+
+jest.mock("@app/utils/storage/secureStorage", () => ({
+  __esModule: true,
+  default: {
+    resetPinAttempts: jest.fn(),
+    setIsBiometricsEnabled: jest.fn(),
+    /** Read by the account registry the screen renders under. */
+    getSessionProfiles: jest.fn().mockResolvedValue([]),
+  },
+}))
+
+const mockedBiometrics = jest.mocked(BiometricWrapper)
+
+const buildRoute = (
+  isResume?: boolean,
+): RouteProp<RootStackParamList, "authentication"> =>
+  ({
+    key: "authentication",
+    name: "authentication",
+    params: {
+      screenPurpose: AuthenticationScreenPurpose.Authenticate,
+      isPinEnabled: true,
+      isResume,
+    },
+  }) as RouteProp<RootStackParamList, "authentication">
+
+const renderScreen = (isResume?: boolean) =>
+  render(
+    <ContextForScreen>
+      <AuthenticationScreen route={buildRoute(isResume)} />
+    </ContextForScreen>,
+  )
+
+describe("AuthenticationScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    /** The OS prompt is stubbed as an immediate success so the unlock path runs. */
+    mockedBiometrics.authenticate.mockImplementation(async (_description, onSuccess) => {
+      onSuccess()
+    })
+  })
+
+  it("steps back into the screen the user left when the lock came from a resume", async () => {
+    renderScreen(true)
+    await flushEffects()
+
+    expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+
+  it("opens the home screen on a cold start", async () => {
+    renderScreen(false)
+    await flushEffects()
+
+    expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+    expect(mockReplace).toHaveBeenCalledWith("Primary")
+    expect(mockGoBack).not.toHaveBeenCalled()
+  })
+
+  it("treats a missing resume flag as a cold start", async () => {
+    renderScreen(undefined)
+    await flushEffects()
+
+    expect(mockReplace).toHaveBeenCalledWith("Primary")
+    expect(mockGoBack).not.toHaveBeenCalled()
+  })
+
+  it("leaves the user on the lock when the prompt is not passed", async () => {
+    mockedBiometrics.authenticate.mockImplementation(async () => {})
+    renderScreen(true)
+    await flushEffects()
+
+    expect(mockSetAppUnlocked).not.toHaveBeenCalled()
+    expect(mockGoBack).not.toHaveBeenCalled()
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/screens/authentication-screen/pin-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/pin-screen.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { BackHandler } from "react-native"
 import { fireEvent, render, screen } from "@testing-library/react-native"
 
 import { PinScreen } from "@app/screens/authentication-screen/pin-screen"
@@ -42,19 +43,33 @@ jest.mock("@app/utils/storage/secureStorage", () => ({
 const CORRECT_PIN = "1234"
 const WRONG_PIN = "9999"
 
-const buildRoute = (isResume?: boolean): RouteProp<RootStackParamList, "pin"> =>
+const buildRoute = (
+  isResume?: boolean,
+  screenPurpose: PinScreenPurpose = PinScreenPurpose.AuthenticatePin,
+): RouteProp<RootStackParamList, "pin"> =>
   ({
     key: "pin",
     name: "pin",
-    params: { screenPurpose: PinScreenPurpose.AuthenticatePin, isResume },
+    params: { screenPurpose, isResume },
   }) as RouteProp<RootStackParamList, "pin">
 
-const renderScreen = (isResume?: boolean) =>
+const renderScreen = (isResume?: boolean, screenPurpose?: PinScreenPurpose) =>
   render(
     <ContextForScreen>
-      <PinScreen route={buildRoute(isResume)} />
+      <PinScreen route={buildRoute(isResume, screenPurpose)} />
     </ContextForScreen>,
   )
+
+let backHandlerSpy: jest.SpyInstance
+
+/** Runs whatever the screen registered for the hardware back press, and reports whether it
+ *  swallowed it. Nothing registered means the press falls through to the navigator. */
+const pressBack = () => {
+  const registration = backHandlerSpy.mock.calls.find(
+    ([eventName]) => eventName === "hardwareBackPress",
+  )
+  return registration?.[1]() ?? false
+}
 
 const enterPin = async (pin: string) => {
   for (const digit of pin.split("")) {
@@ -66,6 +81,38 @@ const enterPin = async (pin: string) => {
 describe("PinScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    backHandlerSpy = jest.spyOn(BackHandler, "addEventListener")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("refusing dismissal while the lock is up", () => {
+    it("swallows the back press when the lock was pushed by a resume", async () => {
+      /** The resume lock sits on top of the screen the user was on, so a back press would
+       *  otherwise pop it and reveal the app without a challenge. */
+      renderScreen(true)
+      await flushEffects()
+
+      expect(pressBack()).toBe(true)
+    })
+
+    it("leaves the back press alone on a cold start, which has nothing behind it", async () => {
+      renderScreen(false)
+      await flushEffects()
+
+      expect(pressBack()).toBe(false)
+    })
+
+    it("leaves the back press alone while a pin is being created from settings", async () => {
+      /** Same screen, no lock: swallowing the press here would strand the user, since the
+       *  screen carries no header to go back with. */
+      renderScreen(undefined, PinScreenPurpose.SetPin)
+      await flushEffects()
+
+      expect(pressBack()).toBe(false)
+    })
   })
 
   it("steps back into the screen the user left when the lock came from a resume", async () => {

--- a/__tests__/screens/authentication-screen/pin-screen.spec.tsx
+++ b/__tests__/screens/authentication-screen/pin-screen.spec.tsx
@@ -1,0 +1,119 @@
+import React from "react"
+import { fireEvent, render, screen } from "@testing-library/react-native"
+
+import { PinScreen } from "@app/screens/authentication-screen/pin-screen"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { PinScreenPurpose } from "@app/utils/enum"
+import { RouteProp } from "@react-navigation/native"
+
+import { ContextForScreen } from "../helper"
+import { flushEffects } from "../../helpers/flush-effects"
+
+const mockReset = jest.fn()
+const mockGoBack = jest.fn()
+const mockSetAppUnlocked = jest.fn()
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ reset: mockReset, goBack: mockGoBack }),
+}))
+
+jest.mock("@app/navigation/navigation-container-wrapper", () => ({
+  useAuthenticationContext: () => ({ setAppUnlocked: mockSetAppUnlocked }),
+}))
+
+jest.mock("@app/hooks/use-logout", () => ({
+  __esModule: true,
+  default: () => ({ logout: jest.fn() }),
+}))
+
+jest.mock("@app/utils/storage/secureStorage", () => ({
+  __esModule: true,
+  default: {
+    getPinOrEmptyString: jest.fn().mockResolvedValue("1234"),
+    getPinAttemptsOrZero: jest.fn().mockResolvedValue(0),
+    resetPinAttempts: jest.fn(),
+    setPinAttempts: jest.fn(),
+    /** Read by the account registry the screen renders under. */
+    getSessionProfiles: jest.fn().mockResolvedValue([]),
+  },
+}))
+
+const CORRECT_PIN = "1234"
+const WRONG_PIN = "9999"
+
+const buildRoute = (isResume?: boolean): RouteProp<RootStackParamList, "pin"> =>
+  ({
+    key: "pin",
+    name: "pin",
+    params: { screenPurpose: PinScreenPurpose.AuthenticatePin, isResume },
+  }) as RouteProp<RootStackParamList, "pin">
+
+const renderScreen = (isResume?: boolean) =>
+  render(
+    <ContextForScreen>
+      <PinScreen route={buildRoute(isResume)} />
+    </ContextForScreen>,
+  )
+
+const enterPin = async (pin: string) => {
+  for (const digit of pin.split("")) {
+    fireEvent.press(screen.getByText(digit))
+  }
+  await flushEffects()
+}
+
+describe("PinScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("steps back into the screen the user left when the lock came from a resume", async () => {
+    renderScreen(true)
+    await flushEffects()
+
+    await enterPin(CORRECT_PIN)
+
+    expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+    expect(mockGoBack).toHaveBeenCalledTimes(1)
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+
+  it("opens the home screen on a cold start", async () => {
+    renderScreen(false)
+    await flushEffects()
+
+    await enterPin(CORRECT_PIN)
+
+    expect(mockSetAppUnlocked).toHaveBeenCalledTimes(1)
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: "Primary" }],
+    })
+    expect(mockGoBack).not.toHaveBeenCalled()
+  })
+
+  it("treats a missing resume flag as a cold start", async () => {
+    renderScreen(undefined)
+    await flushEffects()
+
+    await enterPin(CORRECT_PIN)
+
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: "Primary" }],
+    })
+    expect(mockGoBack).not.toHaveBeenCalled()
+  })
+
+  it("keeps a wrong pin on the lock, resuming nothing", async () => {
+    renderScreen(true)
+    await flushEffects()
+
+    await enterPin(WRONG_PIN)
+
+    expect(mockSetAppUnlocked).not.toHaveBeenCalled()
+    expect(mockGoBack).not.toHaveBeenCalled()
+    expect(mockReset).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/screens/authentication-screen/unlock-screen.spec.ts
+++ b/__tests__/screens/authentication-screen/unlock-screen.spec.ts
@@ -1,0 +1,43 @@
+import { unlockScreenOptions } from "@app/screens/authentication-screen/unlock-screen"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { RouteProp } from "@react-navigation/native"
+
+/** The module also exports the hook, whose context pulls in native boot code this pure
+ *  options function never touches; stubbing it keeps the import graph off the device APIs. */
+jest.mock("@app/navigation/navigation-container-wrapper", () => ({
+  useAuthenticationContext: jest.fn(),
+}))
+
+type UnlockRoute = RouteProp<
+  RootStackParamList,
+  "authenticationCheck" | "authentication" | "pin"
+>
+
+const buildRoute = (params: UnlockRoute["params"]): UnlockRoute =>
+  ({ key: "authenticationCheck", name: "authenticationCheck", params }) as UnlockRoute
+
+describe("unlockScreenOptions", () => {
+  it("blocks the iOS swipe when the lock was pushed by a resume", () => {
+    /** The one guard the automated suite can pin for iOS: the hardware back press the hook
+     *  intercepts never fires there, so this gesture is the only thing standing between an
+     *  edge swipe and the app behind the resume lock. */
+    expect(unlockScreenOptions({ route: buildRoute({ isResume: true }) })).toEqual({
+      headerShown: false,
+      gestureEnabled: false,
+    })
+  })
+
+  it("leaves the swipe enabled on a cold start, the only way out of the settings flows", () => {
+    expect(unlockScreenOptions({ route: buildRoute({ isResume: false }) })).toEqual({
+      headerShown: false,
+      gestureEnabled: true,
+    })
+  })
+
+  it("treats a screen opened without params as a cold start", () => {
+    expect(unlockScreenOptions({ route: buildRoute(undefined) })).toEqual({
+      headerShown: false,
+      gestureEnabled: true,
+    })
+  })
+})

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -19,6 +19,7 @@ const UpgradeModalCooldownDaysKey = "upgradeModalCooldownDays"
 const UpgradeModalShowAtSessionNumberKey = "upgradeModalShowAtSessionNumber"
 const FeeReimbursementMemoKey = "feeReimbursementMemo"
 const SuccessIconDurationKey = "successIconDuration"
+const AppLockGracePeriodSecondsKey = "appLockGracePeriodSeconds"
 const CardTermsAndConditionsUrlKey = "cardTermsAndConditionsUrl"
 const CardPrivacyPolicyUrlKey = "cardPrivacyPolicyUrl"
 const CardCardholderAgreementUrlKey = "cardCardholderAgreementUrl"
@@ -68,6 +69,7 @@ type RemoteConfig = {
   [UpgradeModalShowAtSessionNumberKey]: number
   [FeeReimbursementMemoKey]: string
   [SuccessIconDurationKey]: number
+  [AppLockGracePeriodSecondsKey]: number
   [CardTermsAndConditionsUrlKey]: string
   [CardPrivacyPolicyUrlKey]: string
   [CardCardholderAgreementUrlKey]: string
@@ -139,6 +141,7 @@ export const defaultRemoteConfig: RemoteConfig = {
   upgradeModalShowAtSessionNumber: 1,
   feeReimbursementMemo: "fee reimbursement",
   successIconDuration: 2300,
+  appLockGracePeriodSeconds: 60,
   cardTermsAndConditionsUrl: "https://www.blink.sv/en/terms-conditions",
   cardPrivacyPolicyUrl: "https://www.blink.sv/en/privacy-policy",
   cardCardholderAgreementUrl: "https://www.blink.sv",
@@ -251,6 +254,10 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           .asString()
         const successIconDuration = remoteConfigInstance()
           .getValue(SuccessIconDurationKey)
+          .asNumber()
+
+        const appLockGracePeriodSeconds = remoteConfigInstance()
+          .getValue(AppLockGracePeriodSecondsKey)
           .asNumber()
 
         const cardTermsAndConditionsUrl = remoteConfigInstance()
@@ -370,6 +377,7 @@ export const FeatureFlagContextProvider: React.FC<React.PropsWithChildren> = ({
           upgradeModalShowAtSessionNumber,
           feeReimbursementMemo,
           successIconDuration,
+          appLockGracePeriodSeconds,
           cardTermsAndConditionsUrl,
           cardPrivacyPolicyUrl,
           cardCardholderAgreementUrl,

--- a/app/navigation/app-state.tsx
+++ b/app/navigation/app-state.tsx
@@ -28,6 +28,16 @@ export const AppStateWrapper: React.FC = () => {
    *  path already locks through the cold start. */
   const backgroundedAtRef = React.useRef<number | null>(null)
 
+  /** Read through refs so that flipping the lock, or a remote-config refresh, never tears
+   *  down and re-subscribes the AppState listener underneath a transition in flight. */
+  const isAppLockedRef = React.useRef(isAppLocked)
+  const gracePeriodSecondsRef = React.useRef(appLockGracePeriodSeconds)
+
+  useEffect(() => {
+    isAppLockedRef.current = isAppLocked
+    gracePeriodSecondsRef.current = appLockGracePeriodSeconds
+  }, [isAppLocked, appLockGracePeriodSeconds])
+
   /** The lock the user configured only ever guarded the cold start, leaving a backgrounded
    *  session open indefinitely. Re-raise it on return, past a grace period so the common
    *  hop to another app and straight back does not demand the PIN again. */
@@ -38,10 +48,16 @@ export const AppStateWrapper: React.FC = () => {
 
     /** A cold start left at the unlock screen is already locked; raising it again would
      *  stack a second unlock screen over the first, and demand the PIN twice. */
-    if (isAppLocked) return
+    if (isAppLockedRef.current) return
 
+    /** React Native exposes no monotonic clock, so the trip is measured against the wall
+     *  clock, which the user can move. Winding it forward only locks sooner; winding it
+     *  back is the bypass, so a clock that went backwards is treated as a trip that cannot
+     *  be trusted, and locks rather than being let through. */
     const secondsInBackground = (Date.now() - backgroundedAt) / MILLISECONDS_PER_SECOND
-    if (secondsInBackground < appLockGracePeriodSeconds) return
+    const isWithinGracePeriod =
+      secondsInBackground >= 0 && secondsInBackground < gracePeriodSecondsRef.current
+    if (isWithinGracePeriod) return
 
     const isLockEnabled =
       (await KeyStoreWrapper.getIsPinEnabled()) ||
@@ -52,11 +68,26 @@ export const AppStateWrapper: React.FC = () => {
      *  the navigation is what actually puts the lock in front of the user. */
     setAppLocked()
     navigation.navigate("authenticationCheck", { isResume: true })
-  }, [appLockGracePeriodSeconds, isAppLocked, navigation, setAppLocked])
+  }, [navigation, setAppLocked])
 
   const handleAppStateChange = useCallback(
     async (nextAppState: AppStateStatus) => {
-      if (appState.current.match(/background/) && nextAppState === "active") {
+      /** Recorded before the await below, so that a transition arriving while the relock is
+       *  still running reads the state this one already moved to, rather than a stale one. */
+      const previousAppState = appState.current
+      appState.current = nextAppState
+
+      /** iOS reaches the background through "inactive", which is where `RCTAppState` maps
+       *  `willResignActive`, while Android leaves straight from "active". Both are spelled
+       *  out rather than matched loosely, since /active/ also matches "inactive" and the
+       *  relock would quietly depend on that substring accident. */
+      const isEnteringForeground =
+        previousAppState === "background" && nextAppState === "active"
+      const isLeavingForeground =
+        (previousAppState === "active" || previousAppState === "inactive") &&
+        nextAppState === "background"
+
+      if (isEnteringForeground) {
         isAuthed && client.refetchQueries({ include: [HomeAuthedDocument] })
 
         console.info("App has come to the foreground!")
@@ -65,12 +96,10 @@ export const AppStateWrapper: React.FC = () => {
         await relockIfGracePeriodExpired()
       }
 
-      if (appState.current.match(/active/) && nextAppState === "background") {
+      if (isLeavingForeground) {
         backgroundedAtRef.current = Date.now()
         logEnterBackground()
       }
-
-      appState.current = nextAppState
     },
     [client, isAuthed, relockIfGracePeriodExpired],
   )

--- a/app/navigation/app-state.tsx
+++ b/app/navigation/app-state.tsx
@@ -1,15 +1,58 @@
 import React, { useCallback, useEffect } from "react"
 import { AppState, AppStateStatus } from "react-native"
 
+import { useNavigation } from "@react-navigation/native"
+import { NativeStackNavigationProp } from "@react-navigation/native-stack"
+
 import { useApolloClient } from "@apollo/client"
+import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { HomeAuthedDocument } from "@app/graphql/generated"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
+import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { logEnterBackground, logEnterForeground } from "@app/utils/analytics"
+import KeyStoreWrapper from "@app/utils/storage/secureStorage"
+
+const MILLISECONDS_PER_SECOND = 1000
 
 export const AppStateWrapper: React.FC = () => {
   const isAuthed = useIsAuthed()
   const appState = React.useRef(AppState.currentState)
   const client = useApolloClient()
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const { isAppLocked, setAppLocked } = useAuthenticationContext()
+  const { appLockGracePeriodSeconds } = useRemoteConfig()
+
+  /** When the app left the foreground, or null while it has not. A ref rather than state
+   *  because nothing renders from it, and losing it to a killed process is harmless: that
+   *  path already locks through the cold start. */
+  const backgroundedAtRef = React.useRef<number | null>(null)
+
+  /** The lock the user configured only ever guarded the cold start, leaving a backgrounded
+   *  session open indefinitely. Re-raise it on return, past a grace period so the common
+   *  hop to another app and straight back does not demand the PIN again. */
+  const relockIfGracePeriodExpired = useCallback(async () => {
+    const backgroundedAt = backgroundedAtRef.current
+    backgroundedAtRef.current = null
+    if (backgroundedAt === null) return
+
+    /** A cold start left at the unlock screen is already locked; raising it again would
+     *  stack a second unlock screen over the first, and demand the PIN twice. */
+    if (isAppLocked) return
+
+    const secondsInBackground = (Date.now() - backgroundedAt) / MILLISECONDS_PER_SECOND
+    if (secondsInBackground < appLockGracePeriodSeconds) return
+
+    const isLockEnabled =
+      (await KeyStoreWrapper.getIsPinEnabled()) ||
+      (await KeyStoreWrapper.getIsBiometricsEnabled())
+    if (!isLockEnabled) return
+
+    /** Both halves are needed: the flag defers incoming deep links until the unlock, and
+     *  the navigation is what actually puts the lock in front of the user. */
+    setAppLocked()
+    navigation.navigate("authenticationCheck", { isResume: true })
+  }, [appLockGracePeriodSeconds, isAppLocked, navigation, setAppLocked])
 
   const handleAppStateChange = useCallback(
     async (nextAppState: AppStateStatus) => {
@@ -18,15 +61,18 @@ export const AppStateWrapper: React.FC = () => {
 
         console.info("App has come to the foreground!")
         logEnterForeground()
+
+        await relockIfGracePeriodExpired()
       }
 
       if (appState.current.match(/active/) && nextAppState === "background") {
+        backgroundedAtRef.current = Date.now()
         logEnterBackground()
       }
 
       appState.current = nextAppState
     },
-    [client, isAuthed],
+    [client, isAuthed, relockIfGracePeriodExpired],
   )
 
   useEffect(() => {

--- a/app/navigation/root-navigator.tsx
+++ b/app/navigation/root-navigator.tsx
@@ -68,6 +68,7 @@ import {
   LoginMethodScreen,
 } from "../screens/authentication-screen"
 import { PinScreen } from "../screens/authentication-screen/pin-screen"
+import { unlockScreenOptions } from "../screens/authentication-screen/unlock-screen"
 import { DeveloperScreen } from "../screens/developer-screen"
 import { EarnMapScreen } from "../screens/earns-map-screen"
 import { EarnQuiz, EarnSection } from "../screens/earns-screen"
@@ -230,12 +231,12 @@ export const RootStack = () => {
       <RootNavigator.Screen
         name="authenticationCheck"
         component={AuthenticationCheckScreen}
-        options={{ headerShown: false }}
+        options={unlockScreenOptions}
       />
       <RootNavigator.Screen
         name="authentication"
         component={AuthenticationScreen}
-        options={{ headerShown: false }}
+        options={unlockScreenOptions}
       />
       <RootNavigator.Screen
         name="login"
@@ -252,7 +253,7 @@ export const RootStack = () => {
       <RootNavigator.Screen
         name="pin"
         component={PinScreen}
-        options={{ headerShown: false }}
+        options={unlockScreenOptions}
       />
       <RootNavigator.Screen
         name="Primary"

--- a/app/navigation/stack-param-lists.ts
+++ b/app/navigation/stack-param-lists.ts
@@ -34,12 +34,15 @@ export type RootStackParamList = {
     title?: string
     onboarding?: boolean
   }
-  authenticationCheck: undefined
+  /** `isResume` marks the lock raised on returning from background: unlocking pops back to
+   *  the screen the user was on, instead of resetting to Primary the way a cold start does. */
+  authenticationCheck: { isResume?: boolean } | undefined
   authentication: {
     screenPurpose: AuthenticationScreenPurpose
     isPinEnabled: boolean
+    isResume?: boolean
   }
-  pin: { screenPurpose: PinScreenPurpose }
+  pin: { screenPurpose: PinScreenPurpose; isResume?: boolean }
   Primary: undefined
   earnsSection: { section: EarnSectionType; isAvailable: boolean }
   earnsQuiz: { id: string; isAvailable: boolean }

--- a/app/screens/authentication-screen/authentication-check-screen.tsx
+++ b/app/screens/authentication-screen/authentication-check-screen.tsx
@@ -9,7 +9,8 @@ import { makeStyles, useTheme } from "@rn-vui/themed"
 import { useApolloClient } from "@apollo/client"
 import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { updateDeviceSessionCount } from "@app/graphql/client-only-query"
-import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
+
+import { useUnlockScreen } from "./unlock-screen"
 
 import AppLogoDarkMode from "../../assets/logo/app-logo-dark.svg"
 import AppLogoLightMode from "../../assets/logo/blink-logo-light.svg"
@@ -31,9 +32,9 @@ export const AuthenticationCheckScreen: React.FC = () => {
     useNavigation<NativeStackNavigationProp<RootStackParamList, "authenticationCheck">>()
   const route = useRoute<RouteProp<RootStackParamList, "authenticationCheck">>()
   const isAuthed = useIsAuthed()
-  const { setAppUnlocked } = useAuthenticationContext()
 
   const isResume = route.params?.isResume ?? false
+  const { completeUnlock } = useUnlockScreen({ isResume })
 
   useEffect(() => {
     ;(async () => {
@@ -54,20 +55,15 @@ export const AuthenticationCheckScreen: React.FC = () => {
           isResume,
         })
       } else {
-        setAppUnlocked()
-
         /** Only a cold start opens a device session, and only it owes the user the home
          *  screen; a resume whose lock was turned off meanwhile just steps back. */
-        if (isResume) {
-          navigation.goBack()
-          return
-        }
-
-        updateDeviceSessionCount(client)
-        navigation.replace("Primary")
+        completeUnlock(() => {
+          updateDeviceSessionCount(client)
+          navigation.replace("Primary")
+        })
       }
     })()
-  }, [isAuthed, navigation, setAppUnlocked, client, isResume])
+  }, [isAuthed, navigation, completeUnlock, client, isResume])
 
   return (
     <Screen>

--- a/app/screens/authentication-screen/authentication-check-screen.tsx
+++ b/app/screens/authentication-screen/authentication-check-screen.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { useEffect } from "react"
 import { View } from "react-native"
 
-import { useNavigation } from "@react-navigation/native"
+import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, useTheme } from "@rn-vui/themed"
 
@@ -29,8 +29,11 @@ export const AuthenticationCheckScreen: React.FC = () => {
 
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList, "authenticationCheck">>()
+  const route = useRoute<RouteProp<RootStackParamList, "authenticationCheck">>()
   const isAuthed = useIsAuthed()
   const { setAppUnlocked } = useAuthenticationContext()
+
+  const isResume = route.params?.isResume ?? false
 
   useEffect(() => {
     ;(async () => {
@@ -43,16 +46,28 @@ export const AuthenticationCheckScreen: React.FC = () => {
         navigation.replace("authentication", {
           screenPurpose: AuthenticationScreenPurpose.Authenticate,
           isPinEnabled,
+          isResume,
         })
       } else if (isPinEnabled) {
-        navigation.replace("pin", { screenPurpose: PinScreenPurpose.AuthenticatePin })
+        navigation.replace("pin", {
+          screenPurpose: PinScreenPurpose.AuthenticatePin,
+          isResume,
+        })
       } else {
         setAppUnlocked()
+
+        /** Only a cold start opens a device session, and only it owes the user the home
+         *  screen; a resume whose lock was turned off meanwhile just steps back. */
+        if (isResume) {
+          navigation.goBack()
+          return
+        }
+
         updateDeviceSessionCount(client)
         navigation.replace("Primary")
       }
     })()
-  }, [isAuthed, navigation, setAppUnlocked, client])
+  }, [isAuthed, navigation, setAppUnlocked, client, isResume])
 
   return (
     <Screen>

--- a/app/screens/authentication-screen/authentication-screen.tsx
+++ b/app/screens/authentication-screen/authentication-screen.tsx
@@ -4,10 +4,11 @@ import { Alert, View } from "react-native"
 import { GaloyPrimaryButton } from "@app/components/atomic/galoy-primary-button"
 import { GaloySecondaryButton } from "@app/components/atomic/galoy-secondary-button"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { makeStyles, useTheme } from "@rn-vui/themed"
+
+import { useUnlockScreen } from "./unlock-screen"
 
 import AppLogoDarkMode from "../../assets/logo/app-logo-dark.svg"
 import AppLogoLightMode from "../../assets/logo/blink-logo-light.svg"
@@ -33,8 +34,8 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
 
   const styles = useStyles()
   const { logout } = useLogout()
-  const { screenPurpose, isPinEnabled, isResume } = route.params
-  const { setAppUnlocked } = useAuthenticationContext()
+  const { screenPurpose, isPinEnabled, isResume = false } = route.params
+  const { completeUnlock } = useUnlockScreen({ isResume })
   const { LL } = useI18nContext()
 
   const handleAuthenticationSuccess = React.useCallback(async () => {
@@ -43,15 +44,8 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
     } else if (screenPurpose === AuthenticationScreenPurpose.TurnOnAuthentication) {
       KeyStoreWrapper.setIsBiometricsEnabled()
     }
-    setAppUnlocked()
-
-    if (isResume) {
-      navigation.goBack()
-      return
-    }
-
-    navigation.replace("Primary")
-  }, [navigation, screenPurpose, setAppUnlocked, isResume])
+    completeUnlock(() => navigation.replace("Primary"))
+  }, [navigation, screenPurpose, completeUnlock])
 
   const attemptAuthentication = React.useCallback(() => {
     let description = "attemptAuthentication. should not be displayed?"
@@ -102,7 +96,10 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
       <GaloySecondaryButton
         title={LL.AuthenticationScreen.usePin()}
         onPress={() =>
-          navigation.navigate("pin", { screenPurpose: PinScreenPurpose.AuthenticatePin })
+          navigation.navigate("pin", {
+            screenPurpose: PinScreenPurpose.AuthenticatePin,
+            isResume,
+          })
         }
         containerStyle={styles.buttonContainer}
       />

--- a/app/screens/authentication-screen/authentication-screen.tsx
+++ b/app/screens/authentication-screen/authentication-screen.tsx
@@ -33,7 +33,7 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
 
   const styles = useStyles()
   const { logout } = useLogout()
-  const { screenPurpose, isPinEnabled } = route.params
+  const { screenPurpose, isPinEnabled, isResume } = route.params
   const { setAppUnlocked } = useAuthenticationContext()
   const { LL } = useI18nContext()
 
@@ -44,8 +44,14 @@ export const AuthenticationScreen: React.FC<Props> = ({ route }) => {
       KeyStoreWrapper.setIsBiometricsEnabled()
     }
     setAppUnlocked()
+
+    if (isResume) {
+      navigation.goBack()
+      return
+    }
+
     navigation.replace("Primary")
-  }, [navigation, screenPurpose, setAppUnlocked])
+  }, [navigation, screenPurpose, setAppUnlocked, isResume])
 
   const attemptAuthentication = React.useCallback(() => {
     let description = "attemptAuthentication. should not be displayed?"

--- a/app/screens/authentication-screen/pin-screen.tsx
+++ b/app/screens/authentication-screen/pin-screen.tsx
@@ -2,13 +2,15 @@ import * as React from "react"
 import { useEffect, useState } from "react"
 import { Alert, Text, View } from "react-native"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
 import { RouteProp, useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { Button } from "@rn-vui/base"
 import { makeStyles } from "@rn-vui/themed"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+
+import { useUnlockScreen } from "./unlock-screen"
+
 import { Screen } from "../../components/screen"
 import useLogout from "../../hooks/use-logout"
 import { RootStackParamList } from "../../navigation/stack-param-lists"
@@ -26,8 +28,8 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, "pin">>()
 
   const { logout } = useLogout()
-  const { screenPurpose, isResume } = route.params
-  const { setAppUnlocked } = useAuthenticationContext()
+  const { screenPurpose, isResume = false } = route.params
+  const { completeUnlock } = useUnlockScreen({ isResume })
   const { LL } = useI18nContext()
   const [enteredPIN, setEnteredPIN] = useState("")
   const [helperText, setHelperText] = useState(
@@ -47,17 +49,12 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
   const handleCompletedPinForAuthenticatePin = async (newEnteredPIN: string) => {
     if (newEnteredPIN === (await KeyStoreWrapper.getPinOrEmptyString())) {
       KeyStoreWrapper.resetPinAttempts()
-      setAppUnlocked()
-
-      if (isResume) {
-        navigation.goBack()
-        return
-      }
-
-      navigation.reset({
-        index: 0,
-        routes: [{ name: "Primary" }],
-      })
+      completeUnlock(() =>
+        navigation.reset({
+          index: 0,
+          routes: [{ name: "Primary" }],
+        }),
+      )
     } else if (pinAttempts < MAX_PIN_ATTEMPTS - 1) {
       const newPinAttempts = pinAttempts + 1
       KeyStoreWrapper.setPinAttempts(newPinAttempts.toString())

--- a/app/screens/authentication-screen/pin-screen.tsx
+++ b/app/screens/authentication-screen/pin-screen.tsx
@@ -26,7 +26,7 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList, "pin">>()
 
   const { logout } = useLogout()
-  const { screenPurpose } = route.params
+  const { screenPurpose, isResume } = route.params
   const { setAppUnlocked } = useAuthenticationContext()
   const { LL } = useI18nContext()
   const [enteredPIN, setEnteredPIN] = useState("")
@@ -48,6 +48,12 @@ export const PinScreen: React.FC<Props> = ({ route }) => {
     if (newEnteredPIN === (await KeyStoreWrapper.getPinOrEmptyString())) {
       KeyStoreWrapper.resetPinAttempts()
       setAppUnlocked()
+
+      if (isResume) {
+        navigation.goBack()
+        return
+      }
+
       navigation.reset({
         index: 0,
         routes: [{ name: "Primary" }],

--- a/app/screens/authentication-screen/unlock-screen.ts
+++ b/app/screens/authentication-screen/unlock-screen.ts
@@ -1,0 +1,64 @@
+import { useCallback } from "react"
+import { BackHandler } from "react-native"
+
+import { RouteProp, useFocusEffect, useNavigation } from "@react-navigation/native"
+import {
+  NativeStackNavigationOptions,
+  NativeStackNavigationProp,
+} from "@react-navigation/native-stack"
+
+import { useAuthenticationContext } from "@app/navigation/navigation-container-wrapper"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+
+type UseUnlockScreenParams = {
+  isResume: boolean
+}
+
+/**
+ * Blocking a resume lock from being dismissed takes one guard per platform, and neither is
+ * redundant: iOS `gestureEnabled` blocks the edge swipe, Android the back press
+ * `useUnlockScreen` intercepts. Only a resume turns them off; a cold start needs the gesture
+ * as the only way out of the header-less PIN flow Settings opens.
+ */
+export const unlockScreenOptions = ({
+  route,
+}: {
+  route: RouteProp<RootStackParamList, "authenticationCheck" | "authentication" | "pin">
+}): NativeStackNavigationOptions => ({
+  headerShown: false,
+  gestureEnabled: !route.params?.isResume,
+})
+
+/** Shared contract for the unlock screens: refuse dismissal while a resume lock is up, then
+ *  step back on unlock, where a cold start instead routes forward. */
+export const useUnlockScreen = ({ isResume }: UseUnlockScreenParams) => {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+  const { setAppUnlocked } = useAuthenticationContext()
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isResume) return
+
+      /** BackHandler, not a beforeRemove listener, so the unlock's own goBack still runs:
+       *  that guard would see the stale locked state a tick later and cancel it. */
+      const subscription = BackHandler.addEventListener("hardwareBackPress", () => true)
+      return () => subscription.remove()
+    }, [isResume]),
+  )
+
+  const completeUnlock = useCallback(
+    (navigateOnColdStart: () => void) => {
+      setAppUnlocked()
+
+      if (isResume) {
+        navigation.goBack()
+        return
+      }
+
+      navigateOnColdStart()
+    },
+    [isResume, navigation, setAppUnlocked],
+  )
+
+  return { completeUnlock }
+}


### PR DESCRIPTION
## Summary

The PIN/biometric lock only ever guarded the cold start. Once the app was running, a backgrounded session stayed open indefinitely: anyone picking up the phone could reopen Blink straight into the home screen without being challenged. The lock is now re-applied when the app returns to the foreground after a grace period, and the raised lock resists being dismissed back out of.

## Problem

`AppStateWrapper` handled the background/foreground transitions (analytics, home-query refetch) but never touched the lock. The lock was raised exactly once, by `authenticationCheck` being the initial route at cold start, and no code path raised it again for the life of the process. The setting the user turned on in Settings > Security therefore protected a killed app, not a backgrounded one.

## Fix

`AppStateWrapper` records when the app leaves the foreground and, on return, re-raises the lock if the trip outlasted the grace period and the user has a PIN or biometrics configured. Both halves are needed:

- `setAppLocked()` flips the flag that defers incoming deep links until the unlock.
- `navigate("authenticationCheck", { isResume: true })` puts the lock in front of the user.

The timestamp lives in a ref rather than state: nothing renders from it, and losing it to a killed process is harmless, since that path already locks through the cold start.

## Grace period (remote config)

`appLockGracePeriodSeconds`, default `60`. Without it, the common hop to another app and straight back (copying an address, checking a message) would demand the PIN every time.

Following the existing flags convention, the default is registered through `setDefaults`, so it doubles as the fail-safe when the key is absent. **The Firebase key does not need to exist for this to ship**; it only needs to exist to tune the value remotely.

RN exposes no monotonic clock, so the trip is measured against the wall clock. Winding it forward only locks sooner; a trip that reports a negative duration is not trusted and locks rather than being let through.

## Resume vs cold start

The three unlock screens share a `useUnlockScreen` hook that holds the resume contract in one place. `isResume` threads from `authenticationCheck` into `authentication`/`pin`, and changes only what follows a successful unlock:

- **Cold start**: `updateDeviceSessionCount` plus the reset to `Primary`.
- **Resume**: `goBack()`, returning the user to the screen they were on, and skips `updateDeviceSessionCount`, since only a cold start opens a device session.

The biometric screen's "Use PIN" fallback forwards `isResume`, so a resume that drops to the PIN steps back the same way.

## Keeping the resume lock from being dismissed

A cold-start lock is the initial route with nothing behind it. A resume lock instead sits on top of the live stack, so back navigation would pop it and reveal the app unchallenged. Blocking that takes one guard per platform, and neither is redundant:

- **iOS**: `gestureEnabled: false` on the unlock screens blocks the edge swipe. It is off only on resume, since a fixed value would trap the header-less PIN-creation flow Settings opens, where the swipe is the only way back.
- **Android**: `useUnlockScreen` swallows the hardware back press via `BackHandler`, gated on `isResume`. This leaves the unlock's own programmatic `goBack` untouched.

## The `isAppLocked` guard

The relock bails when the lock is already up, so a cold-start unlock screen the user has not answered yet never gets a second one stacked over it (which would otherwise demand the PIN twice: once for the stacked screen, then again on the one behind it).

## AppState transitions

The transition checks are explicit: `=== "active" || === "inactive"` on the way out, `=== "background" && === "active"` on the way in. On iOS the trip to background passes through `"inactive"` (`RCTAppState.mm` maps `willResignActive` there), so both are matched by name rather than a loose `/active/` regex. The `AppState` values and grace period read through refs, so the listener does not resubscribe on a lock-state flip, and `appState.current` advances synchronously before the relock's await.

## Verification

35 tests across 5 specs: lock past the grace period, no lock within it, biometrics without a PIN, no lock configured, a remote-config value honored, the iOS background sequence, a backwards clock still locking, no double-lock per trip, the `isAppLocked` guard, the Android back press swallowed on resume but not on cold start nor the Settings PIN flow, the iOS swipe gate, and "Use PIN" forwarding `isResume`.

Device-tested on both platforms: Android (back press and the double-PIN scenario) and iOS (edge swipe on the resume lock).
