### PR TITLE
test(notifications): lock delivery gates to auth/permission, not account state

### DIFF
--- a/__tests__/components/push-notification.spec.tsx
+++ b/__tests__/components/push-notification.spec.tsx
@@ -1,8 +1,10 @@
 import React from "react"
-import { render } from "@testing-library/react-native"
+import { render, waitFor } from "@testing-library/react-native"
 
 import { PushNotificationComponent } from "@app/components/push-notification/push-notification"
 import { BulletinsDocument } from "@app/graphql/generated"
+
+import { flushEffects } from "../helpers/flush-effects"
 
 const mockRefetchQueries = jest.fn()
 jest.mock("@apollo/client", () => ({
@@ -12,13 +14,16 @@ jest.mock("@apollo/client", () => ({
   }),
 }))
 
+let mockIsAuthed = true
 jest.mock("@app/graphql/is-authed-context", () => ({
-  useIsAuthed: () => true,
+  useIsAuthed: () => mockIsAuthed,
 }))
 
+const mockHasNotificationPermission = jest.fn()
+const mockAddDeviceToken = jest.fn()
 jest.mock("@app/utils/notifications", () => ({
-  hasNotificationPermission: jest.fn(() => Promise.resolve(false)),
-  addDeviceToken: jest.fn(),
+  hasNotificationPermission: () => mockHasNotificationPermission(),
+  addDeviceToken: (client: unknown) => mockAddDeviceToken(client),
 }))
 
 let onMessageCallback: (msg: Record<string, unknown>) => void
@@ -43,6 +48,8 @@ jest.mock("@react-native-firebase/messaging", () => {
 describe("PushNotificationComponent", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockIsAuthed = true
+    mockHasNotificationPermission.mockResolvedValue(false)
   })
 
   it("renders without crashing", () => {
@@ -61,5 +68,36 @@ describe("PushNotificationComponent", () => {
     const { unmount } = render(<PushNotificationComponent />)
     unmount()
     expect(mockUnsubscribe).toHaveBeenCalled()
+  })
+
+  /** Delivery gates: token registration must depend on auth + permission only —
+   *  never on account state such as a lightning address. */
+  describe("device token registration", () => {
+    it("registers device token when authed with notification permission", async () => {
+      mockHasNotificationPermission.mockResolvedValue(true)
+
+      render(<PushNotificationComponent />)
+
+      await waitFor(() => expect(mockAddDeviceToken).toHaveBeenCalledTimes(1))
+    })
+
+    it("does not register device token when not authed", async () => {
+      mockIsAuthed = false
+      mockHasNotificationPermission.mockResolvedValue(true)
+
+      render(<PushNotificationComponent />)
+      await flushEffects()
+
+      expect(mockHasNotificationPermission).not.toHaveBeenCalled()
+      expect(mockAddDeviceToken).not.toHaveBeenCalled()
+    })
+
+    it("does not register device token without notification permission", async () => {
+      render(<PushNotificationComponent />)
+      await flushEffects()
+
+      expect(mockHasNotificationPermission).toHaveBeenCalledTimes(1)
+      expect(mockAddDeviceToken).not.toHaveBeenCalled()
+    })
   })
 })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -11,7 +11,9 @@ import {
   HomeAuthedDocument,
   HomeUnauthedDocument,
   Network,
+  useBulletinsQuery,
 } from "@app/graphql/generated"
+import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { mockCurrencyList } from "@app/graphql/mocks"
 import { ConvertDirection } from "@app/types/payment"
 
@@ -336,6 +338,16 @@ jest.mock("@app/graphql/mocks", () => {
       // mounted components, keeping Apollo's MockLink warning-free.
       return [...currentMocks, ...actual.default]
     },
+  }
+})
+
+jest.mock("@app/graphql/generated", () => {
+  const actual = jest.requireActual("@app/graphql/generated")
+  return {
+    ...actual,
+    /** Passthrough spy: the real query still runs against MockedProvider; the spy
+     *  only records call args so the bulletins auth skip-gate can be asserted. */
+    useBulletinsQuery: jest.fn((opts: unknown) => actual.useBulletinsQuery(opts)),
   }
 })
 
@@ -1719,5 +1731,50 @@ describe("HomeScreen wind-down states", () => {
     onMigrate()
 
     expect(mockNavigate).toHaveBeenCalledWith("accountMigrationEntry")
+  })
+})
+
+describe("bulletins auth gating", () => {
+  const mockUseBulletinsQuery = useBulletinsQuery as jest.Mock
+
+  beforeEach(() => {
+    currentMocks = []
+    jest.clearAllMocks()
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: null,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it("requests bulletins when authed", async () => {
+    render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(mockUseBulletinsQuery).toHaveBeenCalled()
+    expect(mockUseBulletinsQuery.mock.lastCall[0]).toEqual(
+      expect.objectContaining({ skip: false, variables: { first: 1 } }),
+    )
+  })
+
+  /** Regression lock: campaign bulletins are never fetched for unauthenticated
+   *  sessions — delivery is gated on auth alone, never on account state such as
+   *  a lightning address. */
+  it("skips bulletins query when not authed", async () => {
+    render(
+      <ContextForScreen>
+        <IsAuthedContextProvider value={false}>
+          <HomeScreen />
+        </IsAuthedContextProvider>
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(mockUseBulletinsQuery).toHaveBeenCalled()
+    expect(mockUseBulletinsQuery.mock.lastCall[0].skip).toBe(true)
   })
 })


### PR DESCRIPTION
## Background

Investigation of the question *"are users without a lightning address guaranteed to receive notifications?"* found no lightning-address trigger anywhere in notification delivery. The observed correlation (the "This is a non-custodial account" card appearing right after registering a lightning address) is timing: that card renders when the self-custodial account is active and its wallet is ready — the exact moment you are in the app to set the address. This PR locks the app-side delivery gates in with regression tests so the mobile app is demonstrably free of any account-state condition (such as a lightning address) in notification delivery.

## Changes

**`__tests__/components/push-notification.spec.tsx`** — refactored the hardcoded `useIsAuthed`/`hasNotificationPermission` mocks into per-test controllable ones (the 3 existing tests are unchanged) and added a `device token registration` describe:

- registers device token when authed with notification permission
- does not register device token when not authed (short-circuits before the permission check — an unauthed session has no push channel regardless of backend targeting)
- does not register device token without notification permission

**`__tests__/screens/home.spec.tsx`** — added a passthrough spy on `useBulletinsQuery` (delegates to the real hook; existing 52 tests unaffected) and a `bulletins auth gating` describe:

- requests bulletins when authed (`skip: false, variables: { first: 1 }`)
- skips bulletins query when not authed (`skip: true`) — campaign bulletins are never fetched for unauthenticated sessions

The third gate — the in-app `SelfCustodialInfoBulletin` card being restricted to active self-custodial accounts — is already covered by `__tests__/hooks/use-self-custodial-info-bulletin-state.spec.ts` (no changes needed).

## Test results

- `yarn jest --runTestsByPath __tests__/components/push-notification.spec.tsx __tests__/screens/home.spec.tsx` — 60/60 green (6 + 54)
- `yarn jest --runTestsByPath __tests__/hooks/use-self-custodial-info-bulletin-state.spec.ts` — 7/7 green (reference, unchanged)
- ESLint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)