### PR TITLE
chore(android): update API 36 dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ tilt-down:
 	cd dev && tilt down
 
 emulator:
-	emulator -avd Pixel_API_35 -gpu swiftshader -wipe-data -no-boot-anim
+	emulator -avd Pixel_API_36 -gpu swiftshader -wipe-data -no-boot-anim
 
 reset-e2e:
 	tilt trigger dev-setup

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,10 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 26
         compileSdkVersion = 36
-        targetSdkVersion = 35
+        targetSdkVersion = 36
         ndkVersion = "27.3.13750724"
         kotlinVersion = "2.0.21"
 
@@ -18,6 +18,7 @@ buildscript {
                 android {
                     compileSdkVersion rootProject.ext.compileSdkVersion
                     buildToolsVersion rootProject.ext.buildToolsVersion
+                    ndkVersion rootProject.ext.ndkVersion
                 }
             }
         }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -23,6 +23,7 @@ org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=2g
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.builder.sdkDownload=false
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1757708437,
-        "narHash": "sha256-g1mlvFExY58Jz+mfnm8e6LYoRyoY0znWyB/ukHc9Kk8=",
+        "lastModified": 1784581886,
+        "narHash": "sha256-5tIzbV0SqaYbvEwGCjzan49n4/jdfLmd120DXjF0v80=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "603e5d6c34b03701cf7566edcefa7cb721c415a4",
+        "rev": "43172b9ac18478a7fbecb216ce15294ef207511b",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741473158,
-        "narHash": "sha256-kWNaq6wQUbUMlPgw8Y+9/9wP0F8SHkjy24/mN3UAppg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "7c9e793ebe66bcba8292989a68c0419b737a22a0",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -113,11 +113,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1757545623,
-        "narHash": "sha256-mCxPABZ6jRjUQx3bPP4vjA68ETbPLNz9V2pk9tO7pRQ=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8cd5ce828d5d1d16feff37340171a98fc3bf6526",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1757487488,
-        "narHash": "sha256-zwE/e7CuPJUWKdvvTCB7iunV4E/+G0lKfv4kk/5Izdg=",
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ab0f3607a6c7486ea22229b92ed2d355f1482ee0",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757482963,
-        "narHash": "sha256-GlGB7jW+pD5SRF6sT+c5Rs9SAjX2CoMxadrVOfaQ7MM=",
+        "lastModified": 1784189142,
+        "narHash": "sha256-+1w1B52n/TnmAV9bsZh7f2OVF4jnkFRm8QdjfIiRa0M=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "41d6aa7fe7c566fe7b45f72e855d0fed9dcd6a95",
+        "rev": "eed9cfb18ae6174c47e1ca4f380cf542ba777218",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
 
         nativeBuildInputs = with pkgs;
           [
-            nodePackages.node-gyp
+            node-gyp
             yarn
             jdk17
             tilt
@@ -83,21 +83,21 @@
           android-sdk = android.sdk.${system} (sdkPkgs:
             with sdkPkgs;
               [
-                build-tools-35-0-0
+                build-tools-36-0-0
                 cmdline-tools-latest
                 emulator
                 platform-tools
-                platforms-android-35
+                platforms-android-36
                 ndk-27-3-13750724
                 cmake-3-22-1
               ]
               ++ lib.optionals (system == "aarch64-darwin") [
-                system-images-android-35-google-apis-arm64-v8a
-                system-images-android-35-google-apis-playstore-arm64-v8a
+                system-images-android-36-google-apis-arm64-v8a
+                system-images-android-36-google-apis-playstore-arm64-v8a
               ]
               ++ lib.optionals (system == "x86_64-darwin" || system == "x86_64-linux") [
-                system-images-android-35-google-apis-x86-64
-                system-images-android-35-google-apis-playstore-x86-64
+                system-images-android-36-google-apis-x86-64
+                system-images-android-36-google-apis-playstore-x86-64
               ]);
         };
 
@@ -115,10 +115,10 @@
             export GALOY_QUICKSTART_PATH="dev/vendor/galoy-quickstart"
 
             # Check if the AVD already exists
-            if ! avdmanager list avd -c | grep -q Pixel_API_35; then
-              # Determine ABI based on system architecture and create Pixel_API_35 Android Device
+            if ! avdmanager list avd -c | grep -q Pixel_API_36; then
+              # Determine ABI based on system architecture and create Pixel_API_36 Android Device
               if [ "${pkgs.stdenv.targetPlatform.system}" = "aarch64-darwin" ]; then ARCH="arm64-v8a"; else ARCH="x86_64"; fi
-              echo no | avdmanager create avd --force -n Pixel_API_35 --abi "google_apis_playstore/$ARCH" --package "system-images;android-35;google_apis_playstore;$ARCH" --device 'pixel_8'
+              echo no | avdmanager create avd --force -n Pixel_API_36 --abi "google_apis_playstore/$ARCH" --package "system-images;android-36;google_apis_playstore;$ARCH" --device 'pixel_8'
             fi
 
             XCODE_VERSION="26.5"


### PR DESCRIPTION
## Summary
- update Android build tooling and target SDK values to API 36
- update Nix Android SDK packages and emulator AVD from API 35 to API 36
- refresh flake lock inputs
