### PR TITLE
fix(home): let header grow with font scale so username and settings menu stay usable

### DIFF
--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -87,6 +87,7 @@ export const BalanceHeader: React.FC<Props> = ({
                 style={styles.primaryBalanceText}
                 allowFontScaling
                 adjustsFontSizeToFit
+                numberOfLines={1}
               >
                 {formattedBalance}
               </Text>

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -712,11 +712,18 @@ export const HomeScreen: React.FC = () => {
             iconOnly={true}
             weight="bold"
           />
-          <View>
+          <View style={styles.usernameSlot}>
             {!loading && usernameTitle && (
               <Pressable onPress={canSwitchAccount ? handleSwitchPress : null}>
                 <View style={styles.profileContainer}>
-                  <Text type="p2">{usernameTitle}</Text>
+                  <Text
+                    type="p2"
+                    style={styles.usernameText}
+                    numberOfLines={1}
+                    maxFontSizeMultiplier={1.5}
+                  >
+                    {usernameTitle}
+                  </Text>
                   {canSwitchAccount && <GaloyIcon name={"caret-down"} size={18} />}
                 </View>
               </Pressable>
@@ -894,27 +901,33 @@ const useStyles = makeStyles(({ colors }) => ({
   },
   balanceContainer: {
     marginTop: 7,
-    flexDirection: "column",
-    flex: 1,
-    height: 40,
-    maxHeight: 40,
+    // minHeight (not a fixed height) so the header can grow with the OS font scale
+    // instead of spilling the username onto the balance below (blink-wip#931)
+    minHeight: 40,
   },
   header: {
     flexDirection: "row",
-    flex: 1,
     justifyContent: "space-between",
     alignItems: "center",
     marginHorizontal: 20,
     marginTop: 6,
+    columnGap: 8,
   },
   error: {
     alignSelf: "center",
     color: colors.error,
   },
+  usernameSlot: {
+    flexShrink: 1,
+    alignItems: "center",
+  },
   profileContainer: {
     flexDirection: "row",
     alignItems: "center",
     gap: 6,
+  },
+  usernameText: {
+    flexShrink: 1,
   },
   actionsSeparator: {
     width: 1,
@@ -922,7 +935,7 @@ const useStyles = makeStyles(({ colors }) => ({
     backgroundColor: colors.grey4,
   },
   badgeSlot: {
-    height: 35,
+    minHeight: 35,
     marginVertical: 3,
     justifyContent: "center",
     alignItems: "center",


### PR DESCRIPTION
## Summary

Fixes blinkbitcoin/blink-wip#931 — the username at the top of the home screen was cut off / overlapping the total balance, and with enlarged OS font settings the settings hamburger became untappable.

**Root cause:** the header's `balanceContainer` was hard-capped at `height: 40 / maxHeight: 40`. The username (`p2`, OS-font-scaled) outgrows that box above ~1.4x scale; since RN views don't clip overflow, the text spilled onto the `BalanceHeader` sibling below. `BalanceHeader`'s full-width touchable renders after the header, so the overlap also stole taps from the menu button (which only has a ~17px hitSlop). The bulletin/notification in the report is incidental — bulletins render inside the ScrollView and don't affect the header.

## Changes

- `balanceContainer`: fixed `height`/`maxHeight` → `minHeight: 40` so the row can grow with the font scale (pixel-identical at 1x: 34px icon button + 6px margin = 40).
- `header`: drop `flex: 1` (with a content-driven parent height, `flexBasis: 0` would collapse the row); add `columnGap: 8`.
- Username text: `numberOfLines={1}`, `maxFontSizeMultiplier={1.5}`, `flexShrink: 1` — long names ellipsize instead of crowding the icon buttons, and the account-switcher caret stays visible; the 1.5x cap is defense-in-depth on compact chrome at extreme accessibility sizes.
- Balance text: add `numberOfLines={1}` so the existing `adjustsFontSizeToFit` actually takes effect on iOS.
- `badgeSlot`: `height: 35` → `minHeight: 35` (same bug class, same screen).

**Out of scope:** a global font-scale policy in `app/rne-theme/theme.ts`, the ad-hoc `adjustsFontSizeToFit` in `transaction-limits-screen.tsx`, and `GaloyIconButton` hit-testing. If more custom in-content headers appear, the 1.5 cap should move to a shared constant.

## Verification

- `yarn jest __tests__/screens/home.spec.tsx` — 50/50 pass
- `yarn tsc --noEmit` and eslint on both files — clean
- Manual check recommended on device/sim: iOS `xcrun simctl ui booted content-size accessibility-extra-large` (and XXXL), Android `adb shell settings put system font_scale 2.0` — username never touches the balance; hamburger, graph, username switcher, and balance (hide-amount) all tappable at max scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)