### PR TITLE
revert(home): show the transfer button as disabled (#3939)

### DIFF
--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -628,7 +628,6 @@ const selfCustodialReadyWalletOverride = (usdBalance: number) => ({
   needsBackendAuth: false,
 })
 
-// eslint-disable-next-line max-lines-per-function
 describe("HomeScreen", () => {
   beforeEach(() => {
     currentMocks = []
@@ -688,9 +687,7 @@ describe("HomeScreen", () => {
     },
   )
 
-  const testDisabledTransferButton = async (
-    shouldShowDollarTransferDisabledModal: boolean = true,
-  ) => {
+  it("hides the transfer button when transfers are blocked", async () => {
     mockTransferBlockedOverride = true
     currentMocks = generateHomeMock({
       level: AccountLevel.Two,
@@ -705,69 +702,8 @@ describe("HomeScreen", () => {
       </ContextForScreen>,
     )
 
+    await waitFor(() => expect(() => getByTestId("transfer")).toThrow())
     await flushEffects()
-
-    // Transfers are blocked, but the button is rendered in disabled stat.
-    expect(getByTestId("transfer")).toBeTruthy()
-    expect(mockDollarBalanceModalVisible).toBe(false)
-
-    fireEvent.press(getByTestId("transfer"))
-
-    expect(mockDollarBalanceModalVisible).toBe(shouldShowDollarTransferDisabledModal)
-  }
-
-  it("Disable the transfer button when transfers are blocked and show disabled model when clicked", async () => {
-    await testDisabledTransferButton()
-  })
-
-  it("self custodial with only Bitcoin disables the transfer button when transfers are blocked and show disabled model when clicked", async () => {
-    mockActiveWalletOverride = {
-      wallets: [
-        {
-          id: "btc-1",
-          walletCurrency: "BTC",
-          balance: { amount: 5000, currency: "BTC", currencyCode: "BTC" },
-          transactions: [],
-        },
-      ],
-      status: "ready",
-      accountType: "self-custodial",
-      isReady: true,
-      isSelfCustodial: true,
-      needsBackendAuth: false,
-    }
-
-    await testDisabledTransferButton()
-
-    mockActiveWalletOverride = null
-  })
-
-  it("self custodial with both Bitcoin and USD disables the transfer button when transfers are blocked and show disabled model when clicked", async () => {
-    mockActiveWalletOverride = {
-      wallets: [
-        {
-          id: "btc-1",
-          walletCurrency: "BTC",
-          balance: { amount: 5000, currency: "BTC", currencyCode: "BTC" },
-          transactions: [],
-        },
-        {
-          id: "usd-1",
-          walletCurrency: "USD",
-          balance: { amount: 5000, currency: "USD", currencyCode: "USD" },
-          transactions: [],
-        },
-      ],
-      status: "ready",
-      accountType: "self-custodial",
-      isReady: true,
-      isSelfCustodial: true,
-      needsBackendAuth: false,
-    }
-
-    await testDisabledTransferButton()
-
-    mockActiveWalletOverride = null
   })
 
   it("auto-opens the convert modal when a restricted account holds a Dollar balance", async () => {

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -69,8 +69,8 @@ import { getBtcWallet, getUsdWallet } from "@app/graphql/wallets-utils"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { UnclaimedDepositBanner } from "@app/components/unclaimed-deposit-banner"
 import { testProps } from "@app/utils/testProps"
-import { extractLightningAddressUsername } from "@app/utils/pay-links"
 import { isIos } from "@app/utils/helper"
+import { extractLightningAddressUsername } from "@app/utils/pay-links"
 import {
   useAppConfig,
   useAutoShowUpgradeModal,
@@ -606,22 +606,23 @@ export const HomeScreen: React.FC = () => {
     },
   ]
 
-  // Do not change this condition without product sign-off
-  const shouldShowTransferButton =
-    !isIos ||
-    (isIos && satsBalance > 0) ||
-    dataUnauthed?.globals?.network !== "mainnet" ||
-    levelAccount === AccountLevel.Two ||
-    levelAccount === AccountLevel.Three
+  const isIosWithBalance = isIos && satsBalance > 0
 
-  const isTransferDisabled = isDollarBalanceRestricted || isTransferBlocked
+  const shouldShowTransferButton =
+    !isTransferBlocked &&
+    (isSelfCustodial ||
+      !isIos ||
+      dataUnauthed?.globals?.network !== "mainnet" ||
+      levelAccount === AccountLevel.Two ||
+      levelAccount === AccountLevel.Three ||
+      isIosWithBalance)
 
   if (shouldShowTransferButton) {
     buttons.unshift({
       title: LL.ConversionDetailsScreen.transfer(),
       target: "conversionDetails",
       icon: "transfer",
-      disabled: isTransferDisabled,
+      disabled: isDollarBalanceRestricted,
       onDisabledPress: () => setIsRestrictionModalVisible(true),
     })
   }


### PR DESCRIPTION
Reverts blinkbitcoin/blink-mobile#3939 (commit 593e9041).

## Why

The sign-off on #3939 was reversed after merge: removing/relaxing the iOS transfer gate is deferred to a later, separate PR. This restores the previous home screen behavior and the tests that covered it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)