### PR TITLE
chore(deps): update actions/cache from v2 to v4 as v2 is deprecated

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v2
 
       # Caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             node_modules
@@ -155,7 +155,7 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v2
 
       # Caching
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             node_modules


### PR DESCRIPTION
E2E automated checks fail for Android and iOS because of deprecated actions/cache version

```
Getting action download info
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```