### PR TITLE
fix(settings): show support email with copy action in contact modal

### DIFF
--- a/__tests__/components/contact-modal/contact-modal.spec.tsx
+++ b/__tests__/components/contact-modal/contact-modal.spec.tsx
@@ -1,0 +1,132 @@
+import React from "react"
+import { Linking } from "react-native"
+import { fireEvent, render } from "@testing-library/react-native"
+
+jest.mock("react-native-modal", () => {
+  const ReactActual = jest.requireActual("react")
+  const RN = jest.requireActual("react-native")
+  return ({ isVisible, children }: { isVisible: boolean; children: React.ReactNode }) =>
+    isVisible ? ReactActual.createElement(RN.View, null, children) : null
+})
+
+jest.mock("@rn-vui/themed", () => {
+  const ReactActual = jest.requireActual("react")
+  const RN = jest.requireActual("react-native")
+  const Content: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+    ReactActual.createElement(RN.View, null, children)
+  Content.displayName = "ListItem.Content"
+  const Title: React.FC<{ children?: React.ReactNode }> = ({ children }) =>
+    ReactActual.createElement(RN.View, null, children)
+  Title.displayName = "ListItem.Title"
+  const Chevron: React.FC = () => null
+  Chevron.displayName = "ListItem.Chevron"
+  const ListItem = ({
+    onPress,
+    children,
+  }: {
+    onPress: () => void
+    children: React.ReactNode
+  }) => ReactActual.createElement(RN.TouchableOpacity, { onPress }, children)
+  ListItem.displayName = "ListItem"
+  ListItem.Content = Content
+  ListItem.Title = Title
+  ListItem.Chevron = Chevron
+  return {
+    makeStyles: () => () => ({}),
+    useTheme: () => ({
+      theme: {
+        colors: { black: "#000", white: "#fff", primary: "#fc5805", grey5: "#eee" },
+      },
+    }),
+    Icon: () => null,
+    Text: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(RN.Text, null, children),
+    ListItem,
+  }
+})
+
+jest.mock("@app/config", () => ({
+  CONTACT_EMAIL_ADDRESS: "support@blink.sv",
+  WHATSAPP_CONTACT_NUMBER: "+50365555555",
+}))
+
+jest.mock("@app/utils/external", () => ({ openWhatsApp: jest.fn() }))
+
+const mockCopyToClipboard = jest.fn()
+jest.mock("@app/hooks/use-clipboard", () => ({
+  useClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
+}))
+
+jest.mock("@app/hooks/use-contact-support", () => ({
+  useContactSupport: () => ({ supportEmailAddress: "support@blink.sv" }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      support: {
+        statusPage: () => "Status page",
+        faq: () => "FAQ",
+        telegram: () => "Telegram",
+        mattermost: () => "Mattermost",
+        whatsapp: () => "WhatsApp",
+        email: () => "Email",
+        emailCopied: ({ email }: { email: string }) =>
+          `email ${email} copied to clipboard`,
+      },
+    },
+  }),
+}))
+
+import ContactModal, {
+  SupportChannels,
+} from "@app/components/contact-modal/contact-modal"
+
+const defaultProps = {
+  isVisible: true,
+  toggleModal: jest.fn(),
+  messageBody: "test body",
+  messageSubject: "test subject",
+}
+
+describe("ContactModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+  })
+
+  it("shows the support email and copies it on press without navigating", () => {
+    const toggleModal = jest.fn()
+    const { getByText } = render(
+      <ContactModal
+        {...defaultProps}
+        toggleModal={toggleModal}
+        supportChannels={[SupportChannels.EmailCopy]}
+      />,
+    )
+
+    fireEvent.press(getByText("support@blink.sv"))
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith({
+      content: "support@blink.sv",
+      message: "email support@blink.sv copied to clipboard",
+    })
+    expect(Linking.openURL).not.toHaveBeenCalled()
+    expect(toggleModal).toHaveBeenCalled()
+  })
+
+  it("keeps the mailto behavior for the Email channel", () => {
+    const { getByText } = render(
+      <ContactModal {...defaultProps} supportChannels={[SupportChannels.Email]} />,
+    )
+
+    fireEvent.press(getByText("Email"))
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      `mailto:support@blink.sv?subject=${encodeURIComponent(
+        "test subject",
+      )}&body=${encodeURIComponent("test body")}`,
+    )
+    expect(mockCopyToClipboard).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/contact-modal/contact-modal.spec.tsx
+++ b/__tests__/components/contact-modal/contact-modal.spec.tsx
@@ -2,11 +2,16 @@ import React from "react"
 import { Linking } from "react-native"
 import { fireEvent, render } from "@testing-library/react-native"
 
+let mockModalProps: Record<string, unknown> = {}
 jest.mock("react-native-modal", () => {
   const ReactActual = jest.requireActual("react")
   const RN = jest.requireActual("react-native")
-  return ({ isVisible, children }: { isVisible: boolean; children: React.ReactNode }) =>
-    isVisible ? ReactActual.createElement(RN.View, null, children) : null
+  return (props: { isVisible: boolean; children: React.ReactNode }) => {
+    mockModalProps = props
+    return props.isVisible
+      ? ReactActual.createElement(RN.View, null, props.children)
+      : null
+  }
 })
 
 jest.mock("@rn-vui/themed", () => {
@@ -50,7 +55,10 @@ jest.mock("@app/config", () => ({
   WHATSAPP_CONTACT_NUMBER: "+50365555555",
 }))
 
-jest.mock("@app/utils/external", () => ({ openWhatsApp: jest.fn() }))
+const mockOpenWhatsApp = jest.fn()
+jest.mock("@app/utils/external", () => ({
+  openWhatsApp: (...args: unknown[]) => mockOpenWhatsApp(...args),
+}))
 
 const mockCopyToClipboard = jest.fn()
 jest.mock("@app/hooks/use-clipboard", () => ({
@@ -128,5 +136,96 @@ describe("ContactModal", () => {
       )}&body=${encodeURIComponent("test body")}`,
     )
     expect(mockCopyToClipboard).not.toHaveBeenCalled()
+  })
+
+  type LinkChannelCase = { channel: SupportChannels; label: string; url: string }
+  const linkChannels: LinkChannelCase[] = [
+    {
+      channel: SupportChannels.StatusPage,
+      label: "Status page",
+      url: "https://blink.statuspage.io/",
+    },
+    { channel: SupportChannels.Faq, label: "FAQ", url: "https://faq.blink.sv" },
+    {
+      channel: SupportChannels.Telegram,
+      label: "Telegram",
+      url: "https://t.me/blinkbtc",
+    },
+    {
+      channel: SupportChannels.Mattermost,
+      label: "Mattermost",
+      url: "https://chat.blink.sv",
+    },
+  ]
+
+  linkChannels.forEach(({ channel, label, url }) => {
+    it(`opens the ${label} link on press`, () => {
+      const { getByText } = render(
+        <ContactModal {...defaultProps} supportChannels={[channel]} />,
+      )
+
+      fireEvent.press(getByText(label))
+
+      expect(Linking.openURL).toHaveBeenCalledWith(url)
+    })
+  })
+
+  it("opens WhatsApp with the support number and message body", () => {
+    const { getByText } = render(
+      <ContactModal {...defaultProps} supportChannels={[SupportChannels.WhatsApp]} />,
+    )
+
+    fireEvent.press(getByText("WhatsApp"))
+
+    expect(mockOpenWhatsApp).toHaveBeenCalledWith("+50365555555", "test body")
+  })
+
+  it("renders only the requested channels", () => {
+    const { getByText, queryByText } = render(
+      <ContactModal
+        {...defaultProps}
+        supportChannels={[
+          SupportChannels.Faq,
+          SupportChannels.StatusPage,
+          SupportChannels.EmailCopy,
+        ]}
+      />,
+    )
+
+    expect(getByText("FAQ")).toBeTruthy()
+    expect(getByText("Status page")).toBeTruthy()
+    expect(getByText("support@blink.sv")).toBeTruthy()
+    expect(queryByText("Email")).toBeNull()
+    expect(queryByText("Telegram")).toBeNull()
+    expect(queryByText("Mattermost")).toBeNull()
+    expect(queryByText("WhatsApp")).toBeNull()
+  })
+
+  it("renders nothing while hidden", () => {
+    const { queryByText } = render(
+      <ContactModal
+        {...defaultProps}
+        isVisible={false}
+        supportChannels={[SupportChannels.Faq]}
+      />,
+    )
+
+    expect(queryByText("FAQ")).toBeNull()
+  })
+
+  it("dismisses on backdrop press", () => {
+    const toggleModal = jest.fn()
+    render(
+      <ContactModal
+        {...defaultProps}
+        toggleModal={toggleModal}
+        supportChannels={[SupportChannels.Faq]}
+      />,
+    )
+
+    const onBackdropPress = mockModalProps.onBackdropPress as () => void
+    onBackdropPress()
+
+    expect(toggleModal).toHaveBeenCalled()
   })
 })

--- a/app/components/contact-modal/contact-modal.tsx
+++ b/app/components/contact-modal/contact-modal.tsx
@@ -3,6 +3,8 @@ import { Linking } from "react-native"
 import ReactNativeModal from "react-native-modal"
 
 import { CONTACT_EMAIL_ADDRESS, WHATSAPP_CONTACT_NUMBER } from "@app/config"
+import { useClipboard } from "@app/hooks/use-clipboard"
+import { useContactSupport } from "@app/hooks/use-contact-support"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { openWhatsApp } from "@app/utils/external"
 import { Icon, ListItem, makeStyles, useTheme, Text } from "@rn-vui/themed"
@@ -11,6 +13,7 @@ import TelegramOutline from "./telegram.svg"
 
 export const SupportChannels = {
   Email: "email",
+  EmailCopy: "emailCopy",
   Telegram: "telegram",
   WhatsApp: "whatsapp",
   StatusPage: "statusPage",
@@ -43,8 +46,16 @@ const ContactModal: React.FC<Props> = ({
   const {
     theme: { colors },
   } = useTheme()
+  const { supportEmailAddress } = useContactSupport()
+  const { copyToClipboard } = useClipboard()
 
-  const contactOptionList = [
+  const contactOptionList: {
+    id: SupportChannels
+    name: string
+    icon: React.ReactElement
+    rightIcon?: React.ReactElement
+    action: () => void
+  }[] = [
     {
       id: SupportChannels.StatusPage,
       name: LL.support.statusPage(),
@@ -110,6 +121,21 @@ const ContactModal: React.FC<Props> = ({
         toggleModal()
       },
     },
+    {
+      id: SupportChannels.EmailCopy,
+      name: supportEmailAddress,
+      icon: <Icon name={"mail-outline"} type="ionicon" color={colors.black} size={20} />,
+      rightIcon: (
+        <Icon name={"copy-outline"} type="ionicon" color={colors.primary} size={20} />
+      ),
+      action: () => {
+        copyToClipboard({
+          content: supportEmailAddress,
+          message: LL.support.emailCopied({ email: supportEmailAddress }),
+        })
+        toggleModal()
+      },
+    },
   ]
 
   return (
@@ -136,12 +162,14 @@ const ContactModal: React.FC<Props> = ({
                   <Text type="p2">{item.name}</Text>
                 </ListItem.Title>
               </ListItem.Content>
-              <ListItem.Chevron
-                name={"chevron-forward"}
-                type="ionicon"
-                color={colors.primary}
-                size={20}
-              />
+              {item.rightIcon ?? (
+                <ListItem.Chevron
+                  name={"chevron-forward"}
+                  type="ionicon"
+                  color={colors.primary}
+                  size={20}
+                />
+              )}
             </ListItem>
           )
         })}

--- a/app/screens/settings-screen/settings/community-need-help.tsx
+++ b/app/screens/settings-screen/settings/community-need-help.tsx
@@ -44,7 +44,7 @@ export const NeedHelpSetting: React.FC = () => {
         supportChannels={[
           SupportChannels.Faq,
           SupportChannels.StatusPage,
-          SupportChannels.Email,
+          SupportChannels.EmailCopy,
         ]}
       />
     </>


### PR DESCRIPTION
## Summary

In Settings → Support → "Need help? Contact us.", the **Email** row showed a chevron implying navigation and opened a `mailto:` draft. Per #3941 (requested by Lukas), it now displays `support@blink.sv` directly with a copy icon, and tapping copies the address to the clipboard (toast confirms) — no navigation.

Scoped to Settings only (confirmed with Jonas): a new `SupportChannels.EmailCopy` channel is used by the Settings modal, while the error screen and `ContactSupportButton` keep the existing `Email` channel with its prefilled diagnostics mailto.

- `contact-modal.tsx`: new `EmailCopy` channel — title is the remote-config `supportEmailAddress` (via `useContactSupport`), copy icon instead of chevron (items now support an optional `rightIcon`), action copies via `useClipboard` with the existing `support.emailCopied` toast message.
- `community-need-help.tsx`: uses `EmailCopy` instead of `Email`.
- New spec `__tests__/components/contact-modal/contact-modal.spec.tsx` covering the copy behavior and guarding the untouched mailto behavior.

Closes #3941

## Test plan

- `yarn jest __tests__/components/contact-modal` — 2/2 pass locally
- `yarn tsc --noEmit` and eslint clean on touched files
- CI Tests check

🤖 Generated with [Claude Code](https://claude.com/claude-code)