### PR TITLE
fix(android): enable Crashlytics native symbol upload on release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,6 +133,11 @@ android {
             ndk {
                 abiFilters "armeabi-v7a", "arm64-v8a"
             }
+            // Release strips the native libs, so without uploading the symbol files every
+            // NDK crash reaches Crashlytics as raw addresses and cannot be root-caused.
+            firebaseCrashlytics {
+                nativeSymbolUploadEnabled true
+            }
         }
     }
 }

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,6 +46,18 @@ platform :android do
       flags: "--no-daemon --stacktrace --info",
       properties: env_props,
     )
+    # Non-fatal on purpose: the upload needs a Firebase credential the pipeline does not
+    # carry yet, and a failed upload must not stop the release from shipping.
+    begin
+      gradle(
+        task: "uploadCrashlyticsSymbolFile",
+        build_type: "Release",
+        flags: "--no-daemon --stacktrace",
+        properties: env_props,
+      )
+    rescue => e
+      UI.important("Crashlytics native symbol upload failed (non-fatal): #{e.message}")
+    end
   end
 
   desc "Deploy a new version to the Google Play"

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,17 +46,17 @@ platform :android do
       flags: "--no-daemon --stacktrace --info",
       properties: env_props,
     )
-    # Non-fatal on purpose: the upload needs a Firebase credential the pipeline does not
-    # carry yet, and a failed upload must not stop the release from shipping.
-    begin
+    # Skip when the Firebase credential (GOOGLE_APPLICATION_CREDENTIALS) is absent so ordinary
+    # builds don't pay for a doomed upload; when present, a failure surfaces loudly.
+    if ENV["GOOGLE_APPLICATION_CREDENTIALS"].to_s.empty?
+      UI.important("Skipping Crashlytics native symbol upload: GOOGLE_APPLICATION_CREDENTIALS is not set")
+    else
       gradle(
         task: "uploadCrashlyticsSymbolFile",
         build_type: "Release",
-        flags: "--no-daemon --stacktrace",
+        flags: "--no-daemon --stacktrace --info",
         properties: env_props,
       )
-    rescue => e
-      UI.important("Crashlytics native symbol upload failed (non-fatal): #{e.message}")
     end
   end
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -46,10 +46,14 @@ platform :android do
       flags: "--no-daemon --stacktrace --info",
       properties: env_props,
     )
-    # Skip when the Firebase credential (GOOGLE_APPLICATION_CREDENTIALS) is absent so ordinary
-    # builds don't pay for a doomed upload; when present, a failure surfaces loudly.
-    if ENV["GOOGLE_APPLICATION_CREDENTIALS"].to_s.empty?
+    # Skip when GOOGLE_APPLICATION_CREDENTIALS is unset, or set but pointing at a missing
+    # file, so ordinary builds don't pay for a doomed upload; when it resolves, a failure
+    # surfaces loudly.
+    creds = ENV["GOOGLE_APPLICATION_CREDENTIALS"].to_s
+    if creds.empty?
       UI.important("Skipping Crashlytics native symbol upload: GOOGLE_APPLICATION_CREDENTIALS is not set")
+    elsif !File.exist?(creds)
+      UI.important("Skipping Crashlytics native symbol upload: GOOGLE_APPLICATION_CREDENTIALS does not point to an existing file")
     else
       gradle(
         task: "uploadCrashlyticsSymbolFile",


### PR DESCRIPTION
## Summary

Enables Crashlytics native (NDK) symbol upload so production crashes stop arriving as raw addresses.

Closes #3925

- `android/app/build.gradle`: adds `firebaseCrashlytics { nativeSymbolUploadEnabled true }` to the release build type, which is what registers the symbol generation and upload tasks.
- `android/fastlane/Fastfile`: the release lane now runs `uploadCrashlyticsSymbolFileRelease` after `assemble`/`bundle`, so symbols are uploaded per release build.

## ⚠️ Required CI variable

The upload authenticates against Firebase, and **the pipeline does not carry that credential today**. A Google service account with permission to upload Crashlytics symbols on the `galoyapp` Firebase project needs to be exposed to the release job as:

```
GOOGLE_APPLICATION_CREDENTIALS=<path to the service account JSON file>
```

**It must be a path to a file on disk, not the JSON value.** Concourse params inject raw values, so `ci/tasks/build.sh` (or the job wiring) has to write the service-account JSON out to a file and export `GOOGLE_APPLICATION_CREDENTIALS` pointing at that path. Passing the JSON straight in would make the Crashlytics plugin treat it as a filename and fail with a confusing file-not-found error.

Until the credential is wired, the upload step is **skipped, not failed**: the release lane skips (with a log line) when `GOOGLE_APPLICATION_CREDENTIALS` is unset or points at a missing file, so ordinary builds don't pay for a doomed upload and keep shipping exactly as they do today, just without symbols. Once it resolves to a real file the upload runs, and a genuine failure (an expired or misconfigured service account) surfaces loudly instead of being swallowed.

For reference, the only Google credentials currently in CI are the GCS artifact-bucket service accounts, which do not grant Crashlytics access.

## Verification

Ran `:app:generateCrashlyticsSymbolFileRelease` locally:

- **134 symbol files generated**, covering the three libraries named in the issue: `libreactnative.so`, `libhermesvm.so` and the Breez Spark SDK.
- The generated `reactnative-arm64-0f886ef5554d247646ab8a9aabc62b4b12cfa24a.sym` matches **exactly** the `BuildId` of the `SIGABRT` reported in the issue, so these symbols would have symbolicated that specific crash.
- Counterfactual: with the `firebaseCrashlytics` block removed, no symbol task exists at all, confirming the config is what enables them.

The upload itself is not exercised here, since no Firebase credential is available locally.

## Follow-up

Step 3 of the issue (filing an issue for the actual `SIGABRT` once a symbolicated report arrives) is intentionally out of scope: it depends on a release going out first.
