### PR TITLE
fix(payments): recover successful payment masked by 409 idempotency conflict

### DIFF
--- a/__tests__/graphql/is-idempotency-conflict.spec.ts
+++ b/__tests__/graphql/is-idempotency-conflict.spec.ts
@@ -1,0 +1,71 @@
+import { ApolloError } from "@apollo/client"
+
+import { isIdempotencyConflict } from "@app/graphql/is-idempotency-conflict"
+
+/** A ServerError-shaped network error: non-2xx with a parsed JSON body. */
+const serverError409 = Object.assign(
+  new Error("Response not successful: Received status code 409"),
+  { statusCode: 409, result: { error: "the idempotency key already exist" } },
+)
+
+/** A ServerParseError-shaped network error: the "response was malformed" variant. */
+const serverParseError409 = Object.assign(new Error("JSON parse error"), {
+  statusCode: 409,
+  bodyText: '{"error":"the idempotency key already exist"}',
+})
+
+describe("isIdempotencyConflict", () => {
+  it("detects an ApolloError wrapping a 409 ServerError", () => {
+    expect(isIdempotencyConflict(new ApolloError({ networkError: serverError409 }))).toBe(
+      true,
+    )
+  })
+
+  it("detects an ApolloError wrapping a 409 ServerParseError", () => {
+    expect(
+      isIdempotencyConflict(new ApolloError({ networkError: serverParseError409 })),
+    ).toBe(true)
+  })
+
+  it("detects a bare 409 server error", () => {
+    expect(isIdempotencyConflict(serverError409)).toBe(true)
+  })
+
+  it("falls back to the historical '409: Conflict' message", () => {
+    expect(
+      isIdempotencyConflict(new Error("HTTP fetch failed from 'galoy': 409: Conflict")),
+    ).toBe(true)
+  })
+
+  it("falls back to the raw galoy body message", () => {
+    expect(
+      isIdempotencyConflict(
+        new Error(
+          "service 'galoy' response was malformed: " +
+            '{"error":"the idempotency key already exist"}',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false for other server errors", () => {
+    expect(
+      isIdempotencyConflict(
+        Object.assign(new Error("Internal server error"), { statusCode: 500 }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false for a plain network failure", () => {
+    expect(isIdempotencyConflict(new Error("Network request failed"))).toBe(false)
+  })
+
+  it("is false for a message merely containing 409", () => {
+    expect(isIdempotencyConflict(new Error("sent 409 sats"))).toBe(false)
+  })
+
+  it("is false for non-Error values", () => {
+    expect(isIdempotencyConflict("409: Conflict")).toBe(false)
+    expect(isIdempotencyConflict(undefined)).toBe(false)
+  })
+})

--- a/__tests__/graphql/retry-policy.spec.ts
+++ b/__tests__/graphql/retry-policy.spec.ts
@@ -1,6 +1,7 @@
+import type { Operation } from "@apollo/client"
 import type { NetworkError } from "@apollo/client/errors"
 
-import { shouldRetryOperation } from "@app/graphql/retry-policy"
+import { hasIdempotencyKey, shouldRetryOperation } from "@app/graphql/retry-policy"
 
 /** A settled network failure with no HTTP status, as a lost response surfaces. */
 const networkError = new Error("Network request failed") as NetworkError
@@ -37,11 +38,49 @@ describe("shouldRetryOperation", () => {
     expect(shouldRetryOperation(networkError, NON_IDEMPOTENT_PAYMENT)).toBe(false)
   })
 
+  it("does not retry an on-chain send-all", () => {
+    expect(shouldRetryOperation(networkError, "onChainPaymentSendAll")).toBe(false)
+  })
+
   describe("custodial-to-self-custodial migration mutations", () => {
     MIGRATION_OPERATIONS.forEach((operationName) => {
       it(`does not resend ${operationName} after a lost response`, () => {
         expect(shouldRetryOperation(networkError, operationName)).toBe(false)
       })
     })
+  })
+})
+
+/** A minimal Operation whose context carries the given headers. */
+const operationWithHeaders = (headers?: Record<string, unknown>): Operation =>
+  ({ getContext: () => (headers ? { headers } : {}) }) as unknown as Operation
+
+describe("hasIdempotencyKey", () => {
+  it("detects the key as sent by the payment hooks", () => {
+    expect(
+      hasIdempotencyKey(operationWithHeaders({ "X-Idempotency-Key": "some-uuid" })),
+    ).toBe(true)
+  })
+
+  it("detects the key regardless of header casing", () => {
+    expect(
+      hasIdempotencyKey(operationWithHeaders({ "x-idempotency-key": "some-uuid" })),
+    ).toBe(true)
+  })
+
+  it("ignores an empty key value", () => {
+    expect(hasIdempotencyKey(operationWithHeaders({ "X-Idempotency-Key": "" }))).toBe(
+      false,
+    )
+  })
+
+  it("is false for other headers", () => {
+    expect(hasIdempotencyKey(operationWithHeaders({ authorization: "Bearer t" }))).toBe(
+      false,
+    )
+  })
+
+  it("is false when the context has no headers", () => {
+    expect(hasIdempotencyKey(operationWithHeaders(undefined))).toBe(false)
   })
 })

--- a/__tests__/payment-details/lnurl-payment-details.spec.ts
+++ b/__tests__/payment-details/lnurl-payment-details.spec.ts
@@ -117,6 +117,22 @@ describe("lnurl payment details", () => {
     )
   })
 
+  it("exposes the fetched bolt11 invoice as paymentRequest", () => {
+    const paymentDetails = createLnurlPaymentDetails(defaultParamsWithInvoice)
+    if (paymentDetails.paymentType !== "lnurl") {
+      throw new Error("expected an lnurl payment detail")
+    }
+    expect(paymentDetails.paymentRequest).toBe(defaultParamsWithInvoice.paymentRequest)
+  })
+
+  it("has no paymentRequest before an invoice is fetched", () => {
+    const paymentDetails = createLnurlPaymentDetails(defaultParamsWithoutInvoice)
+    if (paymentDetails.paymentType !== "lnurl") {
+      throw new Error("expected an lnurl payment detail")
+    }
+    expect(paymentDetails.paymentRequest).toBeUndefined()
+  })
+
   describe("sending from a btc wallet", () => {
     const btcSendingWalletParams = {
       ...defaultParamsWithInvoice,

--- a/__tests__/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.spec.ts
+++ b/__tests__/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.spec.ts
@@ -1,9 +1,20 @@
+import { renderHook } from "@testing-library/react-native"
+
 import { TxDirection, TxStatus } from "@app/graphql/generated"
 import {
   getPaymentHashFromInvoice,
   pollForSettledStatus,
   resolveSettledOutcome,
+  useVerifyPaymentSettled,
 } from "@app/screens/send-bitcoin-screen/hooks/use-verify-payment-settled"
+
+const mockExecuteTransactionsByPaymentHash = jest.fn()
+const mockUnauthedQuery = jest.fn()
+jest.mock("@app/graphql/generated", () => ({
+  ...jest.requireActual("@app/graphql/generated"),
+  useTransactionsByPaymentHashLazyQuery: () => [mockExecuteTransactionsByPaymentHash],
+  useHomeUnauthedQuery: () => mockUnauthedQuery(),
+}))
 
 /** The mainnet invoice used across the app's mocks (app/graphql/mocks.ts). */
 const MAINNET_INVOICE =
@@ -106,5 +117,76 @@ describe("pollForSettledStatus", () => {
       status: "SUCCESS",
       createdAt: 1700000000,
     })
+  })
+})
+
+describe("useVerifyPaymentSettled", () => {
+  const withTransactions = (transactions: ReturnType<typeof sendTx>[] | undefined) => ({
+    data: {
+      me: {
+        defaultAccount: {
+          walletById: { transactionsByPaymentHash: transactions },
+        },
+      },
+    },
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUnauthedQuery.mockReturnValue({
+      data: { globals: { network: "mainnet" } },
+    })
+  })
+
+  it("queries by the decoded payment hash and resolves the settled outcome", async () => {
+    mockExecuteTransactionsByPaymentHash.mockResolvedValue(
+      withTransactions([sendTx(TxStatus.Success)]),
+    )
+
+    const { result } = renderHook(() => useVerifyPaymentSettled())
+    await expect(
+      result.current({ walletId: "wallet-1", paymentRequest: MAINNET_INVOICE }),
+    ).resolves.toEqual({ status: "SUCCESS", createdAt: 1700000000 })
+
+    expect(mockExecuteTransactionsByPaymentHash).toHaveBeenCalledWith({
+      variables: { walletId: "wallet-1", paymentHash: MAINNET_INVOICE_HASH },
+    })
+  })
+
+  it("resolves undefined without querying when the invoice is undecodable", async () => {
+    const { result } = renderHook(() => useVerifyPaymentSettled())
+    await expect(
+      result.current({ walletId: "wallet-1", paymentRequest: "not-an-invoice" }),
+    ).resolves.toBeUndefined()
+    expect(mockExecuteTransactionsByPaymentHash).not.toHaveBeenCalled()
+  })
+
+  it("resolves undefined without querying when the network is unknown", async () => {
+    mockUnauthedQuery.mockReturnValue({ data: undefined })
+
+    const { result } = renderHook(() => useVerifyPaymentSettled())
+    await expect(
+      result.current({ walletId: "wallet-1", paymentRequest: MAINNET_INVOICE }),
+    ).resolves.toBeUndefined()
+    expect(mockExecuteTransactionsByPaymentHash).not.toHaveBeenCalled()
+  })
+
+  it("polls between delays and gives up after the configured attempts", async () => {
+    jest.useFakeTimers()
+    try {
+      mockExecuteTransactionsByPaymentHash.mockResolvedValue(withTransactions([]))
+
+      const { result } = renderHook(() => useVerifyPaymentSettled())
+      const outcome = result.current({
+        walletId: "wallet-1",
+        paymentRequest: MAINNET_INVOICE,
+      })
+      await jest.advanceTimersByTimeAsync(5000)
+
+      await expect(outcome).resolves.toBeUndefined()
+      expect(mockExecuteTransactionsByPaymentHash).toHaveBeenCalledTimes(3)
+    } finally {
+      jest.useRealTimers()
+    }
   })
 })

--- a/__tests__/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.spec.ts
+++ b/__tests__/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.spec.ts
@@ -1,0 +1,110 @@
+import { TxDirection, TxStatus } from "@app/graphql/generated"
+import {
+  getPaymentHashFromInvoice,
+  pollForSettledStatus,
+  resolveSettledOutcome,
+} from "@app/screens/send-bitcoin-screen/hooks/use-verify-payment-settled"
+
+/** The mainnet invoice used across the app's mocks (app/graphql/mocks.ts). */
+const MAINNET_INVOICE =
+  "lnbc1p3lwh3npp5z5wkmy86gcww9u2h8tuekqmfz4pwlpkk4rfst8cm7jwzm8fklldsdqqcqzpuxqyz5" +
+  "vqsp52fv968tprd3dqkuqsq78nw8s0xr9zn7rx686ukq2rfnsdf27pwtq9qyyssqhc7m7d3gfvdsywx9" +
+  "56d3u3h45xyf7xurc6yv5qxysspjnhhxstl3wet525ldxn3x6xd0g58nk6wuvwle0fhn5sul396za3qs" +
+  "5ma7zxsqjvklym"
+const MAINNET_INVOICE_HASH =
+  "151d6d90fa461ce2f1573af99b03691542ef86d6a8d3059f1bf49c2d9d36ffdb"
+
+const sendTx = (status: TxStatus, createdAt = 1700000000) => ({
+  status,
+  direction: TxDirection.Send,
+  createdAt,
+})
+const receiveTx = (status: TxStatus) => ({ status, direction: TxDirection.Receive })
+
+describe("getPaymentHashFromInvoice", () => {
+  it("decodes the payment hash from a bolt11 invoice", () => {
+    expect(getPaymentHashFromInvoice(MAINNET_INVOICE, "mainnet")).toBe(
+      MAINNET_INVOICE_HASH,
+    )
+  })
+
+  it("returns undefined for an undecodable destination instead of throwing", () => {
+    expect(getPaymentHashFromInvoice("LNURL1notaninvoice", "mainnet")).toBeUndefined()
+    expect(getPaymentHashFromInvoice("", "mainnet")).toBeUndefined()
+  })
+})
+
+describe("resolveSettledOutcome", () => {
+  it("resolves an outgoing SUCCESS transaction", () => {
+    expect(resolveSettledOutcome([sendTx(TxStatus.Success)])).toEqual({
+      status: "SUCCESS",
+      createdAt: 1700000000,
+    })
+  })
+
+  it("resolves an outgoing PENDING transaction", () => {
+    expect(resolveSettledOutcome([sendTx(TxStatus.Pending)])?.status).toBe("PENDING")
+  })
+
+  it("prefers SUCCESS over PENDING", () => {
+    expect(
+      resolveSettledOutcome([sendTx(TxStatus.Pending), sendTx(TxStatus.Success)])?.status,
+    ).toBe("SUCCESS")
+  })
+
+  it("does not treat a FAILURE as settled", () => {
+    expect(resolveSettledOutcome([sendTx(TxStatus.Failure)])).toBeUndefined()
+  })
+
+  it("ignores incoming transactions", () => {
+    expect(resolveSettledOutcome([receiveTx(TxStatus.Success)])).toBeUndefined()
+  })
+
+  it("is undefined for empty or missing transactions", () => {
+    expect(resolveSettledOutcome([])).toBeUndefined()
+    expect(resolveSettledOutcome(undefined)).toBeUndefined()
+    expect(resolveSettledOutcome(null)).toBeUndefined()
+  })
+})
+
+describe("pollForSettledStatus", () => {
+  const options = { attempts: 3, delayMs: 0 }
+
+  it("resolves once a later attempt finds a settled transaction", async () => {
+    const fetchTransactions = jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce([sendTx(TxStatus.Success)])
+    await expect(pollForSettledStatus(fetchTransactions, options)).resolves.toEqual({
+      status: "SUCCESS",
+      createdAt: 1700000000,
+    })
+    expect(fetchTransactions).toHaveBeenCalledTimes(3)
+  })
+
+  it("stops polling as soon as an outcome is found", async () => {
+    const fetchTransactions = jest.fn().mockResolvedValue([sendTx(TxStatus.Pending)])
+    await pollForSettledStatus(fetchTransactions, options)
+    expect(fetchTransactions).toHaveBeenCalledTimes(1)
+  })
+
+  it("gives up after the configured attempts", async () => {
+    const fetchTransactions = jest.fn().mockResolvedValue([])
+    await expect(
+      pollForSettledStatus(fetchTransactions, options),
+    ).resolves.toBeUndefined()
+    expect(fetchTransactions).toHaveBeenCalledTimes(3)
+  })
+
+  it("treats a fetch error as not-found and keeps polling", async () => {
+    const fetchTransactions = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce([sendTx(TxStatus.Success)])
+    await expect(pollForSettledStatus(fetchTransactions, options)).resolves.toEqual({
+      status: "SUCCESS",
+      createdAt: 1700000000,
+    })
+  })
+})

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -190,6 +190,11 @@ jest.mock("@app/screens/send-bitcoin-screen/use-fee", () => ({
   default: () => mockUseFee(),
 }))
 
+const verifyPaymentSettledMock = jest.fn()
+jest.mock("@app/screens/send-bitcoin-screen/hooks/use-verify-payment-settled", () => ({
+  useVerifyPaymentSettled: () => verifyPaymentSettledMock,
+}))
+
 const mockUseSendBalances = jest.fn()
 jest.mock("@app/screens/send-bitcoin-screen/hooks/use-send-wallets", () => ({
   ...jest.requireActual("@app/screens/send-bitcoin-screen/hooks/use-send-wallets"),
@@ -985,5 +990,147 @@ describe("SendBitcoinConfirmationScreen — skipBalanceCheck matrix", () => {
     await flushEffects()
 
     expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(false)
+  })
+})
+
+describe("SendBitcoinConfirmationScreen — 409 idempotency conflict recovery", () => {
+  const conflictError = Object.assign(
+    new Error("HTTP fetch failed from 'galoy': 409: Conflict"),
+    { statusCode: 409 },
+  )
+
+  const buildLnurlRoute = () => {
+    const { createLnurlPaymentDetails } = PaymentDetailsLightning
+    return {
+      key: "sendBitcoinConfirmationScreen",
+      name: "sendBitcoinConfirmation",
+      params: { paymentDetail: createLnurlPaymentDetails(defaultLightningParams) },
+    } as const
+  }
+
+  const findCompletedRouteParams = () => {
+    const reducerCalls = navigationDispatchMock.mock.calls
+      .map(([reducer]) => reducer)
+      .filter(
+        (reducer): reducer is (state: unknown) => unknown =>
+          typeof reducer === "function",
+      )
+    for (const reducer of reducerCalls) {
+      const action = reducer({ index: 0, routes: [] }) as {
+        payload?: { routes?: Array<{ name: string; params?: unknown }> }
+        routes?: Array<{ name: string; params?: unknown }>
+      }
+      const routes = action.payload?.routes ?? action.routes ?? []
+      const completed = routes.find((r) => r.name === "sendBitcoinCompleted")
+      if (completed) return completed.params as { status?: unknown; createdAt?: unknown }
+    }
+    throw new Error("sendBitcoinCompleted route was not dispatched")
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    loadLocale("en")
+    mockUseSendPayment.mockReturnValue({
+      loading: false,
+      hasAttemptedSend: false,
+      sendPayment: sendPaymentMock,
+    })
+    mockUseFee.mockReturnValue({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+    })
+    mockUseSendBalances.mockReturnValue({
+      btcWallet: {
+        id: "btc-wallet-id",
+        balance: 500000,
+        walletCurrency: WalletCurrency.Btc,
+      },
+      usdWallet: {
+        id: "usd-wallet-id",
+        balance: 10000,
+        walletCurrency: WalletCurrency.Usd,
+      },
+    })
+  })
+
+  it("navigates to the completed screen when the ledger confirms the payment settled", async () => {
+    sendPaymentMock.mockRejectedValueOnce(conflictError)
+    verifyPaymentSettledMock.mockResolvedValueOnce({
+      status: "SUCCESS",
+      createdAt: 1700000000,
+    })
+
+    render(
+      <ContextForScreen>
+        <LightningLnURL route={buildLnurlRoute()} />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("slider"))
+    })
+
+    expect(verifyPaymentSettledMock).toHaveBeenCalledWith({
+      walletId: btcSendingWalletDescriptor.id,
+      paymentRequest: defaultLightningParams.paymentRequest,
+    })
+    const params = findCompletedRouteParams()
+    expect(params.status).toBe("SUCCESS")
+    expect(params.createdAt).toBe(1700000000)
+    expect(screen.queryByText(/Payment already attempted/i)).toBeNull()
+  })
+
+  it("falls back to the already-attempted message when settlement cannot be confirmed", async () => {
+    sendPaymentMock.mockRejectedValueOnce(conflictError)
+    verifyPaymentSettledMock.mockResolvedValueOnce(undefined)
+
+    render(
+      <ContextForScreen>
+        <LightningLnURL route={buildLnurlRoute()} />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("slider"))
+    })
+
+    expect(verifyPaymentSettledMock).toHaveBeenCalledTimes(1)
+    expect(screen.getByText(/Payment already attempted/i)).toBeTruthy()
+    expect(navigationDispatchMock).not.toHaveBeenCalled()
+  })
+
+  it("does not attempt verification for an intraledger payment", async () => {
+    sendPaymentMock.mockRejectedValueOnce(conflictError)
+
+    render(
+      <ContextForScreen>
+        <Intraledger route={route} />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("slider"))
+    })
+
+    expect(verifyPaymentSettledMock).not.toHaveBeenCalled()
+    expect(screen.getByText(/Payment already attempted/i)).toBeTruthy()
+    expect(navigationDispatchMock).not.toHaveBeenCalled()
+  })
+
+  it("still surfaces non-conflict errors unchanged", async () => {
+    sendPaymentMock.mockRejectedValueOnce(new Error("insufficient balance"))
+
+    render(
+      <ContextForScreen>
+        <LightningLnURL route={buildLnurlRoute()} />
+      </ContextForScreen>,
+    )
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("slider"))
+    })
+
+    expect(verifyPaymentSettledMock).not.toHaveBeenCalled()
+    expect(screen.getByText("insufficient balance")).toBeTruthy()
   })
 })

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -44,7 +44,7 @@ import { IsAuthedContextProvider, useIsAuthed } from "./is-authed-context"
 import { LevelContainer } from "./level-component"
 import { MessagingContainer } from "./messaging"
 import { NetworkErrorContextProvider } from "./network-error-context"
-import { shouldRetryOperation } from "./retry-policy"
+import { hasIdempotencyKey, shouldRetryOperation } from "./retry-policy"
 
 const getAuthorizationHeader = (token: string): string => {
   return `Bearer ${token}`
@@ -159,7 +159,10 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
           max: 5,
           retryIf: (error, operation) => {
             console.debug(JSON.stringify(error), "retry on error")
-            return shouldRetryOperation(error, operation.operationName)
+            return (
+              !hasIdempotencyKey(operation) &&
+              shouldRetryOperation(error, operation.operationName)
+            )
           },
         },
       })
@@ -167,8 +170,10 @@ const GaloyClient: React.FC<PropsWithChildren> = ({ children }) => {
       const retry401ErrorLink = new RetryLink({
         attempts: {
           max: 2,
-          retryIf: (error) => {
-            return error && error.statusCode === 401
+          retryIf: (error, operation) => {
+            return (
+              Boolean(error) && error.statusCode === 401 && !hasIdempotencyKey(operation)
+            )
           },
         },
         delay: {

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1999,6 +1999,28 @@ query transactionOwnershipProbe($first: Int) {
   }
 }
 
+query transactionsByPaymentHash($walletId: WalletId!, $paymentHash: PaymentHash!) {
+  me {
+    id
+    defaultAccount {
+      id
+      walletById(walletId: $walletId) {
+        id
+        transactionsByPaymentHash(paymentHash: $paymentHash) {
+          id
+          status
+          direction
+          createdAt
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+
 query walletOverviewScreen {
   me {
     id

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -3722,6 +3722,14 @@ export type MyLnUpdatesSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 export type MyLnUpdatesSubscription = { readonly __typename: 'Subscription', readonly myUpdates: { readonly __typename: 'MyUpdatesPayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly update?: { readonly __typename: 'IntraLedgerUpdate' } | { readonly __typename: 'LnUpdate', readonly paymentHash: string, readonly status: InvoicePaymentStatus } | { readonly __typename: 'OnChainUpdate' } | { readonly __typename: 'Price' } | { readonly __typename: 'RealtimePrice' } | null } };
 
+export type TransactionsByPaymentHashQueryVariables = Exact<{
+  walletId: Scalars['WalletId']['input'];
+  paymentHash: Scalars['PaymentHash']['input'];
+}>;
+
+
+export type TransactionsByPaymentHashQuery = { readonly __typename: 'Query', readonly me?: { readonly __typename: 'User', readonly id: string, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly walletById: { readonly __typename: 'BTCWallet', readonly id: string, readonly transactionsByPaymentHash: ReadonlyArray<{ readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly createdAt: number }> } | { readonly __typename: 'UsdWallet', readonly id: string, readonly transactionsByPaymentHash: ReadonlyArray<{ readonly __typename: 'Transaction', readonly id: string, readonly status: TxStatus, readonly direction: TxDirection, readonly createdAt: number }> } } } | null };
+
 export type ScanningQrCodeScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -7760,6 +7768,59 @@ export function useMyLnUpdatesSubscription(baseOptions?: Apollo.SubscriptionHook
       }
 export type MyLnUpdatesSubscriptionHookResult = ReturnType<typeof useMyLnUpdatesSubscription>;
 export type MyLnUpdatesSubscriptionResult = Apollo.SubscriptionResult<MyLnUpdatesSubscription>;
+export const TransactionsByPaymentHashDocument = gql`
+    query transactionsByPaymentHash($walletId: WalletId!, $paymentHash: PaymentHash!) {
+  me {
+    id
+    defaultAccount {
+      id
+      walletById(walletId: $walletId) {
+        id
+        transactionsByPaymentHash(paymentHash: $paymentHash) {
+          id
+          status
+          direction
+          createdAt
+        }
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __useTransactionsByPaymentHashQuery__
+ *
+ * To run a query within a React component, call `useTransactionsByPaymentHashQuery` and pass it any options that fit your needs.
+ * When your component renders, `useTransactionsByPaymentHashQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useTransactionsByPaymentHashQuery({
+ *   variables: {
+ *      walletId: // value for 'walletId'
+ *      paymentHash: // value for 'paymentHash'
+ *   },
+ * });
+ */
+export function useTransactionsByPaymentHashQuery(baseOptions: Apollo.QueryHookOptions<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables> & ({ variables: TransactionsByPaymentHashQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>(TransactionsByPaymentHashDocument, options);
+      }
+export function useTransactionsByPaymentHashLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>(TransactionsByPaymentHashDocument, options);
+        }
+export function useTransactionsByPaymentHashSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>(TransactionsByPaymentHashDocument, options);
+        }
+export type TransactionsByPaymentHashQueryHookResult = ReturnType<typeof useTransactionsByPaymentHashQuery>;
+export type TransactionsByPaymentHashLazyQueryHookResult = ReturnType<typeof useTransactionsByPaymentHashLazyQuery>;
+export type TransactionsByPaymentHashSuspenseQueryHookResult = ReturnType<typeof useTransactionsByPaymentHashSuspenseQuery>;
+export type TransactionsByPaymentHashQueryResult = Apollo.QueryResult<TransactionsByPaymentHashQuery, TransactionsByPaymentHashQueryVariables>;
 export const ScanningQrCodeScreenDocument = gql`
     query scanningQRCodeScreen {
   globals {

--- a/app/graphql/is-idempotency-conflict.ts
+++ b/app/graphql/is-idempotency-conflict.ts
@@ -1,0 +1,37 @@
+import { ApolloError } from "@apollo/client"
+
+const CONFLICT_STATUS = 409
+
+/**
+ * Matches both the raw galoy body ("the idempotency key already exist") and the
+ * historical "409: Conflict" wrapper, for errors where the status code was lost in
+ * transit (e.g. re-thrown as a plain Error). Kept tight — no bare "409" — so message
+ * text like "409 sats" can never match.
+ */
+const CONFLICT_MESSAGE_PATTERN = /409:?\s*conflict|idempotency key already exist/i
+
+const statusCodeOf = (candidate: unknown): number | undefined =>
+  candidate && typeof candidate === "object" && "statusCode" in candidate
+    ? (candidate as { statusCode?: number }).statusCode
+    : undefined
+
+/**
+ * Whether an error thrown by a payment mutation is the server rejecting a replay of an
+ * already-processed request: HTTP 409 on the X-Idempotency-Key. Covers an ApolloError
+ * wrapping a ServerError or ServerParseError (both carry statusCode — the parse error is
+ * how the "response was malformed" variant surfaces), a bare ServerError/ServerParseError,
+ * and a message-pattern fallback. A 409 means the first attempt reached the server, so the
+ * payment may well have succeeded despite the thrown error.
+ */
+export const isIdempotencyConflict = (err: unknown): boolean => {
+  if (!(err instanceof Error)) {
+    return false
+  }
+  if (err instanceof ApolloError && statusCodeOf(err.networkError) === CONFLICT_STATUS) {
+    return true
+  }
+  if (statusCodeOf(err) === CONFLICT_STATUS) {
+    return true
+  }
+  return CONFLICT_MESSAGE_PATTERN.test(err.message)
+}

--- a/app/graphql/retry-policy.ts
+++ b/app/graphql/retry-policy.ts
@@ -1,3 +1,4 @@
+import type { Operation } from "@apollo/client"
 import type { NetworkError } from "@apollo/client/errors"
 
 /**
@@ -22,6 +23,7 @@ const noRetryOperations = [
   "lnNoAmountUsdInvoicePaymentSend",
 
   "onChainPaymentSend",
+  "onChainPaymentSendAll",
   "onChainUsdPaymentSend",
   "onChainUsdPaymentSendAsBtcDenominated",
   "onChainTxFee",
@@ -42,6 +44,25 @@ const noRetryOperations = [
 ]
 
 const UNAUTHORIZED_STATUS = 401
+
+const IDEMPOTENCY_KEY_HEADER = "x-idempotency-key"
+
+/**
+ * Whether the operation's context carries an X-Idempotency-Key header. Such an operation
+ * must never be transport-retried: the server may have already processed the first
+ * attempt, and a replay with the same key is rejected with 409 Conflict, masking a
+ * successful payment as a failure. The header lookup is case-insensitive so a future
+ * casing change cannot silently disable this gate.
+ */
+export const hasIdempotencyKey = (operation: Operation): boolean => {
+  const headers = operation.getContext().headers as Record<string, unknown> | undefined
+  if (!headers) {
+    return false
+  }
+  return Object.keys(headers).some(
+    (key) => key.toLowerCase() === IDEMPOTENCY_KEY_HEADER && Boolean(headers[key]),
+  )
+}
 
 /**
  * Whether the RetryLink should resend a failed operation. It resends only when there is a

--- a/app/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.ts
+++ b/app/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.ts
@@ -1,0 +1,151 @@
+import { useCallback } from "react"
+
+import { gql } from "@apollo/client"
+import {
+  Network,
+  TxDirection,
+  TxStatus,
+  useHomeUnauthedQuery,
+  useTransactionsByPaymentHashLazyQuery,
+} from "@app/graphql/generated"
+import {
+  getHashFromInvoice,
+  Network as NetworkLibGaloy,
+} from "@blinkbitcoin/blink-client"
+
+import { PaymentSendCompletedStatus } from "../use-send-payment"
+
+gql`
+  query transactionsByPaymentHash($walletId: WalletId!, $paymentHash: PaymentHash!) {
+    me {
+      id
+      defaultAccount {
+        id
+        walletById(walletId: $walletId) {
+          id
+          transactionsByPaymentHash(paymentHash: $paymentHash) {
+            id
+            status
+            direction
+            createdAt
+          }
+        }
+      }
+    }
+  }
+`
+
+/** The 409 replay races the original request, so the transaction may not be visible on
+ *  the first look — poll a few times before giving up. */
+const VERIFY_ATTEMPTS = 3
+const VERIFY_DELAY_MS = 2000
+
+type SettledOutcome = {
+  status: PaymentSendCompletedStatus
+  createdAt?: number
+}
+
+type VerifiableTransaction = {
+  status: TxStatus
+  direction: TxDirection
+  createdAt?: number
+}
+
+/** Decodes the payment hash from a bolt11 invoice; undefined when the input is not a
+ *  decodable invoice for the given network (never throws). */
+export const getPaymentHashFromInvoice = (
+  paymentRequest: string,
+  network: Network,
+): string | undefined => {
+  try {
+    return getHashFromInvoice(paymentRequest, network as NetworkLibGaloy)
+  } catch {
+    return undefined
+  }
+}
+
+/** Maps the transactions found for a payment hash to a completed-screen outcome. Only an
+ *  outgoing SUCCESS or PENDING transaction is proof the payment was accepted — SUCCESS
+ *  wins over PENDING, and a FAILURE-only result (or no send at all) yields undefined. */
+export const resolveSettledOutcome = (
+  transactions: ReadonlyArray<VerifiableTransaction> | undefined | null,
+): SettledOutcome | undefined => {
+  const sends = (transactions ?? []).filter((tx) => tx.direction === TxDirection.Send)
+  const settled =
+    sends.find((tx) => tx.status === TxStatus.Success) ??
+    sends.find((tx) => tx.status === TxStatus.Pending)
+  if (!settled) {
+    return undefined
+  }
+  return {
+    status: settled.status === TxStatus.Success ? "SUCCESS" : "PENDING",
+    createdAt: settled.createdAt,
+  }
+}
+
+/** Polls the injected fetcher until it yields a settled outcome or the attempts run out.
+ *  A fetch error or empty result counts as "not found this attempt" and keeps polling. */
+export const pollForSettledStatus = async (
+  fetchTransactions: () => Promise<
+    ReadonlyArray<VerifiableTransaction> | undefined | null
+  >,
+  { attempts, delayMs }: { attempts: number; delayMs: number },
+): Promise<SettledOutcome | undefined> => {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs)
+      })
+    }
+    let transactions: ReadonlyArray<VerifiableTransaction> | undefined | null
+    try {
+      transactions = await fetchTransactions()
+    } catch {
+      transactions = undefined
+    }
+    const outcome = resolveSettledOutcome(transactions)
+    if (outcome) {
+      return outcome
+    }
+  }
+  return undefined
+}
+
+/**
+ * Ground-truth check for whether a payment the server may have already processed (a 409
+ * idempotency conflict) actually settled: looks up the wallet's transactions by the
+ * invoice's payment hash. Returns the outcome to show on the completed screen, or
+ * undefined when the invoice is undecodable or no settled transaction appears in time.
+ */
+export const useVerifyPaymentSettled = (): ((args: {
+  walletId: string
+  paymentRequest: string
+}) => Promise<SettledOutcome | undefined>) => {
+  // no-cache: a one-shot settlement check must not read or pollute the persisted cache
+  const [fetchTransactionsByPaymentHash] = useTransactionsByPaymentHashLazyQuery({
+    fetchPolicy: "no-cache",
+  })
+  const { data: unauthedData } = useHomeUnauthedQuery({ fetchPolicy: "cache-first" })
+  const network = unauthedData?.globals?.network
+
+  return useCallback(
+    async ({ walletId, paymentRequest }) => {
+      const paymentHash = network
+        ? getPaymentHashFromInvoice(paymentRequest, network)
+        : undefined
+      if (!paymentHash) {
+        return undefined
+      }
+      return pollForSettledStatus(
+        async () => {
+          const { data } = await fetchTransactionsByPaymentHash({
+            variables: { walletId, paymentHash },
+          })
+          return data?.me?.defaultAccount?.walletById?.transactionsByPaymentHash
+        },
+        { attempts: VERIFY_ATTEMPTS, delayMs: VERIFY_DELAY_MS },
+      )
+    },
+    [fetchTransactionsByPaymentHash, network],
+  )
+}

--- a/app/screens/send-bitcoin-screen/payment-details/index.types.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/index.types.ts
@@ -192,6 +192,9 @@ type LnurlSpecificProperties<T extends WalletCurrency> =
   | {
       paymentType: typeof PaymentType.Lnurl
       lnurlParams: LnUrlPayServiceResponse
+      /** The bolt11 invoice fetched from the lnurl service; set once an invoice exists
+       *  (i.e. when the payment is sendable). The lnurl string itself is `destination`. */
+      paymentRequest?: string
       setInvoice: SetInvoice<T>
       setSuccessAction: SetSuccessAction<T>
       isMerchant: boolean

--- a/app/screens/send-bitcoin-screen/payment-details/lightning.ts
+++ b/app/screens/send-bitcoin-screen/payment-details/lightning.ts
@@ -503,6 +503,7 @@ export const createLnurlPaymentDetails = <T extends WalletCurrency>(
     sendingWalletDescriptor,
     unitOfAccountAmount,
     paymentType: PaymentType.Lnurl,
+    paymentRequest,
     destination: lnurl,
     settlementAmount,
     memo,

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -11,8 +11,9 @@ import { PaymentDestinationDisplay } from "@app/components/payment-destination-d
 import { Screen } from "@app/components/screen"
 import { WarningBanner } from "@app/components/warning-banner"
 import { HIDDEN_AMOUNT_PLACEHOLDER } from "@app/config"
-import { WalletCurrency } from "@app/graphql/generated"
+import { Transaction, WalletCurrency } from "@app/graphql/generated"
 import { useHideAmount } from "@app/graphql/hide-amount-context"
+import { isIdempotencyConflict } from "@app/graphql/is-idempotency-conflict"
 import { useClipboard, useDisplayCurrency } from "@app/hooks"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
@@ -37,8 +38,10 @@ import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { testProps } from "../../utils/testProps"
 import { useSendBalances } from "./hooks/use-send-wallets"
+import { useVerifyPaymentSettled } from "./hooks/use-verify-payment-settled"
+import { PaymentSendExtraInfo } from "./payment-details/index.types"
 import useFee from "./use-fee"
-import { useSendPayment } from "./use-send-payment"
+import { PaymentSendCompletedStatus, useSendPayment } from "./use-send-payment"
 import { useSaveLnAddressContact } from "./use-save-lnaddress-contact"
 import { ellipsizeMiddle } from "@app/utils/helper"
 
@@ -115,6 +118,8 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
   })
 
   const [paymentError, setPaymentError] = useState<string | undefined>(undefined)
+  const [isVerifying, setIsVerifying] = useState(false)
+  const verifyPaymentSettled = useVerifyPaymentSettled()
   const { LL } = useI18nContext()
   const translateSdkError = useTranslateSdkError()
   const { copyToClipboard } = useClipboard()
@@ -192,6 +197,75 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     moneyAmount: secondaryAmount ?? ZeroUsdMoneyAmount,
   })
 
+  const navigateToCompleted = React.useCallback(
+    async ({
+      status,
+      extraInfo,
+      transaction,
+    }: {
+      status: PaymentSendCompletedStatus
+      extraInfo?: PaymentSendExtraInfo
+      transaction?: Partial<Transaction> | null
+    }) => {
+      await saveLnAddressContact({
+        paymentType,
+        destination,
+        isMerchant:
+          paymentDetail.paymentType === "lnurl" ? paymentDetail.isMerchant : undefined,
+      })
+
+      navigation.dispatch((state) => {
+        const routes = [
+          { name: "Primary" },
+          {
+            name: "sendBitcoinCompleted",
+            params: {
+              arrivalAtMempoolEstimate: extraInfo?.arrivalAtMempoolEstimate,
+              status,
+              successAction: extraInfo?.successAction ?? paymentDetail?.successAction,
+              preimage: extraInfo?.preimage,
+              note,
+              currencyAmount,
+              satAmount,
+              currencyFeeAmount,
+              satFeeAmount,
+              destination:
+                paymentDetail?.paymentType === "intraledger"
+                  ? destination
+                  : ellipsizeMiddle(destination, {
+                      maxLength: 50,
+                      maxResultLeft: 13,
+                      maxResultRight: 8,
+                    }),
+              paymentType: paymentDetail?.paymentType,
+              createdAt: transaction?.createdAt,
+            },
+          },
+        ]
+        return CommonActions.reset({
+          ...state,
+          routes,
+          index: routes.length - 1,
+        })
+      })
+      ReactNativeHapticFeedback.trigger("notificationSuccess", {
+        ignoreAndroidSystemSettings: true,
+      })
+    },
+    [
+      saveLnAddressContact,
+      navigation,
+      paymentType,
+      destination,
+      paymentDetail,
+      note,
+      currencyAmount,
+      satAmount,
+      currencyFeeAmount,
+      satFeeAmount,
+    ],
+  )
+
   const handleSendPayment = React.useCallback(async () => {
     if (!sendPayment || !sendingWalletDescriptor?.currency) {
       return sendPayment
@@ -211,50 +285,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
       })
 
       if (status === "SUCCESS" || status === "PENDING") {
-        await saveLnAddressContact({
-          paymentType,
-          destination,
-          isMerchant:
-            paymentDetail.paymentType === "lnurl" ? paymentDetail.isMerchant : undefined,
-        })
-
-        navigation.dispatch((state) => {
-          const routes = [
-            { name: "Primary" },
-            {
-              name: "sendBitcoinCompleted",
-              params: {
-                arrivalAtMempoolEstimate: extraInfo?.arrivalAtMempoolEstimate,
-                status,
-                successAction: extraInfo?.successAction ?? paymentDetail?.successAction,
-                preimage: extraInfo?.preimage,
-                note,
-                currencyAmount,
-                satAmount,
-                currencyFeeAmount,
-                satFeeAmount,
-                destination:
-                  paymentDetail?.paymentType === "intraledger"
-                    ? destination
-                    : ellipsizeMiddle(destination, {
-                        maxLength: 50,
-                        maxResultLeft: 13,
-                        maxResultRight: 8,
-                      }),
-                paymentType: paymentDetail?.paymentType,
-                createdAt: transaction?.createdAt,
-              },
-            },
-          ]
-          return CommonActions.reset({
-            ...state,
-            routes,
-            index: routes.length - 1,
-          })
-        })
-        ReactNativeHapticFeedback.trigger("notificationSuccess", {
-          ignoreAndroidSystemSettings: true,
-        })
+        await navigateToCompleted({ status, extraInfo, transaction })
         return
       }
 
@@ -277,9 +308,45 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
       if (err instanceof Error) {
         crashlytics().recordError(err)
 
-        const indempotencyErrorPattern = /409: Conflict/i
-        if (indempotencyErrorPattern.test(err.message)) {
+        if (isIdempotencyConflict(err)) {
+          // The server already processed a first attempt of this payment, so it may well
+          // have succeeded — check the ledger before claiming failure.
+          const paymentRequest =
+            paymentDetail.paymentType === "lightning"
+              ? destination
+              : paymentDetail.paymentType === "lnurl"
+                ? paymentDetail.paymentRequest
+                : undefined
+
+          if (paymentRequest) {
+            setIsVerifying(true)
+            let verified
+            try {
+              verified = await verifyPaymentSettled({
+                walletId: sendingWalletDescriptor.id,
+                paymentRequest,
+              })
+            } finally {
+              setIsVerifying(false)
+            }
+            if (verified) {
+              logPaymentResult({
+                paymentType: paymentDetail.paymentType,
+                paymentStatus: verified.status,
+                sendingWallet: sendingWalletDescriptor.currency,
+              })
+              await navigateToCompleted({
+                status: verified.status,
+                transaction: { createdAt: verified.createdAt },
+              })
+              return
+            }
+          }
+
           setPaymentError(LL.SendBitcoinConfirmationScreen.paymentAlreadyAttempted())
+          ReactNativeHapticFeedback.trigger("notificationError", {
+            ignoreAndroidSystemSettings: true,
+          })
           return
         }
 
@@ -288,19 +355,13 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     }
   }, [
     LL,
-    navigation,
     paymentDetail,
     sendPayment,
     setPaymentError,
-    sendingWalletDescriptor?.currency,
-    paymentType,
+    sendingWalletDescriptor,
     destination,
-    saveLnAddressContact,
-    currencyAmount,
-    satAmount,
-    currencyFeeAmount,
-    satFeeAmount,
-    note,
+    navigateToCompleted,
+    verifyPaymentSettled,
     translateSdkError,
   ])
 
@@ -537,7 +598,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
           <PanGestureHandler>
             <View style={styles.sliderContainer}>
               <GaloySliderButton
-                isLoading={sendPaymentLoading}
+                isLoading={sendPaymentLoading || isVerifying}
                 initialText={LL.SendBitcoinConfirmationScreen.slideToConfirm()}
                 loadingText={LL.SendBitcoinConfirmationScreen.slideConfirming()}
                 onSwipe={handleSendPayment}


### PR DESCRIPTION
Closes #3926

## Problem

A payment mutation carrying an `X-Idempotency-Key` could be transport-replayed by an Apollo retry link after the server had already processed the first attempt. Galoy correctly rejects the replay with `409 Conflict` (`the idempotency key already exist`), but the client surfaced this as a payment **failure** — sometimes as a `ServerParseError` ("service 'galoy' response was malformed") — so a user whose payment succeeded could try to pay again.

## Before / after

No new UI is introduced — both end states are existing screens (the confirmation screen's error banner and the standard payment-completed screen). What changes is which one the user lands on, so the behavior change is shown here as a scenario map instead of screenshots (the state is only reachable through a mid-flight network race, and the navigation outcomes are locked by the screen tests below).

| Scenario | Before | After |
| --- | --- | --- |
| Transport replay of a keyed payment (the trigger) | Possible via the 401 retry link (any operation) and `onChainPaymentSendAll` (missing from the no-retry list) → server answers 409 | Never resent: operations carrying an idempotency key are excluded from both retry links, so the conflict can no longer be client-generated |
| 409 received, LN/LNURL payment actually settled | Error banner "Payment already attempted… start from scratch" — or the raw `service 'galoy' response was malformed…` text when the 409 body failed to parse — user may pay again | Ledger is checked by payment hash (3 × 2 s); confirmed SUCCESS/PENDING routes to the normal **payment-completed screen** |
| 409 received, settlement not confirmable within ~6 s | Same error banner / raw text | "Payment already attempted" banner (accurate: the key is burned, a fresh flow is needed) |
| 409 on intraledger / on-chain | Raw error text or the banner, depending on message shape | Consistent "Payment already attempted" banner (no unique payment identity in the schema to verify against — deliberate) |
| Any other payment error | Unchanged | Unchanged |

```mermaid
flowchart TD
    A[Payment mutation throws] --> B{isIdempotencyConflict?\nstatusCode 409 incl. ServerParseError}
    B -- no --> C[Show error message\nunchanged behavior]
    B -- yes --> D{Invoice available?\nLightning / LNURL}
    D -- no --> G[Show 'Payment already attempted']
    D -- yes --> E[Decode payment hash,\npoll transactionsByPaymentHash 3x2s]
    E -- SUCCESS / PENDING found --> F[Navigate to payment-completed screen]
    E -- nothing / FAILURE only --> G
```

## Changes

**Retry gate (root cause)**
- New `hasIdempotencyKey(operation)` in `app/graphql/retry-policy.ts`: an operation whose context carries an `X-Idempotency-Key` header is never transport-retried, in both the general `retryLink` and the previously operation-agnostic `retry401ErrorLink`. Structural — any future keyed mutation is automatically covered.
- Added the missing `onChainPaymentSendAll` to the `noRetryOperations` belt-and-braces list.

**Robust 409 detection**
- New `app/graphql/is-idempotency-conflict.ts` detects the conflict via `statusCode === 409` on the wrapped `ServerError`/`ServerParseError` (the "malformed response" variant the old `/409: Conflict/i` regex missed), with a tight message-pattern fallback.

**Verify then succeed**
- New `transactionsByPaymentHash` query + `useVerifyPaymentSettled` hook: on a 409, the confirmation screen decodes the payment hash from the invoice (Lightning via `destination`; LNURL via a newly exposed `paymentDetail.paymentRequest`) and polls the ledger (3 × 2 s, `no-cache`). A confirmed SUCCESS/PENDING transaction routes to the normal completed screen instead of showing an error; the slider shows a loading state while verifying.
- Intraledger/on-chain sends keep the existing `paymentAlreadyAttempted` fallback deliberately — the schema offers no unique payment identity for them, and with the retry gate in place client-generated 409s should no longer occur; the verification path is defense-in-depth.

## Tests

- `__tests__/graphql/retry-policy.spec.ts`: `hasIdempotencyKey` cases + `onChainPaymentSendAll` no-retry.
- `__tests__/graphql/is-idempotency-conflict.spec.ts`: ServerError/ServerParseError/bare-409/message-fallback matrix, plus negatives.
- `__tests__/screens/send-bitcoin-screen/hooks/use-verify-payment-settled.spec.ts`: hash decoding (real mainnet mock invoice), settlement resolution matrix, polling behavior, and the hook's Apollo wiring (query variables, undecodable-invoice / unknown-network short-circuits, poll-and-give-up timing).
- `__tests__/screens/send-confirmation.spec.tsx`: the 409 recovery flow end to end on the screen — verified settlement navigates to `sendBitcoinCompleted`, unverifiable falls back to the banner, intraledger skips verification, non-conflict errors pass through unchanged.
- `__tests__/payment-details/lnurl-payment-details.spec.ts`: `paymentRequest` exposed once an invoice is fetched, absent before.

`yarn tsc:check` clean, eslint clean on touched files, targeted suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
