### PR TITLE
fix(home): handle font scaling in header and clear bulletin footer overlap

### DIFF
--- a/__tests__/components/balance-header/balance-header.spec.tsx
+++ b/__tests__/components/balance-header/balance-header.spec.tsx
@@ -8,10 +8,11 @@ import { BalanceMode } from "@app/hooks/use-balance-mode"
 import { BalanceHeader } from "@app/components/balance-header/balance-header"
 
 const mockSwitchMemoryHideAmount = jest.fn()
+let mockHideAmount = false
 
 jest.mock("@app/graphql/hide-amount-context", () => ({
   useHideAmount: () => ({
-    hideAmount: false,
+    hideAmount: mockHideAmount,
     switchMemoryHideAmount: mockSwitchMemoryHideAmount,
   }),
 }))
@@ -37,6 +38,7 @@ const renderHeader = (props: Partial<React.ComponentProps<typeof BalanceHeader>>
 describe("BalanceHeader", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockHideAmount = false
   })
 
   it("renders the formatted balance", () => {
@@ -101,6 +103,23 @@ describe("BalanceHeader", () => {
     expect(getByTestId("balance-value").props.maxFontSizeMultiplier).toBeLessThanOrEqual(
       1.5,
     )
+  })
+
+  it("renders the hidden placeholder instead of the balance when the amount is hidden", () => {
+    mockHideAmount = true
+
+    const { getByText, queryByTestId } = renderHeader({ formattedBalance: "$42.00" })
+
+    expect(getByText("****")).toBeTruthy()
+    expect(queryByTestId("balance-value")).toBeNull()
+  })
+
+  it("caps font scaling on the hidden placeholder (blink-wip#931)", () => {
+    mockHideAmount = true
+
+    const { getByText } = renderHeader()
+
+    expect(getByText("****").props.maxFontSizeMultiplier).toBeLessThanOrEqual(1.5)
   })
 
   it("does not render the status badge by default", () => {

--- a/__tests__/components/balance-header/balance-header.spec.tsx
+++ b/__tests__/components/balance-header/balance-header.spec.tsx
@@ -95,6 +95,14 @@ describe("BalanceHeader", () => {
     expect(queryByTestId("balance-mode-toggle")).toBeNull()
   })
 
+  it("caps font scaling on the balance so it cannot overrun the header (blink-wip#931)", () => {
+    const { getByTestId } = renderHeader({ formattedBalance: "$42.00" })
+
+    expect(getByTestId("balance-value").props.maxFontSizeMultiplier).toBeLessThanOrEqual(
+      1.5,
+    )
+  })
+
   it("does not render the status badge by default", () => {
     const { queryByTestId } = renderHeader()
 

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -1824,6 +1824,35 @@ describe("HomeScreen layout under font scaling (blink-wip#931)", () => {
     expect(headerStyle.minHeight).toBeGreaterThanOrEqual(40)
   })
 
+  it("sizes the header row to its content so it cannot collapse under the min height", async () => {
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    // flex: 1 gives the row a zero flex-basis, so its content would stop
+    // contributing to the auto-height parent and clip again at minHeight.
+    const rowStyle = StyleSheet.flatten(getByTestId("home-header-row").props.style)
+    expect(rowStyle.flex).toBeUndefined()
+  })
+
+  it("keeps the settings menu button wired in the header", async () => {
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    fireEvent.press(getByTestId("home-settings-button"))
+
+    expect(mockNavigate).toHaveBeenCalledWith("settings")
+  })
+
   it("caps username font scaling so the header controls stay reachable", async () => {
     const { getByTestId } = render(
       <ContextForScreen>

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
 import { fireEvent, render, waitFor } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
 
 import { HomeScreen } from "../../app/screens/home-screen"
 import { ContextForScreen } from "./helper"
@@ -1776,5 +1777,65 @@ describe("bulletins auth gating", () => {
 
     expect(mockUseBulletinsQuery).toHaveBeenCalled()
     expect(mockUseBulletinsQuery.mock.lastCall[0].skip).toBe(true)
+  })
+})
+
+describe("HomeScreen layout under font scaling (blink-wip#931)", () => {
+  beforeEach(() => {
+    currentMocks = []
+    mockActiveWalletOverride = null
+    jest.clearAllMocks()
+    mockUseNonCustodialConversionLimits.mockReturnValue({
+      limits: null,
+      loading: false,
+      error: null,
+    })
+  })
+
+  it("pads the scroll content so the last bulletin clears the slide-up handle", async () => {
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    const contentStyle = StyleSheet.flatten(
+      getByTestId("home-screen").props.contentContainerStyle,
+    )
+    // The SlideUpHandle overlays the bottom 97pt (82pt touch area + 15pt offset);
+    // content must clear it so the last bulletin is readable at max scroll.
+    expect(contentStyle.paddingBottom).toBeGreaterThanOrEqual(97)
+  })
+
+  it("lets the header area grow with content instead of clipping at a fixed height", async () => {
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    const headerStyle = StyleSheet.flatten(getByTestId("home-header").props.style)
+    expect(headerStyle.height).toBeUndefined()
+    expect(headerStyle.maxHeight).toBeUndefined()
+    expect(headerStyle.minHeight).toBeGreaterThanOrEqual(40)
+  })
+
+  it("caps username font scaling so the header controls stay reachable", async () => {
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+
+    await flushEffects()
+
+    await waitFor(() => expect(getByTestId("home-username")).toBeTruthy())
+    expect(getByTestId("home-username").props.maxFontSizeMultiplier).toBeLessThanOrEqual(
+      1.5,
+    )
   })
 })

--- a/app/components/balance-header/balance-header.tsx
+++ b/app/components/balance-header/balance-header.tsx
@@ -11,6 +11,10 @@ import { testProps } from "@app/utils/testProps"
 
 import { StatusPill, type StatusPillVariant } from "../status-pill"
 
+/** The 32pt balance sits directly under the fixed-size home header chrome;
+ *  uncapped Dynamic Type makes it overrun the username row above. */
+const MAX_BALANCE_FONT_SIZE_MULTIPLIER = 1.4
+
 const Loader = () => {
   const styles = useStyles()
   return (
@@ -66,7 +70,12 @@ export const BalanceHeader: React.FC<Props> = ({
     <View {...testProps("balance-header")} style={styles.balanceHeaderContainer}>
       {hideAmount ? (
         <TouchableOpacity onPress={switchMemoryHideAmount}>
-          <Text style={styles.balanceHiddenText}>****</Text>
+          <Text
+            style={styles.balanceHiddenText}
+            maxFontSizeMultiplier={MAX_BALANCE_FONT_SIZE_MULTIPLIER}
+          >
+            ****
+          </Text>
         </TouchableOpacity>
       ) : (
         <TouchableOpacity onPress={switchMemoryHideAmount}>
@@ -86,6 +95,7 @@ export const BalanceHeader: React.FC<Props> = ({
                 {...testProps("balance-value")}
                 style={styles.primaryBalanceText}
                 allowFontScaling
+                maxFontSizeMultiplier={MAX_BALANCE_FONT_SIZE_MULTIPLIER}
                 adjustsFontSizeToFit
               >
                 {formattedBalance}

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -96,6 +96,13 @@ const UPGRADE_MODAL_INITIAL_DELAY_MS = 1500
 /** Floor for conversions without a pool minimum (custodial intraledger always,
  *  self-custodial when the SDK reports none): any positive cent converts. */
 const ANY_POSITIVE_CENT_MINIMUM = 1
+/** The SlideUpHandle floats over the bottom 97pt of the scroll view (82pt touch
+ *  area anchored 15pt up); content needs at least that much bottom padding for
+ *  the last bulletin to be readable at max scroll. */
+const SCROLL_BOTTOM_CLEARANCE = 100
+/** Header chrome (username row, balance) sits between fixed-size icon buttons;
+ *  uncapped Dynamic Type pushes the settings menu out of reach. */
+const MAX_HEADER_FONT_SIZE_MULTIPLIER = 1.4
 
 gql`
   query homeAuthed {
@@ -702,7 +709,7 @@ export const HomeScreen: React.FC = () => {
         deadlineTimestamp={migrateNowPrompt.deadlineTimestamp}
         timezone={migrateNowPrompt.timezone}
       />
-      <View style={styles.balanceContainer}>
+      <View {...testProps("home-header")} style={styles.balanceContainer}>
         <View style={styles.header}>
           <GaloyIconButton
             onPress={() => navigation.navigate("priceHistory")}
@@ -715,7 +722,13 @@ export const HomeScreen: React.FC = () => {
             {!loading && usernameTitle && (
               <Pressable onPress={canSwitchAccount ? handleSwitchPress : null}>
                 <View style={styles.profileContainer}>
-                  <Text type="p2">{usernameTitle}</Text>
+                  <Text
+                    {...testProps("home-username")}
+                    type="p2"
+                    maxFontSizeMultiplier={MAX_HEADER_FONT_SIZE_MULTIPLIER}
+                  >
+                    {usernameTitle}
+                  </Text>
                   {canSwitchAccount && <GaloyIcon name={"caret-down"} size={18} />}
                 </View>
               </Pressable>
@@ -831,7 +844,7 @@ export const HomeScreen: React.FC = () => {
 const useStyles = makeStyles(({ colors }) => ({
   scrollViewContainer: {
     paddingHorizontal: 20,
-    paddingBottom: 20,
+    paddingBottom: SCROLL_BOTTOM_CLEARANCE,
     rowGap: 20,
   },
   listItemsContainer: {
@@ -895,13 +908,10 @@ const useStyles = makeStyles(({ colors }) => ({
   balanceContainer: {
     marginTop: 7,
     flexDirection: "column",
-    flex: 1,
-    height: 40,
-    maxHeight: 40,
+    minHeight: 40,
   },
   header: {
     flexDirection: "row",
-    flex: 1,
     justifyContent: "space-between",
     alignItems: "center",
     marginHorizontal: 20,

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -710,7 +710,7 @@ export const HomeScreen: React.FC = () => {
         timezone={migrateNowPrompt.timezone}
       />
       <View {...testProps("home-header")} style={styles.balanceContainer}>
-        <View style={styles.header}>
+        <View {...testProps("home-header-row")} style={styles.header}>
           <GaloyIconButton
             onPress={() => navigation.navigate("priceHistory")}
             size={"medium"}
@@ -735,6 +735,7 @@ export const HomeScreen: React.FC = () => {
             )}
           </View>
           <GaloyIconButton
+            {...testProps("home-settings-button")}
             onPress={() => navigation.navigate("settings")}
             size={"medium"}
             name="menu"


### PR DESCRIPTION
## Summary

Fixes the two home-screen clippings reported in blinkbitcoin/blink-wip#931:

**Header (username clipped, hamburger unreachable at larger font sizes)**
- `balanceContainer` was locked to `height: 40, maxHeight: 40` while the username text scales with iOS Dynamic Type — enlarged text clipped, overlapped the 32pt balance below, and displaced the settings menu tap target. Now `minHeight: 40` so the header grows with content.
- Username and balance text are capped at 1.4× font scale (`maxFontSizeMultiplier`) so the header chrome holds together at all accessibility sizes while still scaling.

**Footer (last bulletin clipped behind the bottom bar)**
- Scroll content ended only 20pt above the bottom edge, inside the `SlideUpHandle` overlay zone (82pt touch area anchored 15pt up), so the last bulletin card sat under the chevron even at max scroll. Bottom padding is now 100pt to clear the handle.

## Test plan

- [x] New specs cover every changed behavior: scroll content clears the handle overlay, header uses growable min-height and content-sized row, username/balance/hidden-placeholder font caps, settings button wiring (`home.spec.tsx`, `balance-header.spec.tsx`)
- [x] `balance-header.tsx` at 100% statement/branch/function coverage; font-cap tests mutation-verified
- [x] Existing home + balance-header suites pass (73 tests)
- [x] `tsc` and `eslint` clean
- [ ] Manual check on iOS with enlarged text size (Settings → Accessibility → Display & Text Size)

Fixes blinkbitcoin/blink-wip#931

🤖 Generated with [Claude Code](https://claude.com/claude-code)
