### PR TITLE
fix(ci): purge build caches and trash in mac worker disk cleanup

### DIFF
--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -26,6 +26,10 @@ free_gb() {
   awk "BEGIN { printf \"%.1f\", $(free_kb) / 1024 / 1024 }"
 }
 
+kb_to_gb() {
+  awk -v kb="$1" 'BEGIN { printf "%.1f", kb / 1024 / 1024 }'
+}
+
 free_space_below_target() {
   (( $(free_kb) < required_kb ))
 }
@@ -73,6 +77,10 @@ unique_paths() {
 }
 
 build_cache_dirs() {
+  # /private/var/root/Library/Caches is listed whole, not per-tool like the
+  # user homes: root runs of Yarn/CocoaPods/etc. scatter caches across it and
+  # everything under it is droppable on a CI worker (20 GB of mixed root
+  # caches in the 2026-07-23 incident). Keep it whole-dir.
   unique_paths \
     "/private/var/root/Library/Caches" \
     "/private/var/root/.gradle/caches" \
@@ -171,6 +179,7 @@ print_disk_report() {
     "$BUILD_HOME/Library/Developer/CoreSimulator/Devices" \
     "/Users/m1/Library/Developer/CoreSimulator/Devices")
 
+  echo "---- Build caches and trash ----"
   while IFS= read -r path; do
     if [[ -e "$path" ]]; then
       du -sh "$path" 2>/dev/null || true
@@ -221,7 +230,7 @@ cleanup_xcode_artifacts() {
   root_derived_data_size_kb="$(path_size_kb "$root_derived_data")"
   if free_space_below_target || (( root_derived_data_size_kb > root_derived_data_max_kb )); then
     echo "Removing root-owned Xcode DerivedData caches from $root_derived_data"
-    echo "Reason: free disk $(free_gb) GB, root DerivedData $((root_derived_data_size_kb / 1024 / 1024)) GB, cap ${ROOT_DERIVED_DATA_MAX_GB} GB"
+    echo "Reason: free disk $(free_gb) GB, root DerivedData $(kb_to_gb "$root_derived_data_size_kb") GB, cap ${ROOT_DERIVED_DATA_MAX_GB} GB"
     remove_all_children "$root_derived_data"
   fi
 }
@@ -230,12 +239,30 @@ cleanup_concourse_dead_volumes() {
   remove_all_children "$CONCOURSE_WORKDIR/volumes/dead"
 }
 
+gradle_daemons_stopped=""
+
 stop_gradle_daemons() {
   # A live daemon holds references into .gradle/caches; purging under it makes
-  # the next build fail with "Could not read workspace metadata".
+  # the next build fail with "Could not read workspace metadata". No build can
+  # be in flight here: build jobs and this cleanup all hold the
+  # mobile-concourse lock (ci/pipeline.yml), so any daemon found is idle.
+  [[ -n "$gradle_daemons_stopped" ]] && return
+  gradle_daemons_stopped=1
+
   echo "Stopping Gradle daemons before purging Gradle caches"
   pkill -f GradleDaemon 2>/dev/null || true
-  sleep 1
+
+  local waited=0
+  while pgrep -f GradleDaemon >/dev/null 2>&1 && (( waited < 15 )); do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if pgrep -f GradleDaemon >/dev/null 2>&1; then
+    echo "Gradle daemons still running after ${waited}s; force-killing"
+    pkill -9 -f GradleDaemon 2>/dev/null || true
+    sleep 1
+  fi
 }
 
 cleanup_build_caches() {
@@ -248,10 +275,11 @@ cleanup_build_caches() {
     size_kb="$(path_size_kb "$dir")"
     if free_space_below_target || (( size_kb > build_cache_max_kb )); then
       echo "Removing build cache $dir"
-      echo "Reason: free disk $(free_gb) GB, cache size $((size_kb / 1024 / 1024)) GB, cap ${BUILD_CACHE_MAX_GB} GB"
+      echo "Reason: free disk $(free_gb) GB, cache size $(kb_to_gb "$size_kb") GB, cap ${BUILD_CACHE_MAX_GB} GB"
       if [[ "$dir" == */.gradle/caches ]]; then
         stop_gradle_daemons
         remove_path "${dir%/caches}/daemon"
+        remove_path "${dir%/caches}/wrapper/dists"
       fi
       remove_all_children "$dir"
     fi

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -7,6 +7,7 @@ MIN_FREE_GB="${MIN_BUILD_FREE_GB:-${2:-30}}"
 HARD_MIN_FREE_GB="${MIN_BUILD_HARD_FREE_GB:-10}"
 XCODE_ARTIFACT_MAX_AGE_DAYS="${XCODE_ARTIFACT_MAX_AGE_DAYS:-14}"
 ROOT_DERIVED_DATA_MAX_GB="${ROOT_DERIVED_DATA_MAX_GB:-20}"
+BUILD_CACHE_MAX_GB="${BUILD_CACHE_MAX_GB:-5}"
 CI_ROOT="${CI_ROOT:-$(pwd)}"
 DISK_CHECK_PATH="${DISK_CHECK_PATH:-$CI_ROOT}"
 CONCOURSE_WORKDIR="${CONCOURSE_WORKDIR:-/Users/m1/concourse/workdir}"
@@ -15,6 +16,7 @@ BUILD_HOME="${HOME:-/Users/m1}"
 required_kb=$((MIN_FREE_GB * 1024 * 1024))
 hard_required_kb=$((HARD_MIN_FREE_GB * 1024 * 1024))
 root_derived_data_max_kb=$((ROOT_DERIVED_DATA_MAX_GB * 1024 * 1024))
+build_cache_max_kb=$((BUILD_CACHE_MAX_GB * 1024 * 1024))
 
 free_kb() {
   df -Pk "$DISK_CHECK_PATH" | awk 'NR == 2 { print $4 }'
@@ -68,6 +70,27 @@ remove_all_children() {
 
 unique_paths() {
   printf "%s\n" "$@" | awk 'NF && !seen[$0]++'
+}
+
+build_cache_dirs() {
+  unique_paths \
+    "/private/var/root/Library/Caches" \
+    "/private/var/root/.gradle/caches" \
+    "$BUILD_HOME/.gradle/caches" \
+    "$BUILD_HOME/Library/Caches/Yarn" \
+    "$BUILD_HOME/Library/Caches/CocoaPods" \
+    "$BUILD_HOME/Library/Caches/node-gyp" \
+    "/Users/m1/.gradle/caches" \
+    "/Users/m1/Library/Caches/Yarn" \
+    "/Users/m1/Library/Caches/CocoaPods" \
+    "/Users/m1/Library/Caches/node-gyp"
+}
+
+trash_dirs() {
+  unique_paths \
+    "/private/var/root/.Trash" \
+    "$BUILD_HOME/.Trash" \
+    "/Users/m1/.Trash"
 }
 
 current_ios_runtime_version() {
@@ -144,7 +167,22 @@ print_disk_report() {
     "$BUILD_HOME/Library/Developer/Xcode/DerivedData" \
     "/Users/m1/Library/Developer/Xcode/Archives" \
     "/Users/m1/Library/Developer/Xcode/DerivedData" \
-    "/Library/Developer/CoreSimulator/Volumes")
+    "/Library/Developer/CoreSimulator/Volumes" \
+    "$BUILD_HOME/Library/Developer/CoreSimulator/Devices" \
+    "/Users/m1/Library/Developer/CoreSimulator/Devices")
+
+  while IFS= read -r path; do
+    if [[ -e "$path" ]]; then
+      du -sh "$path" 2>/dev/null || true
+    fi
+  done < <(build_cache_dirs; trash_dirs)
+
+  echo "---- Top consumers in build homes ----"
+  while IFS= read -r path; do
+    if [[ -d "$path" ]]; then
+      du -xh -d1 "$path" 2>/dev/null | sort -rh | head -10 || true
+    fi
+  done < <(unique_paths "/private/var/root" "$BUILD_HOME" "/Users/m1")
 
   echo "---- iOS simulator runtimes ----"
   if command -v xcrun >/dev/null 2>&1; then
@@ -190,6 +228,26 @@ cleanup_xcode_artifacts() {
 
 cleanup_concourse_dead_volumes() {
   remove_all_children "$CONCOURSE_WORKDIR/volumes/dead"
+}
+
+cleanup_build_caches() {
+  local dir
+  local size_kb
+
+  while IFS= read -r dir; do
+    [[ -d "$dir" ]] || continue
+
+    size_kb="$(path_size_kb "$dir")"
+    if free_space_below_target || (( size_kb > build_cache_max_kb )); then
+      echo "Removing build cache $dir"
+      echo "Reason: free disk $(free_gb) GB, cache size $((size_kb / 1024 / 1024)) GB, cap ${BUILD_CACHE_MAX_GB} GB"
+      remove_all_children "$dir"
+    fi
+  done < <(build_cache_dirs)
+
+  while IFS= read -r dir; do
+    remove_all_children "$dir"
+  done < <(trash_dirs)
 }
 
 cleanup_old_ios_runtimes() {
@@ -248,14 +306,14 @@ assert_free_space() {
 
   if (( available <= hard_required_kb )); then
     echo "ERROR: Only $(free_gb) GB free on $DISK_CHECK_PATH after macOS build cleanup. Required: more than ${HARD_MIN_FREE_GB} GB."
-    echo "Manual follow-up: remove only stale Concourse live volumes with the worker stopped, or run Nix garbage collection with the worker stopped."
+    echo "Manual follow-up: check the 'Top consumers in build homes' report below for unexpected growth; remove stale Concourse live volumes or run Nix garbage collection only with the worker stopped."
     print_disk_report
     exit 1
   fi
 
   if (( available < required_kb )); then
     echo "WARNING: Only $(free_gb) GB free on $DISK_CHECK_PATH after macOS build cleanup. Target: ${MIN_FREE_GB} GB. Builds fail only at or below ${HARD_MIN_FREE_GB} GB."
-    echo "Manual follow-up: remove only stale Concourse live volumes with the worker stopped, or run Nix garbage collection with the worker stopped."
+    echo "Manual follow-up: check the 'Top consumers in build homes' report below for unexpected growth; remove stale Concourse live volumes or run Nix garbage collection only with the worker stopped."
     print_disk_report
     return
   fi
@@ -273,6 +331,7 @@ case "$MODE" in
     print_disk_report
     cleanup_workspace_build_outputs
     cleanup_xcode_artifacts
+    cleanup_build_caches
     cleanup_concourse_dead_volumes
     assert_current_ios_runtime_present
     cleanup_old_ios_runtimes

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -230,6 +230,14 @@ cleanup_concourse_dead_volumes() {
   remove_all_children "$CONCOURSE_WORKDIR/volumes/dead"
 }
 
+stop_gradle_daemons() {
+  # A live daemon holds references into .gradle/caches; purging under it makes
+  # the next build fail with "Could not read workspace metadata".
+  echo "Stopping Gradle daemons before purging Gradle caches"
+  pkill -f GradleDaemon 2>/dev/null || true
+  sleep 1
+}
+
 cleanup_build_caches() {
   local dir
   local size_kb
@@ -241,6 +249,10 @@ cleanup_build_caches() {
     if free_space_below_target || (( size_kb > build_cache_max_kb )); then
       echo "Removing build cache $dir"
       echo "Reason: free disk $(free_gb) GB, cache size $((size_kb / 1024 / 1024)) GB, cap ${BUILD_CACHE_MAX_GB} GB"
+      if [[ "$dir" == */.gradle/caches ]]; then
+        stop_gradle_daemons
+        remove_path "${dir%/caches}/daemon"
+      fi
       remove_all_children "$dir"
     fi
   done < <(build_cache_dirs)

--- a/ci/tasks/macos-build-disk-cleanup.sh
+++ b/ci/tasks/macos-build-disk-cleanup.sh
@@ -36,9 +36,14 @@ free_space_below_target() {
 
 path_size_kb() {
   local path="$1"
+  local size
 
   if [[ -e "$path" ]]; then
-    du -sk "$path" 2>/dev/null | awk 'NR == 1 { print $1 }'
+    # du exits nonzero when any entry is unreadable (TCC-protected caches do
+    # this even for root) while still printing a total for what it could read;
+    # without the || true, pipefail + set -e would silently kill the script.
+    size="$(du -sk "$path" 2>/dev/null | awk 'NR == 1 { print $1 }' || true)"
+    echo "${size:-0}"
   else
     echo 0
   fi


### PR DESCRIPTION
## Context

Today's prod-build failed on `scaleway-mac-13342` with `ERROR: Only 5.5 GB free ... Required: more than 10 GB` even though `macos-build-disk-cleanup.sh pre` had just run — everything the script knows about was already clean. Manual diagnosis on the worker found ~42 GB in paths the script neither reports nor cleans:

| Path | Size |
|---|---|
| `/private/var/root/Library/Caches` (Yarn/CocoaPods as root) | 20 GB |
| `/private/var/root/.gradle` | 16 GB |
| `/private/var/root/.Trash` | 2.8 GB |
| `/Users/m1/Library/Caches/Yarn` | 3.1 GB |

These were deleted manually to unblock the worker (now ~73 GB free). This PR makes the script handle them itself.

## Changes

- **Cleanup** (`pre`/`scheduled`): purge build cache dirs (Yarn, CocoaPods, node-gyp, Gradle) for root, `$BUILD_HOME` and m1 when a dir exceeds `BUILD_CACHE_MAX_GB` (default 5 GB) or free space is below target — same pattern as the existing `ROOT_DERIVED_DATA_MAX_GB` cap. CI trash dirs are always emptied.
- **Diagnostics**: the disk report now includes cache/trash dir sizes and a "Top consumers in build homes" `du -d1` breakdown of `/private/var/root` and the build homes, so the next invisible consumer shows up in the failure log instead of requiring SSH archaeology.
- **Hint**: the "Manual follow-up" message now points at the top-consumers report (the old stale-live-volumes advice was a dead end in this incident — live volumes were only 1.9 GB).

## Verification

- `bash -n` and `shellcheck` clean.
- `check` mode run locally with worker-like env (`HOME=/Users/m1`, empty `CI_ROOT`): full report prints, missing paths tolerated, exit 0.
- Cache purge logic mirrors the manual cleanup performed on the worker today; the daily `cleanup-mac-build-worker` job will exercise `scheduled` mode after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)