### PR TITLE
fix(settings): gate username creation behind backup in non-custodial mode

### DIFF
--- a/__tests__/components/backup-required-modal.spec.tsx
+++ b/__tests__/components/backup-required-modal.spec.tsx
@@ -1,0 +1,153 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react-native"
+
+import { BackupRequiredModal } from "@app/components/backup-required-modal"
+
+const mockNavigate = jest.fn()
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
+jest.mock("@rn-vui/themed", () => {
+  const colors = {
+    grey0: "#ccc",
+    grey2: "#999",
+    grey5: "#f5f5f5",
+    primary: "#fc5805",
+    black: "#000",
+    white: "#fff",
+  }
+  return {
+    makeStyles:
+      (fn: (...args: unknown[]) => Record<string, object>) => (props?: unknown) =>
+        fn({ colors }, props ?? {}),
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("Text", props, children),
+    useTheme: () => ({ theme: { colors, mode: "light" } }),
+  }
+})
+
+const mockGaloyIcon = jest.fn<null, [Record<string, unknown>]>(() => null)
+
+jest.mock("@app/components/atomic/galoy-icon", () => ({
+  GaloyIcon: (props: Record<string, unknown>) => {
+    mockGaloyIcon(props)
+    return null
+  },
+}))
+
+jest.mock("@app/components/atomic/galoy-icon-button", () => ({
+  GaloyIconButton: ({ onPress }: { onPress: () => void }) =>
+    React.createElement("Pressable", { onPress, testID: "close-button" }),
+}))
+
+jest.mock("@app/components/atomic/galoy-primary-button", () => ({
+  GaloyPrimaryButton: ({ onPress, title }: { onPress: () => void; title: string }) =>
+    React.createElement(
+      "Pressable",
+      { onPress, testID: "backup-button" },
+      React.createElement("Text", {}, title),
+    ),
+}))
+
+jest.mock("@app/components/atomic/galoy-secondary-button", () => ({
+  GaloySecondaryButton: () => null,
+}))
+
+jest.mock("react-native-modal", () => {
+  const MockModal = ({
+    children,
+    isVisible,
+  }: {
+    children: React.ReactNode
+    isVisible: boolean
+  }) => (isVisible ? React.createElement("View", { testID: "modal" }, children) : null)
+  MockModal.displayName = "MockModal"
+  return MockModal
+})
+
+jest.mock("@app/utils/testProps", () => ({
+  testProps: (id: string) => ({ testID: id }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      BackupRequired: {
+        modalTitle: () => "Back up your wallet first",
+        modalDescription: () =>
+          "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        backupNow: () => "Back up wallet",
+      },
+    },
+  }),
+}))
+
+describe("BackupRequiredModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders when visible", () => {
+    const { getByTestId } = render(
+      <BackupRequiredModal isVisible={true} onClose={jest.fn()} />,
+    )
+
+    expect(getByTestId("modal")).toBeTruthy()
+  })
+
+  it("does not render when not visible", () => {
+    const { queryByTestId } = render(
+      <BackupRequiredModal isVisible={false} onClose={jest.fn()} />,
+    )
+
+    expect(queryByTestId("modal")).toBeNull()
+  })
+
+  it("renders title and description", () => {
+    const { getByText } = render(
+      <BackupRequiredModal isVisible={true} onClose={jest.fn()} />,
+    )
+
+    expect(getByText("Back up your wallet first")).toBeTruthy()
+    expect(
+      getByText(
+        "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+      ),
+    ).toBeTruthy()
+  })
+
+  it("renders back up wallet button", () => {
+    const { getByText } = render(
+      <BackupRequiredModal isVisible={true} onClose={jest.fn()} />,
+    )
+
+    expect(getByText("Back up wallet")).toBeTruthy()
+  })
+
+  it("navigates to backup method screen and closes on button press", () => {
+    const onClose = jest.fn()
+    const { getByTestId } = render(
+      <BackupRequiredModal isVisible={true} onClose={onClose} />,
+    )
+
+    fireEvent.press(getByTestId("backup-button"))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
+  })
+
+  it("uses primary color for warning icon", () => {
+    render(<BackupRequiredModal isVisible={true} onClose={jest.fn()} />)
+
+    expect(mockGaloyIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "warning",
+        size: 52,
+        color: "#fc5805",
+      }),
+    )
+  })
+})

--- a/__tests__/components/backup-required-modal.spec.tsx
+++ b/__tests__/components/backup-required-modal.spec.tsx
@@ -34,13 +34,8 @@ const mockGaloyIcon = jest.fn<null, [Record<string, unknown>]>(() => null)
 jest.mock("@app/components/atomic/galoy-icon", () => ({
   GaloyIcon: (props: Record<string, unknown>) => {
     mockGaloyIcon(props)
-    return null
+    return React.createElement("View", { testID: `galoy-icon-${props.name}` })
   },
-}))
-
-jest.mock("@app/components/atomic/galoy-icon-button", () => ({
-  GaloyIconButton: ({ onPress }: { onPress: () => void }) =>
-    React.createElement("Pressable", { onPress, testID: "close-button" }),
 }))
 
 jest.mock("@app/components/atomic/galoy-primary-button", () => ({
@@ -137,6 +132,22 @@ describe("BackupRequiredModal", () => {
 
     expect(onClose).toHaveBeenCalledTimes(1)
     expect(mockNavigate).toHaveBeenCalledWith("selfCustodialBackupMethod")
+    // the modal must be dismissed before the backup screen is pushed
+    expect(onClose.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("closes without navigating when dismissed via the close icon", () => {
+    const onClose = jest.fn()
+    const { getByTestId } = render(
+      <BackupRequiredModal isVisible={true} onClose={onClose} />,
+    )
+
+    fireEvent.press(getByTestId("galoy-icon-close"))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it("uses primary color for warning icon", () => {

--- a/__tests__/components/set-lightning-address-modal-ui.spec.tsx
+++ b/__tests__/components/set-lightning-address-modal-ui.spec.tsx
@@ -1,0 +1,125 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+jest.mock("@rn-vui/themed", () => {
+  const colors = {
+    grey0: "#ccc",
+    grey2: "#999",
+    grey3: "#aaa",
+    grey4: "#eee",
+    grey5: "#f5f5f5",
+    primary: "#fc5805",
+    warning: "#ffaa00",
+    black: "#000",
+    white: "#fff",
+  }
+  return {
+    makeStyles:
+      (fn: (...args: unknown[]) => Record<string, object>) => (props?: unknown) =>
+        fn({ colors }, props ?? {}),
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("Text", props, children),
+    useTheme: () => ({ theme: { colors, mode: "light" } }),
+  }
+})
+
+jest.mock("@app/components/atomic/galoy-icon-button", () => ({
+  GaloyIconButton: () => null,
+}))
+
+jest.mock("@app/components/atomic/galoy-primary-button", () => ({
+  GaloyPrimaryButton: ({ title }: { title: string }) =>
+    React.createElement("Text", {}, title),
+}))
+
+jest.mock("@app/components/atomic/galoy-secondary-button", () => ({
+  GaloySecondaryButton: () => null,
+}))
+
+jest.mock("@app/components/atomic/galoy-error-box", () => ({
+  GaloyErrorBox: ({ errorMessage }: { errorMessage: string }) =>
+    React.createElement("Text", { testID: "error-box" }, errorMessage),
+}))
+
+jest.mock("react-native-modal", () => {
+  const MockModal = ({
+    children,
+    isVisible,
+  }: {
+    children: React.ReactNode
+    isVisible: boolean
+  }) => (isVisible ? React.createElement("View", { testID: "modal" }, children) : null)
+  MockModal.displayName = "MockModal"
+  return MockModal
+})
+
+jest.mock("@app/utils/testProps", () => ({
+  testProps: (id: string) => ({ testID: id }),
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  useUserUpdateUsernameMutation: () => [jest.fn(), { loading: false }],
+  MyUserIdDocument: {},
+}))
+
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({
+    appConfig: { galoyInstance: { name: "Blink", lnAddressHostname: "blink.sv" } },
+  }),
+  useSaveSessionProfile: () => ({ saveProfile: jest.fn() }),
+}))
+
+jest.mock("@app/i18n/i18n-react", () => ({
+  useI18nContext: () => ({
+    LL: {
+      SetAddressModal: {
+        setLightningAddress: () => "Set Lightning address",
+        receiveMoney: () => "Receive money with this address.",
+        itCannotBeChanged: () => "It cannot be changed later!",
+        Errors: {
+          tooShort: () => "Address must be at least 3 characters long",
+          backupRequired: () =>
+            "Back up your wallet before creating a Lightning address",
+        },
+      },
+    },
+  }),
+}))
+
+import { SetLightningAddressModalUI } from "@app/components/set-lightning-address-modal"
+import { SetUsernameError } from "@app/components/set-lightning-address-modal/username-validation"
+
+const baseProps = {
+  isVisible: true,
+  toggleModal: jest.fn(),
+  onSetLightningAddress: jest.fn(),
+  loading: false,
+  lnAddress: "alice",
+  hostname: "blink.sv",
+  bankName: "Blink",
+}
+
+describe("SetLightningAddressModalUI error messages", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("shows the backup-required message for a BACKUP_REQUIRED error", () => {
+    const { getByText } = render(
+      <SetLightningAddressModalUI
+        {...baseProps}
+        error={SetUsernameError.BACKUP_REQUIRED}
+      />,
+    )
+
+    expect(
+      getByText("Back up your wallet before creating a Lightning address"),
+    ).toBeTruthy()
+  })
+
+  it("shows no error box when there is no error", () => {
+    const { queryByTestId } = render(<SetLightningAddressModalUI {...baseProps} />)
+
+    expect(queryByTestId("error-box")).toBeNull()
+  })
+})

--- a/__tests__/components/set-lightning-address-modal-ui.spec.tsx
+++ b/__tests__/components/set-lightning-address-modal-ui.spec.tsx
@@ -78,8 +78,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
         itCannotBeChanged: () => "It cannot be changed later!",
         Errors: {
           tooShort: () => "Address must be at least 3 characters long",
-          backupRequired: () =>
-            "Back up your wallet before creating a Lightning address",
+          backupRequired: () => "Back up your wallet before creating a Lightning address",
         },
       },
     },

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -140,6 +140,32 @@ describe("AccountLNAddress (self-custodial)", () => {
     expect(mockCopyToClipboard).not.toHaveBeenCalled()
   })
 
+  it("also gates address creation while the backup is still pending", () => {
+    mockBackupStatus = "pending"
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+
+    render(<AccountLNAddress />)
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+    expect(mockScModal).not.toHaveBeenCalled()
+  })
+
+  it("closes the backup-required modal through its onClose prop", () => {
+    mockBackupStatus = "none"
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+
+    render(<AccountLNAddress />)
+
+    act(() => (lastRowProps().action as () => void)())
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+
+    act(() => (mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.onClose as () => void)())
+
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+  })
+
   it("still copies an existing address on press when backup is not completed", () => {
     mockBackupStatus = "none"
     mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: SC_ADDRESS })

--- a/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/account-ln-address.spec.tsx
@@ -21,6 +21,17 @@ jest.mock("@app/components/set-lightning-address-modal", () => ({
   SetLightningAddressModal: mockCustodialModal,
 }))
 
+const mockBackupRequiredModal = jest.fn((_props: Record<string, unknown>) => null)
+jest.mock("@app/components/backup-required-modal", () => ({
+  BackupRequiredModal: mockBackupRequiredModal,
+}))
+
+let mockBackupStatus = "completed"
+jest.mock("@app/self-custodial/providers/backup-state", () => ({
+  BackupStatus: { None: "none", Pending: "pending", Completed: "completed" },
+  useBackupState: () => ({ backupState: { status: mockBackupStatus, method: null } }),
+}))
+
 jest.mock("@app/components/atomic/galoy-icon", () => ({
   GaloyIcon: () => null,
 }))
@@ -74,6 +85,7 @@ const SC_ADDRESS = "alice@staging.blink.sv"
 describe("AccountLNAddress (self-custodial)", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockBackupStatus = "completed"
     mockSettingsScreenQuery.mockReturnValue({ data: undefined, loading: false })
     mockUseAccountRegistry.mockReturnValue({
       activeAccount: { id: "sc-1", type: AccountType.SelfCustodial },
@@ -112,6 +124,36 @@ describe("AccountLNAddress (self-custodial)", () => {
     expect(mockScModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
   })
 
+  it("opens the backup-required modal instead of the create modal when backup is not completed", () => {
+    mockBackupStatus = "none"
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+
+    render(<AccountLNAddress />)
+
+    expect(lastRowProps().title).toBe("Create address")
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+    expect(mockScModal).not.toHaveBeenCalled()
+    expect(mockCopyToClipboard).not.toHaveBeenCalled()
+  })
+
+  it("still copies an existing address on press when backup is not completed", () => {
+    mockBackupStatus = "none"
+    mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: SC_ADDRESS })
+
+    render(<AccountLNAddress />)
+
+    act(() => (lastRowProps().action as () => void)())
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      expect.objectContaining({ content: SC_ADDRESS }),
+    )
+    expect(mockBackupRequiredModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(false)
+  })
+
   it("shows the persisted address (not the set prompt) while the live address is still resolving", () => {
     mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
     mockUseAccountRegistry.mockReturnValue({
@@ -129,6 +171,8 @@ describe("AccountLNAddress (self-custodial)", () => {
 describe("AccountLNAddress (custodial)", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    // an incomplete backup must never gate the custodial flow
+    mockBackupStatus = "none"
     mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
     mockUseAccountRegistry.mockReturnValue({
       activeAccount: { id: "cust-1", type: AccountType.Custodial },
@@ -150,6 +194,7 @@ describe("AccountLNAddress (custodial)", () => {
     act(() => (lastRowProps().action as () => void)())
 
     expect(mockCustodialModal.mock.calls.at(-1)?.[0]?.isVisible).toBe(true)
+    expect(mockBackupRequiredModal).not.toHaveBeenCalled()
     expect(mockCopyToClipboard).not.toHaveBeenCalled()
   })
 

--- a/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
+++ b/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
@@ -86,6 +86,19 @@ describe("useRegisterLightningAddress", () => {
     expect(result.current.loading).toBe(false)
   })
 
+  it("refuses to register while the backup is still pending", async () => {
+    mockBackupStatus = "pending"
+    const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.BACKUP_REQUIRED)
+    expect(mockRegister).not.toHaveBeenCalled()
+  })
+
   it("reports an unknown error when the SDK is not connected", async () => {
     mockSdk = null
     const { result } = renderHook(() => useRegisterLightningAddress(jest.fn()))

--- a/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
+++ b/__tests__/self-custodial/hooks/use-register-lightning-address.spec.ts
@@ -19,12 +19,19 @@ jest.mock("@app/self-custodial/providers/wallet", () => ({
   }),
 }))
 
+let mockBackupStatus = "completed"
+jest.mock("@app/self-custodial/providers/backup-state", () => ({
+  BackupStatus: { None: "none", Pending: "pending", Completed: "completed" },
+  useBackupState: () => ({ backupState: { status: mockBackupStatus, method: null } }),
+}))
+
 const FAKE_SDK = { id: "sdk" }
 
 describe("useRegisterLightningAddress", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockSdk = FAKE_SDK
+    mockBackupStatus = "completed"
     mockCheckAvailable.mockResolvedValue(true)
     mockRegister.mockResolvedValue({ lightningAddress: "alice@staging.blink.sv" })
     mockUpdateAccount.mockResolvedValue(undefined)
@@ -60,6 +67,23 @@ describe("useRegisterLightningAddress", () => {
     expect(mockCheckAvailable).not.toHaveBeenCalled()
     expect(mockRegister).not.toHaveBeenCalled()
     expect(onRegistered).not.toHaveBeenCalled()
+  })
+
+  it("refuses to register when the backup is not completed", async () => {
+    mockBackupStatus = "none"
+    const onRegistered = jest.fn()
+    const { result } = renderHook(() => useRegisterLightningAddress(onRegistered))
+
+    act(() => result.current.setLnAddress("alice"))
+    await act(async () => {
+      await result.current.register()
+    })
+
+    expect(result.current.error).toBe(SetUsernameError.BACKUP_REQUIRED)
+    expect(mockCheckAvailable).not.toHaveBeenCalled()
+    expect(mockRegister).not.toHaveBeenCalled()
+    expect(onRegistered).not.toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
   })
 
   it("reports an unknown error when the SDK is not connected", async () => {

--- a/app/components/backup-required-modal/backup-required-modal.tsx
+++ b/app/components/backup-required-modal/backup-required-modal.tsx
@@ -1,0 +1,66 @@
+import React from "react"
+
+import { makeStyles, Text, useTheme } from "@rn-vui/themed"
+import { useNavigation } from "@react-navigation/native"
+import { NativeStackNavigationProp } from "@react-navigation/native-stack"
+
+import { useI18nContext } from "@app/i18n/i18n-react"
+import { RootStackParamList } from "@app/navigation/stack-param-lists"
+import { testProps } from "@app/utils/testProps"
+
+import { GaloyIcon } from "../atomic/galoy-icon"
+import CustomModal from "../custom-modal/custom-modal"
+
+type BackupRequiredModalProps = {
+  isVisible: boolean
+  onClose: () => void
+}
+
+export const BackupRequiredModal: React.FC<BackupRequiredModalProps> = ({
+  isVisible,
+  onClose,
+}) => {
+  const styles = useStyles()
+  const {
+    theme: { colors },
+  } = useTheme()
+  const { LL } = useI18nContext()
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>()
+
+  const handleBackup = () => {
+    onClose()
+    navigation.navigate("selfCustodialBackupMethod")
+  }
+
+  return (
+    <CustomModal
+      isVisible={isVisible}
+      toggleModal={onClose}
+      showCloseIconButton={true}
+      image={
+        <GaloyIcon
+          name="warning"
+          size={52}
+          color={colors.primary}
+          {...testProps("backup-required-warning-icon")}
+        />
+      }
+      title={LL.BackupRequired.modalTitle()}
+      body={
+        <Text style={styles.description}>{LL.BackupRequired.modalDescription()}</Text>
+      }
+      primaryButtonTitle={LL.BackupRequired.backupNow()}
+      primaryButtonOnPress={handleBackup}
+      {...testProps("backup-required-modal")}
+    />
+  )
+}
+
+const useStyles = makeStyles(({ colors }) => ({
+  description: {
+    textAlign: "center",
+    fontSize: 16,
+    lineHeight: 22,
+    color: colors.black,
+  },
+}))

--- a/app/components/backup-required-modal/index.ts
+++ b/app/components/backup-required-modal/index.ts
@@ -1,0 +1,1 @@
+export { BackupRequiredModal } from "./backup-required-modal"

--- a/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
+++ b/app/components/set-lightning-address-modal/set-lightning-address-modal.tsx
@@ -181,6 +181,9 @@ export const SetLightningAddressModalUI = ({
     case SetUsernameError.UNKNOWN_ERROR:
       errorMessage = LL.SetAddressModal.Errors.unknownError()
       break
+    case SetUsernameError.BACKUP_REQUIRED:
+      errorMessage = LL.SetAddressModal.Errors.backupRequired()
+      break
   }
 
   return (

--- a/app/components/set-lightning-address-modal/username-validation.ts
+++ b/app/components/set-lightning-address-modal/username-validation.ts
@@ -4,6 +4,7 @@ export const SetUsernameError = {
   INVALID_CHARACTER: "INVALID_CHARACTER",
   ADDRESS_UNAVAILABLE: "ADDRESS_UNAVAILABLE",
   UNKNOWN_ERROR: "UNKNOWN_ERROR",
+  BACKUP_REQUIRED: "BACKUP_REQUIRED",
 } as const
 
 const UsernameRegex = /^(?![13_]|bc1|lnbc1)(?=.*[a-z])[0-9a-z_]{3,50}$/i

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2700,6 +2700,7 @@ const en: BaseTranslation = {
       invalidCharacter: "Address can only contain letters, numbers, and underscores",
       addressUnavailable: "Sorry, this address is already taken",
       unknownError: "An unknown error occurred, please try again later",
+      backupRequired: "Back up your wallet before creating a Lightning address",
     },
     receiveMoney:
       "Receive money from other lightning wallets and {bankName: string} users with this address.",
@@ -3883,6 +3884,12 @@ const en: BaseTranslation = {
     modalDescription:
       "We highly recommend you backup your wallet to prevent a complete loss of funds in case you lose this device.",
     secureMe: "Secure wallet",
+  },
+  BackupRequired: {
+    modalTitle: "Back up your wallet first",
+    modalDescription:
+      "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    backupNow: "Back up wallet",
   },
   NonCustodialInfoBulletin: {
     title: "This is a non-custodial account",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -8505,6 +8505,10 @@ type RootTranslation = {
 			 * A​n​ ​u​n​k​n​o​w​n​ ​e​r​r​o​r​ ​o​c​c​u​r​r​e​d​,​ ​p​l​e​a​s​e​ ​t​r​y​ ​a​g​a​i​n​ ​l​a​t​e​r
 			 */
 			unknownError: string
+			/**
+			 * B​a​c​k​ ​u​p​ ​y​o​u​r​ ​w​a​l​l​e​t​ ​b​e​f​o​r​e​ ​c​r​e​a​t​i​n​g​ ​a​ ​L​i​g​h​t​n​i​n​g​ ​a​d​d​r​e​s​s
+			 */
+			backupRequired: string
 		}
 		/**
 		 * R​e​c​e​i​v​e​ ​m​o​n​e​y​ ​f​r​o​m​ ​o​t​h​e​r​ ​l​i​g​h​t​n​i​n​g​ ​w​a​l​l​e​t​s​ ​a​n​d​ ​{​b​a​n​k​N​a​m​e​}​ ​u​s​e​r​s​ ​w​i​t​h​ ​t​h​i​s​ ​a​d​d​r​e​s​s​.
@@ -12373,6 +12377,20 @@ type RootTranslation = {
 		 * S​e​c​u​r​e​ ​w​a​l​l​e​t
 		 */
 		secureMe: string
+	}
+	BackupRequired: {
+		/**
+		 * B​a​c​k​ ​u​p​ ​y​o​u​r​ ​w​a​l​l​e​t​ ​f​i​r​s​t
+		 */
+		modalTitle: string
+		/**
+		 * Y​o​u​r​ ​L​i​g​h​t​n​i​n​g​ ​a​d​d​r​e​s​s​ ​i​s​ ​p​e​r​m​a​n​e​n​t​l​y​ ​l​i​n​k​e​d​ ​t​o​ ​t​h​i​s​ ​w​a​l​l​e​t​.​ ​B​a​c​k​ ​u​p​ ​y​o​u​r​ ​r​e​c​o​v​e​r​y​ ​p​h​r​a​s​e​ ​f​i​r​s​t​,​ ​s​o​ ​y​o​u​ ​n​e​v​e​r​ ​l​o​s​e​ ​a​c​c​e​s​s​ ​t​o​ ​y​o​u​r​ ​a​d​d​r​e​s​s​ ​a​n​d​ ​f​u​n​d​s​.
+		 */
+		modalDescription: string
+		/**
+		 * B​a​c​k​ ​u​p​ ​w​a​l​l​e​t
+		 */
+		backupNow: string
 	}
 	NonCustodialInfoBulletin: {
 		/**
@@ -21160,6 +21178,10 @@ export type TranslationFunctions = {
 			 * An unknown error occurred, please try again later
 			 */
 			unknownError: () => LocalizedString
+			/**
+			 * Back up your wallet before creating a Lightning address
+			 */
+			backupRequired: () => LocalizedString
 		}
 		/**
 		 * Receive money from other lightning wallets and {bankName} users with this address.
@@ -24965,6 +24987,20 @@ export type TranslationFunctions = {
 		 * Secure wallet
 		 */
 		secureMe: () => LocalizedString
+	}
+	BackupRequired: {
+		/**
+		 * Back up your wallet first
+		 */
+		modalTitle: () => LocalizedString
+		/**
+		 * Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.
+		 */
+		modalDescription: () => LocalizedString
+		/**
+		 * Back up wallet
+		 */
+		backupNow: () => LocalizedString
 	}
 	NonCustodialInfoBulletin: {
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2606,7 +2606,8 @@
             "tooLong": "Address must be at most 50 characters long",
             "invalidCharacter": "Address can only contain letters, numbers, and underscores",
             "addressUnavailable": "Sorry, this address is already taken",
-            "unknownError": "An unknown error occurred, please try again later"
+            "unknownError": "An unknown error occurred, please try again later",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
         "itCannotBeChanged": "Choose well – it cannot be changed later!"
@@ -3718,6 +3719,11 @@
         "modalTitle": "Secure your funds",
         "modalDescription": "We highly recommend you backup your wallet to prevent a complete loss of funds in case you lose this device.",
         "secureMe": "Secure wallet"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "This is a non-custodial account",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adres kan nie meer as 50 karakters lank wees nie",
       "invalidCharacter": "Adres kan net letters, nommers en 'n onderstreep bevat",
       "addressUnavailable": "Jammer, die adres is reeds geneem",
-      "unknownError": "'n Onbekende fout het voorgekom, probeer asseblief later weer"
+      "unknownError": "'n Onbekende fout het voorgekom, probeer asseblief later weer",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Ontvang geld van ander lightningbeursies en {bankName: string}-gebruikers met die adres",
     "itCannotBeChanged": "Dit kan nie later verander word nie."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Beveilig jou fondse",
     "modalDescription": "Ons beveel sterk aan dat u u beursie rugsteun om 'n algehele verlies van fondse te voorkom indien u hierdie toestel verloor.",
     "secureMe": "Beveilig beursie"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Hierdie is 'n nie-bewaarrekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "قم بتأمين أموالك",
     "modalDescription": "نوصي بشدة بعمل نسخة احتياطية لمحفظتك لمنع فقدان كامل للأموال في حال فقدت هذا الجهاز.",
     "secureMe": "تأمين المحفظة"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "هذا حساب غير حافظ",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2593,7 +2593,8 @@
       "tooLong": "L'adreça pot ser com a màxim de 50 caràcters",
       "invalidCharacter": "L'adreça només pot contenir lletres, números i guions baixos",
       "addressUnavailable": "Ho sentim, aquesta adreça ja està presa",
-      "unknownError": "S'ha produït un error desconegut. Torna-ho a provar més tard"
+      "unknownError": "S'ha produït un error desconegut. Torna-ho a provar més tard",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Rep diners d'altres moneders lightning i usuaris de {bankName: string} amb aquesta adreça.",
     "itCannotBeChanged": "No es pot canviar més endavant."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Assegura els teus fons",
     "modalDescription": "Et recomanem fermament que facis una còpia de seguretat de la teva cartera per evitar una pèrdua total de fons en cas que perdis aquest dispositiu.",
     "secureMe": "Assegurar cartera"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Aquest és un compte no custodi",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adresa může mít maximálně 50 znaků",
       "invalidCharacter": "Adresa může obsahovat pouze písmena, číslice a podtržítka.",
       "addressUnavailable": "Tato adresa je již obsazena",
-      "unknownError": "Došlo k neznámé chybě, zkuste to prosím později"
+      "unknownError": "Došlo k neznámé chybě, zkuste to prosím později",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Přijímejte peníze z jiných Lightning peněženek a od uživatelů {bankName: string} s touto adresou.",
     "itCannotBeChanged": "Později ji nelze změnit."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Zabezpečte své prostředky",
     "modalDescription": "Důrazně doporučujeme zálohovat peněženku, abyste předešli úplné ztrátě prostředků v případě ztráty tohoto zařízení.",
     "secureMe": "Zabezpečit peněženku"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Toto je nesvěřenský účet",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adressen må maksimalt være 50 tegn lang",
       "invalidCharacter": "Adressen kan kun indeholde bogstaver, tal og understregninger",
       "addressUnavailable": "Beklager, denne adresse er allerede taget",
-      "unknownError": "Der opstod en ukendt fejl, prøv igen senere"
+      "unknownError": "Der opstod en ukendt fejl, prøv igen senere",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Modtag penge fra andre lightning tegnebøger bøger og {bankName: string} brugere med denne adresse.",
     "itCannotBeChanged": "Det kan ikke ændres senere."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Sikr dine midler",
     "modalDescription": "Vi anbefaler stærkt, at du sikkerhedskopierer din tegnebog for at forhindre et fuldstændigt tab af midler, hvis du mister denne enhed.",
     "secureMe": "Sikr tegnebog"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Dette er en ikke-depotkonto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2593,7 +2593,8 @@
             "tooLong": "Die Adresse darf nicht länger als 50 Zeichen sein",
             "invalidCharacter": "Die Adresse darf nur Buchstaben, Zahlen und Unterstriche beinhalten",
             "addressUnavailable": "Entschuldigung, diese Adresse ist schon vergeben",
-            "unknownError": "Ein unbekannter Fehler ist aufgetreten, bitte versuche es später erneut"
+            "unknownError": "Ein unbekannter Fehler ist aufgetreten, bitte versuche es später erneut",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Empfange Geld von anderen Lightning Wallets und {bankName: string} Usern mit dieser Adresse.",
         "itCannotBeChanged": "Kann später nicht mehr geändert werden."
@@ -3705,6 +3706,11 @@
         "modalTitle": "Sichern Sie Ihre Mittel",
         "modalDescription": "Wir empfehlen dringend, Ihre Wallet zu sichern, um einen vollständigen Verlust Ihrer Mittel zu verhindern, falls Sie dieses Gerät verlieren.",
         "secureMe": "Wallet sichern"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "Dies ist ein nicht-verwahrtes Konto",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Η διεύθυνση πρέπει να είναι μέχρι 50 χαρακτήσρες",
       "invalidCharacter": "Η διεύθυνση μπορεί να περιέχει μόνο γράμματα, αριθμούς και κάτω παύλες",
       "addressUnavailable": "Λυπούμαστε, αυτή η διεύθυνση είναι κατειλημμένη ",
-      "unknownError": "Προέκυψε άγνωστο σφάλμα, παρακαλούμε δοκιμάστε ξανά αργότερα "
+      "unknownError": "Προέκυψε άγνωστο σφάλμα, παρακαλούμε δοκιμάστε ξανά αργότερα ",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Λάβετε χρήματα από άλλα πορτοφόλια lightning και {bankName: string} χρήστες με αυτή τη διεύθυνση.",
     "itCannotBeChanged": "Αυτό δεν μπορεί ν' αλλάξει αργότερα."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Ασφαλίστε τα κεφάλαιά σας",
     "modalDescription": "Σας συνιστούμε ανεπιφύλακτα να δημιουργήσετε αντίγραφο ασφαλείας του πορτοφολιού σας για να αποτρέψετε πλήρη απώλεια κεφαλαίων σε περίπτωση που χάσετε αυτήν τη συσκευή.",
     "secureMe": "Ασφάλιση πορτοφολιού"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Αυτός είναι ένας λογαριασμός μη φύλαξης",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2593,7 +2593,8 @@
             "tooLong": "La dirección debe tener como máximo 50 carácteres",
             "invalidCharacter": "La dirección solo puede contener letras, números y guiones bajos",
             "addressUnavailable": "Lo siento, esta dirección ya está ocupada por otro usuario.",
-            "unknownError": "Se produjo un error desconocido, inténtelo de nuevo más tarde"
+            "unknownError": "Se produjo un error desconocido, inténtelo de nuevo más tarde",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Reciba dinero de otras billeteras lightning y  de usuarios de {bankName: string} con esta dirección.",
         "itCannotBeChanged": "Elígela bien – ¡no se puede cambiar después!"
@@ -3705,6 +3706,11 @@
         "modalTitle": "Asegura tus fondos",
         "modalDescription": "Te recomendamos encarecidamente respaldar tu billetera para prevenir una pérdida total de fondos en caso de que pierdas este dispositivo.",
         "secureMe": "Asegurar billetera"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "Esta es una cuenta no custodial",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2593,7 +2593,8 @@
             "tooLong": "L’adresse ne peut excéder plus de 50 caractères",
             "invalidCharacter": "L’adresse ne peut contenir que des lettres, chiffres et des tirets.",
             "addressUnavailable": "Désolé, cette adresse est déjà utilisée",
-            "unknownError": "Une erreur inconnue est survenue, merci d’essayer ultérieurement"
+            "unknownError": "Une erreur inconnue est survenue, merci d’essayer ultérieurement",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Recevoir de l’argent depuis d’autres portefeuilles Lightning et d’utilisateurs {bankName: string} avec cette adresse.",
         "itCannotBeChanged": "Ce ne sera plus possible de changer après"
@@ -3705,6 +3706,11 @@
         "modalTitle": "Sécurisez vos fonds",
         "modalDescription": "Nous vous recommandons vivement de sauvegarder votre portefeuille pour éviter une perte totale de fonds en cas de perte de cet appareil.",
         "secureMe": "Sécuriser le portefeuille"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "Ceci est un compte non-custodial",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adresa mora imati najviše 50 znakova",
       "invalidCharacter": "Adresa može sadržavati samo slova, brojke i donje crte",
       "addressUnavailable": "Nažalost, ova adresa je već zauzeta",
-      "unknownError": "Došlo je do nepoznate pogreške, molimo pokušajte ponovno kasnije"
+      "unknownError": "Došlo je do nepoznate pogreške, molimo pokušajte ponovno kasnije",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Primajte novac od drugih Lightning novčanika i korisnika {bankName: string} s ovom adresom.",
     "itCannotBeChanged": "Kasnije se ne može promijeniti."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Osigurajte svoja sredstva",
     "modalDescription": "Preporučujemo da napravite sigurnosnu kopiju novčanika kako biste spriječili potpuni gubitak sredstava u slučaju da izgubite ovaj uređaj.",
     "secureMe": "Osiguraj novčanik"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Ovo je račun bez skrbništva",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2593,7 +2593,8 @@
       "tooLong": "A cím legfeljebb 50 karakter hosszú lehet",
       "invalidCharacter": "A cím csak betűket, számokat és aláhúzásjeleket tartalmazhat",
       "addressUnavailable": "Sajnáljuk, ez a cím már foglalt",
-      "unknownError": "Ismeretlen hiba történt, kérjük, próbálja újra később"
+      "unknownError": "Ismeretlen hiba történt, kérjük, próbálja újra később",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Fogadj pénzt más Lightning tárcákból és {bankName: string} felhasználóktól ezzel a címmel.",
     "itCannotBeChanged": "Később nem lehet megváltoztatni."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Biztosítsd a pénzeszközeidet",
     "modalDescription": "Nyomatékosan javasoljuk, hogy készíts biztonsági mentést a tárcádról, hogy megelőzd a pénzeszközeid teljes elvesztését, ha elveszíted ezt az eszközt.",
     "secureMe": "Tárca biztosítása"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Ez egy nem letétkezelt fiók",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Հասցեն պետք է ունենա առնվազն 50 նիշ",
       "invalidCharacter": "րՀասցեն կարող է ունենալ միայն նամակներ, թվեր, և ստորագծեր",
       "addressUnavailable": "Ներողություն, այս հասցեն արդեն կիրառվում է",
-      "unknownError": "Անհայտ սխալ։ Խնդրում ենք կրկին փորձել ավելի ուշ"
+      "unknownError": "Անհայտ սխալ։ Խնդրում ենք կրկին փորձել ավելի ուշ",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Ստանալ գումար այլ lightning դրամապանակներից և {bankName: string} օգտատերերից այս հասցեով։ ",
     "itCannotBeChanged": "Այն չի կարող փոփոխվել ավելի ուշ։"
@@ -3705,6 +3706,11 @@
     "modalTitle": "Ապահովեք ձեր միջոցները",
     "modalDescription": "Խիստ խորհուրդ ենք տալիս պահուստավորել ձեր դրամապանակը՝ միջոցների ամբողջական կորուստը կանխելու համար, եթե կորցնեք այս սարքը։",
     "secureMe": "Ապահովել դրամապանակը"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Սա ոչ պահպանող հաշիվ է",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Alamat harus memiliki maksimal 50 karakter",
       "invalidCharacter": "Alamat hanya boleh berisi huruf, angka, dan garis bawah",
       "addressUnavailable": "Maaf, alamat ini sudah digunakan",
-      "unknownError": "Terjadi kesalahan yang tidak diketahui, silakan coba lagi nanti"
+      "unknownError": "Terjadi kesalahan yang tidak diketahui, silakan coba lagi nanti",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Terima uang dari dompet Lightning lainnya dan pengguna {bankName: string} dengan alamat ini.",
     "itCannotBeChanged": "Ini tidak dapat diubah nanti."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Amankan dana Anda",
     "modalDescription": "Kami sangat menyarankan Anda untuk mencadangkan dompet Anda untuk mencegah kehilangan total dana jika Anda kehilangan perangkat ini.",
     "secureMe": "Amankan dompet"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Ini adalah akun non-kustodial",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2593,7 +2593,8 @@
             "tooLong": "L'indirizzo deve essere lungo al massimo 50 caratteri",
             "invalidCharacter": "L'indirizzo può contenere solo lettere, numeri e caratteri di sottolineatura",
             "addressUnavailable": "Spiacenti, questo indirizzo è già stato preso",
-            "unknownError": "Si è verificato un errore sconosciuto, riprova più tardi"
+            "unknownError": "Si è verificato un errore sconosciuto, riprova più tardi",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Ricevi denaro da altri portafogli Lightning e da utenti {bankName: string} con questo indirizzo.",
         "itCannotBeChanged": "Non potrà essere modificato in seguito."
@@ -3705,6 +3706,11 @@
         "modalTitle": "Metti al sicuro i tuoi fondi",
         "modalDescription": "Ti consigliamo vivamente di eseguire il backup del tuo portafoglio per prevenire una perdita totale dei fondi nel caso in cui perdessi questo dispositivo.",
         "secureMe": "Proteggi portafoglio"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "Questo è un account non custodiale",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2593,7 +2593,8 @@
             "tooLong": "アドレスは50文字以上でなければなりません",
             "invalidCharacter": "アドレスにはアルファベット、数字、アンダースコアのみ使用できます",
             "addressUnavailable": "申し訳ありませんが、このアドレスは既に使われています",
-            "unknownError": "不明なエラーが発生しました。時間をあけてもう一度トライしてみてください"
+            "unknownError": "不明なエラーが発生しました。時間をあけてもう一度トライしてみてください",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "このアドレスで他のライトニング・ウォレットや{bankName: string}ユーザーからお金を受け取ります。",
         "itCannotBeChanged": "あとから変更することはできません"
@@ -3705,6 +3706,11 @@
         "modalTitle": "資金を保護してください",
         "modalDescription": "このデバイスを紛失した場合の資金の完全な喪失を防ぐために、ウォレットのバックアップを強くお勧めします。",
         "secureMe": "ウォレットを保護"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "これは非カストディアルアカウントです",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Endagiriro eteekwa ennyo okuba n'ennukuta 50",
       "invalidCharacter": "Endagiriro esobola okubaamu ennukuta, ennamba, n'okuggumiza",
       "addressUnavailable": "Tusonyiwe, eno endagiriro yatwaliddwa dda",
-      "unknownError": "Ensobi etamanyiddwa etuseewo, tukusaba okugezaako nate oluvannyuma"
+      "unknownError": "Ensobi etamanyiddwa etuseewo, tukusaba okugezaako nate oluvannyuma",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Funa ssente okuva mu waleti za laddu endala ne {bankName: string} abakozesa ne ndagiriro eno.",
     "itCannotBeChanged": "Tekisobola kukyusibwa oluvannyuma."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Kuuma ssente zo",
     "modalDescription": "Tukutegeeza nnyo okukola backup ya wallet yo okusobola okuziyiza okufiirwa ssente zo zonna bw'onooba ofiirwa device eno.",
     "secureMe": "Kuuma wallet"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Eno ye akawunti etakuumibwa",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Panjang alamat maksimum adalah 50 aksara",
       "invalidCharacter": "Alamat hanya boleh mengandungi huruf, nombor dan underscores sahaja",
       "addressUnavailable": "Maaf, alamat ini sudah ada pemiliknya ",
-      "unknownError": "Ada masalah yang belum dikenal pasti berlaku, sila cuba lagi sekali."
+      "unknownError": "Ada masalah yang belum dikenal pasti berlaku, sila cuba lagi sekali.",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Terima wang daripada dompet Lightning yang lain dan pengguna {bankName: string} dengan alamat ini.",
     "itCannotBeChanged": "Ia tak boleh ditukar selepas ini."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Lindungi dana anda",
     "modalDescription": "Kami sangat mengesyorkan anda membuat sandaran dompet anda untuk mengelakkan kehilangan dana sepenuhnya sekiranya anda kehilangan peranti ini.",
     "secureMe": "Lindungi dompet"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Ini ialah akaun bukan kustodial",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Het adres mag maximaal 50 tekens lang zijn",
       "invalidCharacter": "Adres mag alleen letters, cijfers en onderstrepingstekens bevatten",
       "addressUnavailable": "Sorry, dit adres is al in gebruik",
-      "unknownError": "Er is een onbekende fout opgetreden. Probeer het later opnieuw"
+      "unknownError": "Er is een onbekende fout opgetreden. Probeer het later opnieuw",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Ontvang geld van andere Lightning-wallets en {bankName: string}-gebruikers met dit adres.",
     "itCannotBeChanged": "Het kan later niet meer worden gewijzigd."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Beveilig uw fondsen",
     "modalDescription": "We raden u ten zeerste aan om een back-up van uw portemonnee te maken om volledig verlies van fondsen te voorkomen als u dit apparaat kwijtraakt.",
     "secureMe": "Portemonnee beveiligen"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Dit is een niet-bewaarde rekening",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2593,7 +2593,8 @@
             "tooLong": "O endereço deve ter no máximo 50 caracteres de comprimento.",
             "invalidCharacter": "O endereço só pode conter letras, números e sublinhados.",
             "addressUnavailable": "Desculpe, este endereço já está em uso.",
-            "unknownError": "Ocorreu um erro desconhecido, por favor tente novamente mais tarde."
+            "unknownError": "Ocorreu um erro desconhecido, por favor tente novamente mais tarde.",
+            "backupRequired": "Back up your wallet before creating a Lightning address"
         },
         "receiveMoney": "Receba dinheiro de outras carteiras lightning e usuários do {bankName: string} com este endereço.",
         "itCannotBeChanged": "Não pode ser alterado posteriormente."
@@ -3705,6 +3706,11 @@
         "modalTitle": "Proteja seus fundos",
         "modalDescription": "Recomendamos fortemente que você faça backup da sua carteira para evitar uma perda total de fundos caso perca este dispositivo.",
         "secureMe": "Proteger carteira"
+    },
+    "BackupRequired": {
+        "modalTitle": "Back up your wallet first",
+        "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+        "backupNow": "Back up wallet"
     },
     "NonCustodialInfoBulletin": {
         "title": "Esta é uma conta não custodial",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Waqaychay qullqiykikunata",
     "modalDescription": "Ñuqayku mayt'a kunaykiku wallitaykita waqaychayta ama tukuy qullqiyki chinkananpaq kay aparatuykita chinkachispayki.",
     "secureMe": "Waqaychay wallita"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Kayqa mana waqaychasqa kuentam",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adresa poate să aibă cel mult 50 de caractere",
       "invalidCharacter": "Adresa poate conține doar litere, cifre și caractere de subliniere",
       "addressUnavailable": "Ne pare rău, această adresă este deja luată",
-      "unknownError": "A apărut o eroare necunoscută, încercați din nou mai târziu"
+      "unknownError": "A apărut o eroare necunoscută, încercați din nou mai târziu",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Primiți bani de la alte portofele Lightning și de la utilizatorii {bankName: string} cu această adresă.",
     "itCannotBeChanged": "Nu poate fi schimbată mai târziu."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Securizați-vă fondurile",
     "modalDescription": "Vă recomandăm insistent să faceți o copie de siguranță a portofelului pentru a preveni pierderea totală a fondurilor în cazul în care pierdeți acest dispozitiv.",
     "secureMe": "Securizare portofel"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Acesta este un cont non-custodial",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adresa môže mať maximálne 50 znakov",
       "invalidCharacter": "Adresa môže obsahovať iba písmená, číslice a podčiarkovníky.",
       "addressUnavailable": "Táto adresa je už obsadená",
-      "unknownError": "Došlo k neznámej chybe, skúste to prosím neskôr"
+      "unknownError": "Došlo k neznámej chybe, skúste to prosím neskôr",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Prijímajte peniaze z iných Lightning peňaženiek a od používateľov {bankName: string} s touto adresou.",
     "itCannotBeChanged": "Neskôr ju nie je možné zmeniť."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Zabezpečte svoje prostriedky",
     "modalDescription": "Dôrazne odporúčame zálohovať peňaženku, aby ste predišli úplnej strate prostriedkov v prípade straty tohto zariadenia.",
     "secureMe": "Zabezpečiť peňaženku"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Toto je nesvereneský účet",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Obezbedite svoja sredstva",
     "modalDescription": "Preporučujemo da napravite rezervnu kopiju novčanika kako biste sprečili potpuni gubitak sredstava u slučaju da izgubite ovaj uređaj.",
     "secureMe": "Obezbedi novčanik"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Ово је не-кастодијални налог",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Anwani lazima iwe na herufi si zaidi ya 50",
       "invalidCharacter": "Anwani inaweza kuwa na herufi, nambari, na alama ya chini pekee",
       "addressUnavailable": "Samahani, anwani hii tayari imetumika",
-      "unknownError": "Kuna hitilafu isiyofahamika, tafadhali jaribu tena baadaye"
+      "unknownError": "Kuna hitilafu isiyofahamika, tafadhali jaribu tena baadaye",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Pokea pesa kutoka kwa mkoba mwingine wa umeme na watumiaji wa {bankName: string} na anwani hii.",
     "itCannotBeChanged": "Haitaweza kubadilishwa baadaye."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Linda fedha zako",
     "modalDescription": "Tunakushauri sana uhifadhi pochi yako ili kuzuia kupoteza fedha zako zote iwapo utapoteza kifaa hiki.",
     "secureMe": "Linda pochi"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Hii ni akaunti isiyo ya udhamini",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "รักษาความปลอดภัยเงินของคุณ",
     "modalDescription": "เราขอแนะนำอย่างยิ่งให้คุณสำรองข้อมูลกระเป๋าเงินเพื่อป้องกันการสูญเสียเงินทั้งหมดในกรณีที่คุณทำอุปกรณ์นี้หาย",
     "secureMe": "รักษาความปลอดภัยกระเป๋าเงิน"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "นี่คือบัญชีแบบไม่ฝากดูแล",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Adres en fazla 50 karakter uzunluğunda olabilir",
       "invalidCharacter": "Adres yalnızca harf, sayı ve alttan çizgi içerebilir",
       "addressUnavailable": "Üzgünüm, bu adres çoktan alındı",
-      "unknownError": "Bilinmeyen bir hata yaşandı, lütfen daha sonra tekrar deneyin"
+      "unknownError": "Bilinmeyen bir hata yaşandı, lütfen daha sonra tekrar deneyin",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Bu adresle diğer lightning cüzdanlarından ve {bankName: string} kullanıcılarından para alın.",
     "itCannotBeChanged": "Bu daha sonra değiştirilebilir."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Fonlarınızı güvenceye alın",
     "modalDescription": "Cüzdanınızı yedeklemenizi şiddetle tavsiye ederiz. Bu cihazı kaybetmeniz durumunda fonlarınızın tamamen kaybolmasını önlemek için.",
     "secureMe": "Cüzdanı güvenceye al"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Bu, saklamasız bir hesaptır",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Bảo mật tiền của bạn",
     "modalDescription": "Chúng tôi khuyến nghị bạn sao lưu ví để ngăn chặn mất hoàn toàn tiền trong trường hợp bạn mất thiết bị này.",
     "secureMe": "Bảo mật ví"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Đây là tài khoản không lưu ký",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2593,7 +2593,8 @@
       "tooLong": "Address must be at most 50 characters long",
       "invalidCharacter": "Address can only contain letters, numbers, and underscores",
       "addressUnavailable": "Sorry, this address is already taken",
-      "unknownError": "An unknown error occurred, please try again later"
+      "unknownError": "An unknown error occurred, please try again later",
+      "backupRequired": "Back up your wallet before creating a Lightning address"
     },
     "receiveMoney": "Receive money from other lightning wallets and {bankName: string} users with this address.",
     "itCannotBeChanged": "It can't be changed later."
@@ -3705,6 +3706,11 @@
     "modalTitle": "Khuseleka imali yakho",
     "modalDescription": "Siyakucebisa kakhulu ukuba wenze isipele songeno lwengxowa yakho ukukhusela ukuphulukana ngokupheleleyo neemali zakho xa uphulukana nale divayisi.",
     "secureMe": "Khuseleka ingxowa"
+  },
+  "BackupRequired": {
+    "modalTitle": "Back up your wallet first",
+    "modalDescription": "Your Lightning address is permanently linked to this wallet. Back up your recovery phrase first, so you never lose access to your address and funds.",
+    "backupNow": "Back up wallet"
   },
   "NonCustodialInfoBulletin": {
     "title": "Le yiakhawunti engagcinwanga",

--- a/app/screens/settings-screen/settings/account-ln-address.tsx
+++ b/app/screens/settings-screen/settings/account-ln-address.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react"
 import { useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import { BackupRequiredModal } from "@app/components/backup-required-modal"
 import { SetLightningAddressModal } from "@app/components/set-lightning-address-modal"
 import { SetSelfCustodialLightningAddressModal } from "@app/screens/settings-screen/self-custodial/set-lightning-address-modal"
 import { useSettingsScreenQuery } from "@app/graphql/generated"
@@ -9,6 +10,10 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useAppConfig, useClipboard } from "@app/hooks"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import {
+  BackupStatus,
+  useBackupState,
+} from "@app/self-custodial/providers/backup-state"
 import { AccountType } from "@app/types/wallet"
 import { getLightningAddress } from "@app/utils/pay-links"
 
@@ -93,16 +98,22 @@ const CustodialLightningAddressRow: React.FC = () => {
 
 const SelfCustodialLightningAddressRow: React.FC = () => {
   const address = useSelfCustodialLightningAddress()
+  const { backupState } = useBackupState()
+  const isBackupRequired = backupState.status !== BackupStatus.Completed
 
   return (
     <LightningAddressRow
       address={address}
-      renderModal={({ isVisible, toggleModal }) => (
-        <SetSelfCustodialLightningAddressModal
-          isVisible={isVisible}
-          toggleModal={toggleModal}
-        />
-      )}
+      renderModal={({ isVisible, toggleModal }) =>
+        isBackupRequired ? (
+          <BackupRequiredModal isVisible={isVisible} onClose={toggleModal} />
+        ) : (
+          <SetSelfCustodialLightningAddressModal
+            isVisible={isVisible}
+            toggleModal={toggleModal}
+          />
+        )
+      }
     />
   )
 }

--- a/app/screens/settings-screen/settings/account-ln-address.tsx
+++ b/app/screens/settings-screen/settings/account-ln-address.tsx
@@ -10,10 +10,7 @@ import { useIsAuthed } from "@app/graphql/is-authed-context"
 import { useAppConfig, useClipboard } from "@app/hooks"
 import { useAccountRegistry } from "@app/hooks/use-account-registry"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import {
-  BackupStatus,
-  useBackupState,
-} from "@app/self-custodial/providers/backup-state"
+import { BackupStatus, useBackupState } from "@app/self-custodial/providers/backup-state"
 import { AccountType } from "@app/types/wallet"
 import { getLightningAddress } from "@app/utils/pay-links"
 

--- a/app/self-custodial/hooks/use-register-lightning-address.ts
+++ b/app/self-custodial/hooks/use-register-lightning-address.ts
@@ -9,6 +9,10 @@ import {
   checkLightningAddressAvailable,
   registerLightningAddress,
 } from "@app/self-custodial/bridge"
+import {
+  BackupStatus,
+  useBackupState,
+} from "@app/self-custodial/providers/backup-state"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 
 type UseRegisterLightningAddress = {
@@ -23,6 +27,7 @@ export const useRegisterLightningAddress = (
   onRegistered: () => void,
 ): UseRegisterLightningAddress => {
   const { sdk, updateCurrentSelfCustodialAccount } = useSelfCustodialWallet()
+  const { backupState } = useBackupState()
   const guard = useInFlightGuard()
   const [lnAddress, setLnAddressValue] = useState("")
   const [error, setError] = useState<SetUsernameError | undefined>()
@@ -35,6 +40,10 @@ export const useRegisterLightningAddress = (
 
   const register = async () => {
     await guard.run(async () => {
+      if (backupState.status !== BackupStatus.Completed) {
+        setError(SetUsernameError.BACKUP_REQUIRED)
+        return
+      }
       const validation = validateUsername(lnAddress)
       if (!validation.valid) {
         setError(validation.error)

--- a/app/self-custodial/hooks/use-register-lightning-address.ts
+++ b/app/self-custodial/hooks/use-register-lightning-address.ts
@@ -9,10 +9,7 @@ import {
   checkLightningAddressAvailable,
   registerLightningAddress,
 } from "@app/self-custodial/bridge"
-import {
-  BackupStatus,
-  useBackupState,
-} from "@app/self-custodial/providers/backup-state"
+import { BackupStatus, useBackupState } from "@app/self-custodial/providers/backup-state"
 import { useSelfCustodialWallet } from "@app/self-custodial/providers/wallet"
 
 type UseRegisterLightningAddress = {


### PR DESCRIPTION
Fixes blinkbitcoin/blink-wip#997

## Problem

In self-custodial mode a user can create a username (Lightning address) without having completed the seed-phrase backup. They can then start receiving funds into a wallet that cannot be recovered if the device is lost.

## Changes

- **Settings gate**: `SelfCustodialLightningAddressRow` now renders a new `BackupRequiredModal` instead of the create-address modal when `backupState.status !== Completed`. The modal explains why backup comes first and its primary button leads into the existing backup flow (`selfCustodialBackupMethod`), mirroring `BackupNudgeModal`.
- **Defense in depth**: `useRegisterLightningAddress.register()` refuses with a new `SetUsernameError.BACKUP_REQUIRED` when backup is not completed, mapped to an error message in the shared modal UI.
- New `BackupRequired` i18n strings and `SetAddressModal.Errors.backupRequired` (en source + regenerated types).

The custodial flow is unchanged. The receive-screen paycode prompt needs no gate: in self-custodial mode the invoice type never switches to PayCode without a registered address, and self-custodial onboarding has no username step.

## Tests

- New `backup-required-modal.spec.tsx` (render, copy, navigate-to-backup).
- `account-ln-address.spec.tsx`: gated tap shows the backup prompt and never opens the create modal; existing address still copies; custodial flow unaffected by backup status.
- `use-register-lightning-address.spec.ts`: guard refuses before validation/SDK calls.

## Screenshots

New non-custodial wallet, backup **not** completed ("Your funds are at risk" banner visible), Settings → Create address:

| Before (main) | After (this PR) | Backup flow entry | After backup completed |
|---|---|---|---|
| <img src="https://gist.githubusercontent.com/grimen/6324fe75277f5c30da2b585afb779624/raw/1-before-main-unbacked-modal-opens.png" width="200" /> | <img src="https://gist.githubusercontent.com/grimen/6324fe75277f5c30da2b585afb779624/raw/2-after-pr-backup-required-prompt.png" width="200" /> | <img src="https://gist.githubusercontent.com/grimen/6324fe75277f5c30da2b585afb779624/raw/3-after-pr-backup-method-flow.png" width="200" /> | <img src="https://gist.githubusercontent.com/grimen/6324fe75277f5c30da2b585afb779624/raw/4-after-pr-backup-completed-unlocked.png" width="200" /> |
| Create-address modal opens despite missing backup — "it cannot be changed later!" | Same tap now shows the backup-required prompt | "Back up wallet" lands on the existing backup-method screen | Risk banner gone; Create address opens normally |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
