### PR TITLE
chore: remove personal name references from code comments

### DIFF
--- a/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
+++ b/__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx
@@ -227,7 +227,7 @@ describe("MigrationContactSupportScreen", () => {
     expect(mockUseMigrationSupportEmail).toHaveBeenCalledWith("start-refused")
   })
 
-  /** Lukas's rule: the error screen is the support channel, so what failed is on the screen,
+  /** The error screen is the support channel, so what failed is on the screen,
    *  the reason code included, not just in the email. */
   it("shows the reason code on the screen", async () => {
     mockReason = MigrationSupportReason.SelfCustodialAccountMissing

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -606,7 +606,7 @@ export const HomeScreen: React.FC = () => {
     },
   ]
 
-  // Do not change this condition without checking with Lukas first
+  // Do not change this condition without product sign-off
   const shouldShowTransferButton =
     !isIos ||
     (isIos && satsBalance > 0) ||


### PR DESCRIPTION
## Summary

Removes the two remaining references to a team member's name in code comments, keeping each comment's actual guidance intact:

- `app/screens/home-screen/home-screen.tsx`: the guard comment on the iOS transfer-button condition now asks for product sign-off instead of naming a person.
- `__tests__/screens/account-migration/to-non-custodial/contact-support-screen.spec.tsx`: the test doc comment now states the rule without attribution.

No functional changes — comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)