### PR TITLE
fix(android): BitcoinPriceWidget stored REALTIME_PRICE defaults to null

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,6 +135,12 @@ android {
             }
         }
     }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources true
+        }
+    }
 }
 
 dependencies {
@@ -158,6 +164,10 @@ dependencies {
 
     androidTestImplementation('com.wix:detox:+')
     implementation 'androidx.appcompat:appcompat:1.1.0'
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.test:core:1.6.0")
+    testImplementation("org.robolectric:robolectric:4.16")
 }
 
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -168,6 +168,8 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("androidx.test:core:1.6.0")
     testImplementation("org.robolectric:robolectric:4.16")
+    testImplementation("androidx.work:work-testing:2.9.0")
+
 }
 
 

--- a/android/app/src/main/java/com/galoyapp/BitcoinPriceWidget.kt
+++ b/android/app/src/main/java/com/galoyapp/BitcoinPriceWidget.kt
@@ -132,9 +132,8 @@ internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManage
     val prefs = context.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
     val priceArray = JSONArray(prefs.getString("PRICE_ARRAY", "[]"))
 
-    val realtimePrice = JSONObject(prefs.getString("REALTIME_PRICE", "No Data") ?: "{}")
-    if (!realtimePrice.has("noData")) {
-
+    val realtimePrice = JSONObject(prefs.getString("REALTIME_PRICE", null) ?: "{}")
+    if (realtimePrice.has("btcSatPrice")) {
         val bitmap = generateChartBitmap(context, priceArray, minWidth, maxHeight)
         views.setImageViewBitmap(R.id.chart_image_view, bitmap)
 

--- a/android/app/src/main/java/com/galoyapp/BitcoinPriceWidget.kt
+++ b/android/app/src/main/java/com/galoyapp/BitcoinPriceWidget.kt
@@ -34,6 +34,10 @@ import org.json.JSONObject
 import kotlin.math.pow
 
 class BitcoinPriceWidget : AppWidgetProvider() {
+    companion object {
+        internal const val FETCH_PRICE_WORK_TAG = "FETCH_PRICE_WORK"
+    }
+
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         for (appWidgetId in appWidgetIds) {
             updateAppWidget(context, appWidgetManager, appWidgetId)
@@ -46,10 +50,12 @@ class BitcoinPriceWidget : AppWidgetProvider() {
         val immediateWorkRequest = OneTimeWorkRequestBuilder<FetchPriceWorker>()
             .setInputData(Data.Builder().putString("RANGE", "ONE_DAY").build())
             .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .addTag(FETCH_PRICE_WORK_TAG)
             .build()
 
         val periodicWorkRequest = PeriodicWorkRequestBuilder<FetchPriceWorker>(15, TimeUnit.MINUTES)
             .setInputData(Data.Builder().putString("RANGE", "ONE_DAY").build())
+            .addTag(FETCH_PRICE_WORK_TAG)
             .build()
 
         WorkManager.getInstance(context).apply {
@@ -65,7 +71,7 @@ class BitcoinPriceWidget : AppWidgetProvider() {
     }
 
     override fun onDisabled(context: Context) {
-        WorkManager.getInstance(context).cancelAllWorkByTag("FETCH_PRICE_WORK")
+        WorkManager.getInstance(context).cancelAllWorkByTag(FETCH_PRICE_WORK_TAG)
     }
 }
 
@@ -134,8 +140,12 @@ internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManage
 
     val realtimePrice = JSONObject(prefs.getString("REALTIME_PRICE", null) ?: "{}")
     if (realtimePrice.has("btcSatPrice")) {
-        val bitmap = generateChartBitmap(context, priceArray, minWidth, maxHeight)
-        views.setImageViewBitmap(R.id.chart_image_view, bitmap)
+        // The launcher may not have provided widget dimensions yet (options can be
+        // empty right after the widget is placed); Bitmap.createBitmap(0, 0) throws.
+        if (minWidth > 0 && maxHeight > 0) {
+            val bitmap = generateChartBitmap(context, priceArray, minWidth, maxHeight)
+            views.setImageViewBitmap(R.id.chart_image_view, bitmap)
+        }
 
         val btcSatBase = realtimePrice.getJSONObject("btcSatPrice").getLong("base")
         val btcSatOffset = realtimePrice.getJSONObject("btcSatPrice").getInt("offset")
@@ -171,9 +181,14 @@ enum class BitcoinPriceRanges {
 }
 
 class FetchPriceWorker(context: Context, params: WorkerParameters) : Worker(context, params) {
+    companion object {
+        // Replaceable in unit tests to stub out the network call.
+        internal var fetch: (BitcoinPriceRanges) -> JSONObject = ::fetchBitcoinPrice
+    }
+
     override fun doWork(): Result {
         val range = BitcoinPriceRanges.valueOf(inputData.getString("RANGE") ?: "ONE_DAY")
-        val jsonResponse = fetchBitcoinPrice(range)
+        val jsonResponse = fetch(range)
         val priceArray = jsonResponse.getJSONArray("btcPriceList")
         val realtimePrice = jsonResponse.getJSONObject("realtimePrice")
         val prefs =
@@ -201,25 +216,26 @@ class FetchPriceWorker(context: Context, params: WorkerParameters) : Worker(cont
         }
     }
 
-    private fun fetchBitcoinPrice(range: BitcoinPriceRanges): JSONObject {
-        val url = URL("https://api.blink.sv/graphql")
-        val query = "query BitcoinPriceForAppWidget(\$range: PriceGraphRange!) { btcPriceList(range: \$range) { timestamp price { base offset currencyUnit formattedAmount } } realtimePrice { btcSatPrice { base offset } timestamp usdCentPrice { base offset } } }"
-        val jsonInputString = """{ "query": "$query", "variables": { "range": "$range" } }"""
+}
 
-        with(url.openConnection() as HttpURLConnection) {
-            requestMethod = "POST"
-            setRequestProperty("Content-Type", "application/json")
-            doOutput = true
-            outputStream.use { os ->
-                os.write(jsonInputString.toByteArray())
+private fun fetchBitcoinPrice(range: BitcoinPriceRanges): JSONObject {
+    val url = URL("https://api.blink.sv/graphql")
+    val query = "query BitcoinPriceForAppWidget(\$range: PriceGraphRange!) { btcPriceList(range: \$range) { timestamp price { base offset currencyUnit formattedAmount } } realtimePrice { btcSatPrice { base offset } timestamp usdCentPrice { base offset } } }"
+    val jsonInputString = """{ "query": "$query", "variables": { "range": "$range" } }"""
+
+    with(url.openConnection() as HttpURLConnection) {
+        requestMethod = "POST"
+        setRequestProperty("Content-Type", "application/json")
+        doOutput = true
+        outputStream.use { os ->
+            os.write(jsonInputString.toByteArray())
+        }
+        return if (responseCode == HttpURLConnection.HTTP_OK) {
+            BufferedReader(InputStreamReader(inputStream)).use { br ->
+                JSONObject(br.readText()).getJSONObject("data")
             }
-            return if (responseCode == HttpURLConnection.HTTP_OK) {
-                BufferedReader(InputStreamReader(inputStream)).use { br ->
-                    JSONObject(br.readText()).getJSONObject("data")
-                }
-            } else {
-                JSONObject("{\"btcPriceList\": [], \"realtimePrice\": { \"noData\": true } }")
-            }
+        } else {
+            JSONObject("{\"btcPriceList\": [], \"realtimePrice\": { \"noData\": true } }")
         }
     }
 }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -1,0 +1,45 @@
+package com.galoyapp
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.view.View
+import android.widget.TextView
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowAppWidgetManager
+import com.galoyapp.R
+
+@RunWith(RobolectricTestRunner::class)
+class BitcoinPriceWidgetTest {
+    private var context: Context? = null
+    private var appWidgetManager: AppWidgetManager? = null
+    private var shadowAppWidgetManager: ShadowAppWidgetManager? = null
+
+    @Before
+    @Throws(Exception::class)
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        appWidgetManager = AppWidgetManager.getInstance(context)
+        shadowAppWidgetManager = Shadows.shadowOf(appWidgetManager)
+    }
+
+    @Test
+    fun shouldInflateViewAndAssignId() {
+        val widgetId =
+            shadowAppWidgetManager!!.createWidget(
+                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+            )
+        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+
+        Assert.assertEquals(
+            "Loadings…",
+            (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
+        )
+    }
+
+}

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -19,7 +19,9 @@ import org.robolectric.shadows.ShadowAppWidgetManager
 import com.galoyapp.R
 
 @RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@Config(
+    application = TestApplication::class
+)
 class BitcoinPriceWidgetTest {
     private var context: Context? = null
     private var appWidgetManager: AppWidgetManager? = null
@@ -31,18 +33,17 @@ class BitcoinPriceWidgetTest {
         context = ApplicationProvider.getApplicationContext()
         appWidgetManager = AppWidgetManager.getInstance(context)
         shadowAppWidgetManager = Shadows.shadowOf(appWidgetManager)
-
-        // Build a test-friendly configuration using a SynchronousExecutor
-        val config = Configuration.Builder()
-            .setExecutor(SynchronousExecutor())
-            .build()
-
-        // Explicitly initialize WorkManager for the Robolectric environment
-        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
     }
 
     @Test
-    fun shouldInflateViewAndAssignId() {
+    fun shouldInflateViewAndAssignIdWithoutDoingAnyWork() {
+        // Build a test-friendly configuration without an executor
+        val config = Configuration.Builder()
+            .build()
+
+        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
+
+        // Test loading the widget and check results without any logic executed
         val widgetId =
             shadowAppWidgetManager!!.createWidget(
                 BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
@@ -53,6 +54,28 @@ class BitcoinPriceWidgetTest {
             "Loading…",
             (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
         )
+    }
+
+    @Test
+    fun shouldInflateViewAndAssignIdWhileExecutingWork() {
+        // Build a test-friendly configuration using a SynchronousExecutor
+        val config = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .build()
+
+        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
+
+        // Wait for the work to be processed and check result is correct
+//        val widgetId =
+//            shadowAppWidgetManager!!.createWidget(
+//                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+//            )
+//        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+//
+//        Assert.assertEquals(
+//            "Loading…",
+//            (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
+//        )
     }
 
 }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -7,10 +7,16 @@ import android.view.View
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.TestWorkerBuilder
 import androidx.work.testing.WorkManagerTestInitHelper
 import java.util.concurrent.Executor
+import org.json.JSONObject
+import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -29,6 +35,7 @@ class BitcoinPriceWidgetTest {
     private var context: Context? = null
     private var appWidgetManager: AppWidgetManager? = null
     private var shadowAppWidgetManager: ShadowAppWidgetManager? = null
+    private val defaultFetch = FetchPriceWorker.fetch
 
     @Before
     @Throws(Exception::class)
@@ -45,12 +52,31 @@ class BitcoinPriceWidgetTest {
         shadowAppWidgetManager = Shadows.shadowOf(appWidgetManager)
     }
 
+    @After
+    fun tearDown() {
+        FetchPriceWorker.fetch = defaultFetch
+    }
+
+    private fun createWidget(): Int =
+        shadowAppWidgetManager!!.createWidget(
+            BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+        )
+
+    private fun seedStoredPrice() {
+        context!!.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
+            .edit()
+            // (50 / 10^6) * 100_000_000 / 100 = $50.00
+            .putString("REALTIME_PRICE", """{"btcSatPrice":{"base":50,"offset":6}}""")
+            .putString(
+                "PRICE_ARRAY",
+                """[{"price":{"formattedAmount":"49.5"}},{"price":{"formattedAmount":"50.5"}}]"""
+            )
+            .commit()
+    }
+
     @Test
     fun shouldInflateViewAndAssignIdWithoutDoingAnyWork() {
-        val widgetId =
-            shadowAppWidgetManager!!.createWidget(
-                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
-            )
+        val widgetId = createWidget()
         val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
 
         Assert.assertEquals(
@@ -61,10 +87,7 @@ class BitcoinPriceWidgetTest {
 
     @Test
     fun showsErrorStateWhenNoStoredPrice() {
-        val widgetId =
-            shadowAppWidgetManager!!.createWidget(
-                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
-            )
+        val widgetId = createWidget()
         val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
 
         Assert.assertEquals(View.VISIBLE, widgetView.findViewById<View>(R.id.error_message).visibility)
@@ -74,20 +97,9 @@ class BitcoinPriceWidgetTest {
 
     @Test
     fun showsFormattedPriceWhenStoredPriceExists() {
-        val widgetId =
-            shadowAppWidgetManager!!.createWidget(
-                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
-            )
+        val widgetId = createWidget()
 
-        context!!.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
-            .edit()
-            // (50 / 10^6) * 100_000_000 / 100 = $50.00
-            .putString("REALTIME_PRICE", """{"btcSatPrice":{"base":50,"offset":6}}""")
-            .putString(
-                "PRICE_ARRAY",
-                """[{"price":{"formattedAmount":"49.5"}},{"price":{"formattedAmount":"50.5"}}]"""
-            )
-            .commit()
+        seedStoredPrice()
         val options = Bundle().apply {
             putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 320)
             putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, 200)
@@ -106,17 +118,90 @@ class BitcoinPriceWidgetTest {
     }
 
     @Test
-    fun schedulesPriceFetchWorkOnEnabled() {
-        shadowAppWidgetManager!!.createWidget(
-            BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+    fun rendersPriceWithoutChartWhenWidgetHasNoSizeYet() {
+        val widgetId = createWidget()
+        seedStoredPrice()
+
+        // No updateAppWidgetOptions: the launcher has not sized the widget, so
+        // OPTION_APPWIDGET_MIN_WIDTH/MAX_HEIGHT are 0. Must not crash in
+        // Bitmap.createBitmap ("width and height must be > 0").
+        updateAppWidget(context!!, appWidgetManager!!, widgetId)
+        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+
+        Assert.assertEquals(
+            "$50.00",
+            (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
         )
+    }
+
+    @Test
+    fun schedulesPriceFetchWorkOnEnabled() {
+        createWidget()
 
         val workInfos = WorkManager.getInstance(context!!)
-            .getWorkInfosByTag(FetchPriceWorker::class.java.name)
+            .getWorkInfosByTag(BitcoinPriceWidget.FETCH_PRICE_WORK_TAG)
             .get()
 
         // onEnabled enqueues one immediate and one periodic fetch.
         Assert.assertEquals(2, workInfos.size)
+    }
+
+    @Test
+    fun cancelsScheduledWorkOnDisabled() {
+        createWidget()
+
+        BitcoinPriceWidget().onDisabled(context!!)
+
+        val workInfos = WorkManager.getInstance(context!!)
+            .getWorkInfosByTag(BitcoinPriceWidget.FETCH_PRICE_WORK_TAG)
+            .get()
+        Assert.assertTrue(workInfos.isNotEmpty())
+        Assert.assertTrue(workInfos.all { it.state == WorkInfo.State.CANCELLED })
+    }
+
+    @Test
+    fun workerStoresFetchedPriceData() {
+        FetchPriceWorker.fetch = {
+            JSONObject(
+                """{"btcPriceList":[{"price":{"formattedAmount":"49.5"}}],
+                    "realtimePrice":{"btcSatPrice":{"base":50,"offset":6}}}"""
+            )
+        }
+        val worker = TestWorkerBuilder.from(context!!, FetchPriceWorker::class.java, SynchronousExecutor())
+            .setInputData(Data.Builder().putString("RANGE", "ONE_DAY").build())
+            .build()
+
+        val result = worker.doWork()
+
+        Assert.assertTrue(result is ListenableWorker.Result.Success)
+        val prefs = context!!.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
+        Assert.assertTrue(
+            JSONObject(prefs.getString("REALTIME_PRICE", "{}")!!).has("btcSatPrice")
+        )
+        Assert.assertEquals(
+            "49.5",
+            org.json.JSONArray(prefs.getString("PRICE_ARRAY", "[]"))
+                .getJSONObject(0).getJSONObject("price").getString("formattedAmount")
+        )
+    }
+
+    @Test
+    fun workerStoresErrorPayloadAndWidgetShowsErrorWhenFetchFails() {
+        val widgetId = createWidget()
+        // What fetchBitcoinPrice returns on a non-200 response.
+        FetchPriceWorker.fetch = {
+            JSONObject("""{"btcPriceList": [], "realtimePrice": { "noData": true } }""")
+        }
+        val worker = TestWorkerBuilder.from(context!!, FetchPriceWorker::class.java, SynchronousExecutor())
+            .setInputData(Data.Builder().putString("RANGE", "ONE_DAY").build())
+            .build()
+
+        worker.doWork()
+
+        updateAppWidget(context!!, appWidgetManager!!, widgetId)
+        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+        Assert.assertEquals(View.VISIBLE, widgetView.findViewById<View>(R.id.error_message).visibility)
+        Assert.assertEquals(View.GONE, widgetView.findViewById<View>(R.id.btc_price).visibility)
     }
 
 }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -11,10 +11,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
+import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowAppWidgetManager
 import com.galoyapp.R
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class)
 class BitcoinPriceWidgetTest {
     private var context: Context? = null
     private var appWidgetManager: AppWidgetManager? = null
@@ -37,7 +39,7 @@ class BitcoinPriceWidgetTest {
         val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
 
         Assert.assertEquals(
-            "Loadings…",
+            "Loading…",
             (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
         )
     }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -66,16 +66,16 @@ class BitcoinPriceWidgetTest {
         WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
 
         // Wait for the work to be processed and check result is correct
-//        val widgetId =
-//            shadowAppWidgetManager!!.createWidget(
-//                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
-//            )
-//        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
-//
-//        Assert.assertEquals(
-//            "Loading…",
-//            (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
-//        )
+        val widgetId =
+            shadowAppWidgetManager!!.createWidget(
+                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+            )
+        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+
+        Assert.assertEquals(
+            "21/everything",
+            (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
+        )
     }
 
 }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -2,12 +2,15 @@ package com.galoyapp
 
 import android.appwidget.AppWidgetManager
 import android.content.Context
+import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
+import androidx.work.WorkManager
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
+import java.util.concurrent.Executor
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -31,19 +34,19 @@ class BitcoinPriceWidgetTest {
     @Throws(Exception::class)
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
+        // onEnabled schedules FetchPriceWorker; give it a test WorkManager whose
+        // worker executor drops tasks so no worker (and no network fetch) runs.
+        val config = Configuration.Builder()
+            .setExecutor(Executor { })
+            .setTaskExecutor(SynchronousExecutor())
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
         appWidgetManager = AppWidgetManager.getInstance(context)
         shadowAppWidgetManager = Shadows.shadowOf(appWidgetManager)
     }
 
     @Test
     fun shouldInflateViewAndAssignIdWithoutDoingAnyWork() {
-        // Build a test-friendly configuration without an executor
-        val config = Configuration.Builder()
-            .build()
-
-        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
-
-        // Test loading the widget and check results without any logic executed
         val widgetId =
             shadowAppWidgetManager!!.createWidget(
                 BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
@@ -51,31 +54,69 @@ class BitcoinPriceWidgetTest {
         val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
 
         Assert.assertEquals(
-            "Loading…",
+            context!!.getString(R.string.loading),
             (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
         )
     }
 
     @Test
-    fun shouldInflateViewAndAssignIdWhileExecutingWork() {
-        // Build a test-friendly configuration using a SynchronousExecutor
-        val config = Configuration.Builder()
-            .setExecutor(SynchronousExecutor())
-            .build()
-
-        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
-
-        // Wait for the work to be processed and check result is correct
+    fun showsErrorStateWhenNoStoredPrice() {
         val widgetId =
             shadowAppWidgetManager!!.createWidget(
                 BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
             )
         val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
 
+        Assert.assertEquals(View.VISIBLE, widgetView.findViewById<View>(R.id.error_message).visibility)
+        Assert.assertEquals(View.GONE, widgetView.findViewById<View>(R.id.btc_price).visibility)
+        Assert.assertEquals(View.GONE, widgetView.findViewById<View>(R.id.btc_price_label).visibility)
+    }
+
+    @Test
+    fun showsFormattedPriceWhenStoredPriceExists() {
+        val widgetId =
+            shadowAppWidgetManager!!.createWidget(
+                BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+            )
+
+        context!!.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
+            .edit()
+            // (50 / 10^6) * 100_000_000 / 100 = $50.00
+            .putString("REALTIME_PRICE", """{"btcSatPrice":{"base":50,"offset":6}}""")
+            .putString(
+                "PRICE_ARRAY",
+                """[{"price":{"formattedAmount":"49.5"}},{"price":{"formattedAmount":"50.5"}}]"""
+            )
+            .commit()
+        val options = Bundle().apply {
+            putInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 320)
+            putInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, 200)
+        }
+        appWidgetManager!!.updateAppWidgetOptions(widgetId, options)
+
+        updateAppWidget(context!!, appWidgetManager!!, widgetId)
+        val widgetView = shadowAppWidgetManager!!.getViewFor(widgetId)
+
         Assert.assertEquals(
-            "21/everything",
+            "$50.00",
             (widgetView.findViewById<View?>(R.id.btc_price) as TextView).getText().toString()
         )
+        Assert.assertEquals(View.VISIBLE, widgetView.findViewById<View>(R.id.btc_price).visibility)
+        Assert.assertEquals(View.GONE, widgetView.findViewById<View>(R.id.error_message).visibility)
+    }
+
+    @Test
+    fun schedulesPriceFetchWorkOnEnabled() {
+        shadowAppWidgetManager!!.createWidget(
+            BitcoinPriceWidget::class.java, R.layout.bitcoin_price_widget
+        )
+
+        val workInfos = WorkManager.getInstance(context!!)
+            .getWorkInfosByTag(FetchPriceWorker::class.java.name)
+            .get()
+
+        // onEnabled enqueues one immediate and one periodic fetch.
+        Assert.assertEquals(2, workInfos.size)
     }
 
 }

--- a/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
+++ b/android/app/src/test/java/com/galoyapp/BitcoinPriceWidgetTest.kt
@@ -5,6 +5,9 @@ import android.content.Context
 import android.view.View
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -28,6 +31,14 @@ class BitcoinPriceWidgetTest {
         context = ApplicationProvider.getApplicationContext()
         appWidgetManager = AppWidgetManager.getInstance(context)
         shadowAppWidgetManager = Shadows.shadowOf(appWidgetManager)
+
+        // Build a test-friendly configuration using a SynchronousExecutor
+        val config = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .build()
+
+        // Explicitly initialize WorkManager for the Robolectric environment
+        WorkManagerTestInitHelper.initializeTestWorkManager(context!!, config)
     }
 
     @Test

--- a/android/app/src/test/java/com/galoyapp/TestApplication.java
+++ b/android/app/src/test/java/com/galoyapp/TestApplication.java
@@ -1,0 +1,6 @@
+package com.galoyapp;
+
+import android.app.Application;
+
+public class TestApplication  extends Application {
+}


### PR DESCRIPTION
The Bitcoin price widget crashed its broadcast receiver when no realtime price has been stored yet because it used "No data" as a default value and would only provide a empty json object if it found a null on the REALTIME_PRICE key.

Just replacing the default value with null fixes the problem. 

Second problem was that it would check for a `noData` key in the json object, which I guess would be returned from the backend if the backend had no data to provide. Fix for the second problem would be checking if the json had object had the desired `btcSatPrice` key with the price data (might need to confirm the backend doesn't return this when there's errors).  

Replicated the problem and tested the solution by removing the `REALTIME_PRICE` preference in the BitcoinPriceWidget onEnabled.

```
super.onEnabled(context)

val prefs = context.getSharedPreferences("bitcoinPricePrefs", Context.MODE_PRIVATE)
prefs.edit().remove("REALTIME_PRICE").apply()
```


<img width="410" height="915" alt="image" src="https://github.com/user-attachments/assets/9cc95658-66aa-4ef4-8a2c-2d7fc8780cdb" />
