### PR TITLE
fix(ui): remove doubled bottom safe-area inset on tab screens

### DIFF
--- a/__tests__/components/screen.spec.tsx
+++ b/__tests__/components/screen.spec.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { Text } from "react-native"
+import { render } from "@testing-library/react-native"
+
+import { Screen } from "@app/components/screen"
+
+jest.mock("@rn-vui/themed", () => ({
+  useTheme: () => ({ theme: { mode: "light", colors: { white: "#FFFFFF" } } }),
+}))
+
+jest.mock("react-native-safe-area-context", () => {
+  const ReactActual = jest.requireActual<typeof React>("react")
+  return {
+    SafeAreaView: ({ children, ...props }: React.PropsWithChildren<object>) =>
+      ReactActual.createElement("SafeAreaView", { ...props, testID: "safe-area" }, children),
+  }
+})
+
+const renderScreen = (props: React.ComponentProps<typeof Screen> = {}) =>
+  render(
+    <Screen {...props}>
+      <Text>content</Text>
+    </Screen>,
+  )
+
+describe("Screen safe-area edges", () => {
+  it("defaults to all edges when the header is hidden", () => {
+    const { getByTestId } = renderScreen({ headerShown: false })
+    expect(getByTestId("safe-area").props.edges).toEqual([
+      "top",
+      "left",
+      "right",
+      "bottom",
+    ])
+  })
+
+  it("defaults to side and bottom edges when a header is shown", () => {
+    const { getByTestId } = renderScreen()
+    expect(getByTestId("safe-area").props.edges).toEqual(["left", "right", "bottom"])
+  })
+
+  it("lets the edges prop override the derived edges", () => {
+    const { getByTestId } = renderScreen({
+      headerShown: false,
+      edges: ["top", "left", "right"],
+    })
+    expect(getByTestId("safe-area").props.edges).toEqual(["top", "left", "right"])
+  })
+
+  it("applies the edges override on scrolling screens too", () => {
+    const { getByTestId } = renderScreen({ preset: "scroll", edges: ["left", "right"] })
+    expect(getByTestId("safe-area").props.edges).toEqual(["left", "right"])
+  })
+
+  it("renders no SafeAreaView when unsafe, even with edges set", () => {
+    const { queryByTestId } = renderScreen({ unsafe: true, edges: ["bottom"] })
+    expect(queryByTestId("safe-area")).toBeNull()
+  })
+})

--- a/__tests__/components/screen.spec.tsx
+++ b/__tests__/components/screen.spec.tsx
@@ -12,7 +12,11 @@ jest.mock("react-native-safe-area-context", () => {
   const ReactActual = jest.requireActual<typeof React>("react")
   return {
     SafeAreaView: ({ children, ...props }: React.PropsWithChildren<object>) =>
-      ReactActual.createElement("SafeAreaView", { ...props, testID: "safe-area" }, children),
+      ReactActual.createElement(
+        "SafeAreaView",
+        { ...props, testID: "safe-area" },
+        children,
+      ),
   }
 })
 

--- a/__tests__/screens/earn-map-screen.spec.tsx
+++ b/__tests__/screens/earn-map-screen.spec.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import type { ReactTestInstance } from "react-test-renderer"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
@@ -40,6 +41,21 @@ describe("EarnMapScreen", () => {
     loadLocale("en")
     LL = i18nObject("en")
     mockNavigate.mockClear()
+  })
+  it("excludes the bottom safe-area edge on the loading screen", () => {
+    mockedUseQuizServer.mockReturnValue({
+      loading: true,
+      earnedSats: 0,
+      quizServerData: [],
+    })
+    const { UNSAFE_getAllByType } = render(
+      <ContextForScreen>
+        <EarnMapScreen />
+      </ContextForScreen>,
+    )
+
+    const edges = UNSAFE_getAllByType(SafeAreaView).map((view) => view.props.edges)
+    expect(edges).toContainEqual(["left", "right"])
   })
   it("closes the one-section-per-day modal when continuing without rewards", async () => {
     const futureSeconds = Math.floor(Date.now() / 1000) + 3600

--- a/__tests__/screens/earn-map-screen.spec.tsx
+++ b/__tests__/screens/earn-map-screen.spec.tsx
@@ -48,6 +48,7 @@ describe("EarnMapScreen", () => {
       earnedSats: 0,
       quizServerData: [],
     })
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
     const { UNSAFE_getAllByType } = render(
       <ContextForScreen>
         <EarnMapScreen />

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -3,6 +3,7 @@ import { it } from "@jest/globals"
 import { MockedResponse } from "@apollo/client/testing"
 import { fireEvent, render, waitFor } from "@testing-library/react-native"
 import { StyleSheet } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 
 import { HomeScreen } from "../../app/screens/home-screen"
 import { ContextForScreen } from "./helper"
@@ -658,6 +659,19 @@ describe("HomeScreen", () => {
     await flushEffects()
 
     expect(getByTestId("slide-up-handle")).toBeTruthy()
+  })
+
+  it("excludes the bottom safe-area edge the tab bar already reserves", async () => {
+    const { UNSAFE_getAllByType } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    const edges = UNSAFE_getAllByType(SafeAreaView).map((view) => view.props.edges)
+    expect(edges).toContainEqual(["top", "left", "right"])
+    expect(edges).not.toContainEqual(expect.arrayContaining(["bottom"]))
   })
 
   it.each([...iosCases, ...androidCases] satisfies ConvertButtonCase[])(

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -662,6 +662,7 @@ describe("HomeScreen", () => {
   })
 
   it("excludes the bottom safe-area edge the tab bar already reserves", async () => {
+    // eslint-disable-next-line camelcase -- testing-library exposes this API verbatim
     const { UNSAFE_getAllByType } = render(
       <ContextForScreen>
         <HomeScreen />

--- a/__tests__/screens/map-screen.spec.tsx
+++ b/__tests__/screens/map-screen.spec.tsx
@@ -14,6 +14,7 @@ let capturedHandleCalloutPress:
       mapInfo: { coordinates: { latitude: number; longitude: number }; title: string }
     }) => void)
   | undefined
+let capturedScreenProps: Record<string, unknown> | undefined
 
 jest.mock("@react-navigation/native", () => ({
   useFocusEffect: jest.fn(),
@@ -90,8 +91,10 @@ jest.mock("@app/components/screen", () => {
   const ReactActual = jest.requireActual("react")
   const RN = jest.requireActual("react-native")
   return {
-    Screen: ({ children }: { children?: React.ReactNode }) =>
-      ReactActual.createElement(RN.View, null, children),
+    Screen: ({ children, ...props }: { children?: React.ReactNode }) => {
+      capturedScreenProps = props
+      return ReactActual.createElement(RN.View, null, children)
+    },
   }
 })
 
@@ -140,6 +143,17 @@ describe("MapScreen.handleCalloutPress", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     capturedHandleCalloutPress = undefined
+    capturedScreenProps = undefined
+  })
+
+  it("excludes the bottom safe-area edge the tab bar already reserves", async () => {
+    mockUseIsAuthed.mockReturnValue(true)
+    mockUseActiveWallet.mockReturnValue({ isSelfCustodial: false })
+
+    renderMapScreen()
+    await waitForCalloutHandler()
+
+    expect(capturedScreenProps?.edges).toEqual(["left", "right"])
   })
 
   it("navigates to sendBitcoinDestination for a custodial authed user", async () => {

--- a/__tests__/screens/people.spec.tsx
+++ b/__tests__/screens/people.spec.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { render } from "@testing-library/react-native"
+
+import { PeopleScreen } from "@app/screens/people-screen/people"
+
+jest.mock("@rn-vui/themed", () => {
+  const colors: Record<string, string> = { white: "#FFFFFF" }
+  return {
+    makeStyles:
+      (fn: (theme: { colors: Record<string, string> }) => Record<string, object>) =>
+      () =>
+        fn({ colors }),
+    useTheme: () => ({ theme: { mode: "light", colors } }),
+  }
+})
+
+jest.mock("react-native-safe-area-context", () => {
+  const ReactActual = jest.requireActual<typeof React>("react")
+  return {
+    SafeAreaView: ({ children, ...props }: React.PropsWithChildren<object>) =>
+      ReactActual.createElement("SafeAreaView", { ...props, testID: "safe-area" }, children),
+  }
+})
+
+jest.mock("@app/screens/people-screen/circles/circles-card-people-home", () => ({
+  CirclesCardPeopleHome: () => null,
+}))
+jest.mock("@app/screens/people-screen/contacts/contacts-card", () => ({
+  ContactsCard: () => null,
+}))
+jest.mock("@app/screens/people-screen/circles/invite-friends-card", () => ({
+  InviteFriendsCard: () => null,
+}))
+
+describe("PeopleScreen", () => {
+  it("excludes the bottom safe-area edge the tab bar already reserves", () => {
+    const { getByTestId } = render(<PeopleScreen />)
+
+    expect(getByTestId("safe-area").props.edges).toEqual(["top", "left", "right"])
+  })
+})

--- a/__tests__/screens/people.spec.tsx
+++ b/__tests__/screens/people.spec.tsx
@@ -7,8 +7,7 @@ jest.mock("@rn-vui/themed", () => {
   const colors: Record<string, string> = { white: "#FFFFFF" }
   return {
     makeStyles:
-      (fn: (theme: { colors: Record<string, string> }) => Record<string, object>) =>
-      () =>
+      (fn: (theme: { colors: Record<string, string> }) => Record<string, object>) => () =>
         fn({ colors }),
     useTheme: () => ({ theme: { mode: "light", colors } }),
   }
@@ -18,7 +17,11 @@ jest.mock("react-native-safe-area-context", () => {
   const ReactActual = jest.requireActual<typeof React>("react")
   return {
     SafeAreaView: ({ children, ...props }: React.PropsWithChildren<object>) =>
-      ReactActual.createElement("SafeAreaView", { ...props, testID: "safe-area" }, children),
+      ReactActual.createElement(
+        "SafeAreaView",
+        { ...props, testID: "safe-area" },
+        children,
+      ),
   }
 })
 

--- a/app/components/screen/screen.props.ts
+++ b/app/components/screen/screen.props.ts
@@ -1,4 +1,5 @@
 import { ViewStyle } from "react-native"
+import { Edge } from "react-native-safe-area-context"
 
 import { KeyboardOffsets, ScreenPresets } from "./screen.presets"
 
@@ -32,6 +33,12 @@ export interface ScreenProps {
    * Should we not wrap in SafeAreaView? Defaults to false.
    */
   unsafe?: boolean
+
+  /**
+   * Overrides the safe-area edges derived from headerShown. Ignored when unsafe.
+   * Tab screens should omit "bottom" — the tab bar already reserves that inset.
+   */
+  edges?: Edge[]
 
   headerShown?: boolean
 

--- a/app/components/screen/screen.tsx
+++ b/app/components/screen/screen.tsx
@@ -26,9 +26,10 @@ function ScreenWithoutScrolling(props: ScreenProps) {
 
   const edges: Edge[] | undefined = props.unsafe
     ? undefined
-    : props.headerShown === false
-      ? ["top", "left", "right", "bottom"]
-      : ["left", "right", "bottom"]
+    : props.edges ??
+      (props.headerShown === false
+        ? ["top", "left", "right", "bottom"]
+        : ["left", "right", "bottom"])
 
   return (
     <KeyboardAvoidingView
@@ -63,9 +64,10 @@ function ScreenWithScrolling(props: ScreenProps) {
 
   const edges: Edge[] | undefined = props.unsafe
     ? undefined
-    : props.headerShown === false
-      ? ["top", "left", "right", "bottom"]
-      : ["left", "right", "bottom"]
+    : props.edges ??
+      (props.headerShown === false
+        ? ["top", "left", "right", "bottom"]
+        : ["left", "right", "bottom"])
 
   return (
     <KeyboardAvoidingView

--- a/app/screens/earns-map-screen/earns-map-screen.tsx
+++ b/app/screens/earns-map-screen/earns-map-screen.tsx
@@ -269,7 +269,7 @@ const EarnMapScreenContent: React.FC = () => {
 
   if (loading) {
     return (
-      <Screen>
+      <Screen edges={["left", "right"]}>
         <View style={styles.loadingView}>
           <ActivityIndicator size="large" color={colors._blue} />
         </View>

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -667,7 +667,7 @@ export const HomeScreen: React.FC = () => {
   }
 
   return (
-    <Screen headerShown={false}>
+    <Screen headerShown={false} edges={["top", "left", "right"]}>
       {AccountCreationNeededModal}
       <StableSatsModal
         isVisible={isStablesatModalVisible}

--- a/app/screens/map-screen/map-screen.tsx
+++ b/app/screens/map-screen/map-screen.tsx
@@ -184,7 +184,7 @@ export const MapScreen: React.FC<Props> = ({ navigation }) => {
   }
 
   return (
-    <Screen>
+    <Screen edges={["left", "right"]}>
       {initialLocation && (
         <MapComponent
           data={data}

--- a/app/screens/people-screen/people.tsx
+++ b/app/screens/people-screen/people.tsx
@@ -11,7 +11,12 @@ export const PeopleScreen: React.FC = () => {
   const styles = useStyles()
 
   return (
-    <Screen style={styles.screen} preset="scroll" headerShown={false}>
+    <Screen
+      style={styles.screen}
+      preset="scroll"
+      headerShown={false}
+      edges={["top", "left", "right"]}
+    >
       <CirclesCardPeopleHome />
       <ContactsCard />
       <InviteFriendsCard />


### PR DESCRIPTION
Fixes #3969

## Summary

On tab screens there is a ~34pt band of dead space between the content and the bottom tab bar on home-indicator devices. The shared `Screen` component's `SafeAreaView` always applies the `bottom` safe-area edge, but the bottom-tab bar already reserves `60 + insets.bottom` — so the inset is padded twice. With the migration reminder and the self-custodial announcement now competing for room on Home, that lost real estate matters.

## Changes

- Add an optional `edges` prop to `Screen` that overrides the safe-area edges derived from `headerShown` (ignored when `unsafe`). Screens that don't pass it are unchanged.
- Drop the `bottom` edge on the four tab screens: Home, People, Map, and the Earn loading state (the main Earn render is already `unsafe`).

## Notes

- The 100pt `SCROLL_BOTTOM_CLEARANCE` on Home (#3955) is unchanged: the `SlideUpHandle` is anchored to the same content box, so it shifts down with the viewport and still covers the bottom ~97pt of the scroll view.
- On devices without a bottom inset (e.g. SE, Android 3-button nav) there is no visual change.

## Test plan

- [x] `yarn tsc:check`, eslint clean on touched files
- [x] `home.spec.tsx`, `map-screen.spec.tsx`, `earn-map-screen.spec.tsx` — 62/62 pass
- [x] New coverage: `__tests__/components/screen.spec.tsx` (edges matrix: derived defaults, override in fixed + scroll variants, `unsafe`), plus per-tab-screen asserts — Home & Earn loading via rendered `SafeAreaView` edges, Map via captured `Screen` props, People via a new minimal spec — 71/71 pass
- [ ] Manual iOS check on a home-indicator device: dead band gone on all four tabs; Home scrolled to max still clears the SlideUpHandle; handle sits 15pt above the tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

iPhone 16 Pro simulator, same account and scroll position. Note the whitespace band between the clipped bulletin and the tab bar on the left — gone on the right.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-3968-assets/before-home.png" width="320" /> | <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-3968-assets/after-home.png" width="320" /> |

Close-up of the bottom region — before, the last bulletin clips ~34pt above the tab bar with a dead white band below it; after, the content runs to the tab bar edge and three more lines of the bulletin are visible:

| Before (close-up) | After (close-up) |
|---|---|
| <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-3968-assets/before-home-closeup.png" width="400" /> | <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-3968-assets/after-home-closeup.png" width="400" /> |

Home is the only tab with a visible at-rest delta: People's content is top-anchored and shorter than the viewport, Map sizes itself independently of the container, and the Earn change only affects a transient loading spinner. Those call sites are locked by the tests instead (see test plan).


