### PR TITLE
fix(send): prefer lightning= LNURL over onchain in unified BIP-21 URIs

### DIFF
--- a/__tests__/payment-destination/unified-bip21.spec.ts
+++ b/__tests__/payment-destination/unified-bip21.spec.ts
@@ -115,11 +115,30 @@ describe("parseDestination with unified BIP-21 URIs", () => {
     )
   })
 
-  it("falls back to the onchain address when LNURL resolution fails", async () => {
+  it("prefers the LNURL even when the onchain address is on the wrong network", async () => {
+    const testnetAddress = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"
+
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${testnetAddress}?lightning=${lnurl}`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        destinationDirection: DestinationDirection.Send,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Lnurl,
+          lnurl,
+        }),
+      }),
+    )
+  })
+
+  it("falls back to the onchain address and amount when LNURL resolution fails", async () => {
     mockRequestPayServiceParams.mockRejectedValue(new Error("network error"))
 
     const destination = await parseDestination(
-      parseParams(`bitcoin:${onchainAddress}?lightning=${lnurl}`),
+      parseParams(`bitcoin:${onchainAddress}?amount=0.001&lightning=${lnurl}`),
     )
 
     expect(destination).toEqual(
@@ -128,6 +147,7 @@ describe("parseDestination with unified BIP-21 URIs", () => {
         validDestination: expect.objectContaining({
           paymentType: PaymentType.Onchain,
           address: onchainAddress,
+          amount: 100000,
         }),
       }),
     )
@@ -208,6 +228,15 @@ describe("getLnurlFromUnifiedUri", () => {
     expect(
       getLnurlFromUnifiedUri(
         `bitcoin:${onchainAddress}?lightning=${encodeURIComponent(lnurl.toUpperCase())}`,
+      ),
+    ).toBe(lnurl)
+  })
+
+  it("keeps the raw value when percent-decoding fails", () => {
+    // trailing bare "%" makes decodeURIComponent throw; the raw value still parses
+    expect(
+      getLnurlFromUnifiedUri(
+        `bitcoin:${onchainAddress}?lightning=${lnurl.toUpperCase()}%`,
       ),
     ).toBe(lnurl)
   })

--- a/__tests__/payment-destination/unified-bip21.spec.ts
+++ b/__tests__/payment-destination/unified-bip21.spec.ts
@@ -1,0 +1,226 @@
+import { getParams } from "js-lnurl"
+import { requestPayServiceParams, LnUrlPayServiceResponse, Satoshis } from "lnurl-pay"
+
+import { Network } from "@app/graphql/generated"
+import {
+  getLnurlFromUnifiedUri,
+  parseDestination,
+} from "@app/screens/send-bitcoin-screen/payment-destination"
+import { DestinationDirection } from "@app/screens/send-bitcoin-screen/payment-destination/index.types"
+import { PaymentType } from "@blinkbitcoin/blink-client"
+
+// Real parser + LNURL detection; only the network boundaries are mocked.
+jest.mock("js-lnurl", () => ({
+  ...jest.requireActual("js-lnurl"),
+  getParams: jest.fn(),
+}))
+jest.mock("lnurl-pay", () => ({
+  ...jest.requireActual("lnurl-pay"),
+  requestPayServiceParams: jest.fn(),
+}))
+
+// Payment-detail builders are lazy (createPaymentDetail closures); stub them so the
+// real parser graph loads without pulling the heavy detail factories.
+jest.mock("@app/screens/send-bitcoin-screen/payment-details", () => ({
+  createAmountOnchainPaymentDetails: jest.fn(),
+  createNoAmountOnchainPaymentDetails: jest.fn(),
+  createAmountLightningPaymentDetails: jest.fn(),
+  createNoAmountLightningPaymentDetails: jest.fn(),
+  createIntraledgerPaymentDetails: jest.fn(),
+  createLnurlPaymentDetails: jest.fn(),
+}))
+
+const mockGetParams = getParams as jest.MockedFunction<typeof getParams>
+const mockRequestPayServiceParams = requestPayServiceParams as jest.MockedFunction<
+  typeof requestPayServiceParams
+>
+
+// BIP-173 mainnet test vector
+const onchainAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+// LNURL from issue #3964 (BTCPay unified QR), lowercased
+const lnurl =
+  "lnurl1dp68gurn8ghj7cn5vdcxz7fwwpjhg7nnvd5zuet49ap9gse024y5cnj42fxz7urp0yhkjt64f44yxdr3f3vxz3nhxdmhxkt2v9png33kgg7u80eh"
+// BOLT11 spec test vector (donation invoice, no expiry tag)
+const bolt11 =
+  "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w"
+
+const externalLnurlPayParams: LnUrlPayServiceResponse = {
+  callback: "https://external.com/callback",
+  fixed: false,
+  min: 1 as Satoshis,
+  max: 1000000 as Satoshis,
+  domain: "external.com",
+  metadata: [["text/plain", "pay bob"]],
+  metadataHash: "hash",
+  identifier: "bob@external.com",
+  description: "",
+  image: "",
+  commentAllowed: 0,
+  rawData: {},
+}
+
+const parseParams = (rawInput: string) => ({
+  rawInput,
+  myWalletIds: ["my-wallet-id"],
+  bitcoinNetwork: Network.Mainnet,
+  lnurlDomains: ["blink.sv"],
+  accountDefaultWalletQuery: jest.fn() as never,
+})
+
+describe("parseDestination with unified BIP-21 URIs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetParams.mockResolvedValue({
+      status: "OK",
+      reason: "",
+      domain: "external.com",
+      url: "https://external.com",
+    } as never)
+    mockRequestPayServiceParams.mockResolvedValue(externalLnurlPayParams)
+  })
+
+  it("prefers the lightning= LNURL over the onchain address", async () => {
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${onchainAddress}?lightning=${lnurl}`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        destinationDirection: DestinationDirection.Send,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Lnurl,
+          lnurl,
+        }),
+      }),
+    )
+  })
+
+  it("handles fully-uppercase BTCPay QR content", async () => {
+    const destination = await parseDestination(
+      parseParams(
+        `BITCOIN:${onchainAddress.toUpperCase()}?LIGHTNING=${lnurl.toUpperCase()}`,
+      ),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        destinationDirection: DestinationDirection.Send,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Lnurl,
+          lnurl,
+        }),
+      }),
+    )
+  })
+
+  it("falls back to the onchain address when LNURL resolution fails", async () => {
+    mockRequestPayServiceParams.mockRejectedValue(new Error("network error"))
+
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${onchainAddress}?lightning=${lnurl}`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Onchain,
+          address: onchainAddress,
+        }),
+      }),
+    )
+  })
+
+  it("falls back to the onchain address when LNURL resolution throws hard", async () => {
+    mockRequestPayServiceParams.mockRejectedValue(new Error("network error"))
+    mockGetParams.mockRejectedValue(new Error("network error"))
+
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${onchainAddress}?lightning=${lnurl}`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Onchain,
+          address: onchainAddress,
+        }),
+      }),
+    )
+  })
+
+  it("leaves plain onchain URIs untouched", async () => {
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${onchainAddress}?amount=0.001`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Onchain,
+          address: onchainAddress,
+        }),
+      }),
+    )
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+    expect(mockGetParams).not.toHaveBeenCalled()
+  })
+
+  it("still resolves a lightning= bolt11 invoice as Lightning", async () => {
+    const destination = await parseDestination(
+      parseParams(`bitcoin:${onchainAddress}?lightning=${bolt11}`),
+    )
+
+    expect(destination).toEqual(
+      expect.objectContaining({
+        valid: true,
+        validDestination: expect.objectContaining({
+          paymentType: PaymentType.Lightning,
+          paymentRequest: bolt11,
+        }),
+      }),
+    )
+    expect(mockRequestPayServiceParams).not.toHaveBeenCalled()
+    expect(mockGetParams).not.toHaveBeenCalled()
+  })
+})
+
+describe("getLnurlFromUnifiedUri", () => {
+  it("extracts an LNURL from the lightning param", () => {
+    expect(getLnurlFromUnifiedUri(`bitcoin:${onchainAddress}?lightning=${lnurl}`)).toBe(
+      lnurl,
+    )
+  })
+
+  it("matches param name and value case-insensitively", () => {
+    expect(
+      getLnurlFromUnifiedUri(
+        `BITCOIN:${onchainAddress.toUpperCase()}?AMOUNT=0.001&LIGHTNING=${lnurl.toUpperCase()}`,
+      ),
+    ).toBe(lnurl)
+  })
+
+  it("decodes percent-encoded values", () => {
+    expect(
+      getLnurlFromUnifiedUri(
+        `bitcoin:${onchainAddress}?lightning=${encodeURIComponent(lnurl.toUpperCase())}`,
+      ),
+    ).toBe(lnurl)
+  })
+
+  it("returns undefined when there is no lightning param", () => {
+    expect(getLnurlFromUnifiedUri(`bitcoin:${onchainAddress}?amount=0.001`)).toBe(
+      undefined,
+    )
+  })
+
+  it("returns undefined for bolt11 values (handled by the library)", () => {
+    expect(getLnurlFromUnifiedUri(`bitcoin:${onchainAddress}?lightning=${bolt11}`)).toBe(
+      undefined,
+    )
+  })
+})

--- a/app/screens/send-bitcoin-screen/payment-destination/index.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.ts
@@ -13,12 +13,14 @@ import { resolveIntraledgerDestination } from "./intraledger"
 import { resolveLightningDestination } from "./lightning"
 import { resolveLnurlDestination } from "./lnurl"
 import { resolveOnchainDestination } from "./onchain"
+import { getLnurlFromUnifiedUri } from "./unified"
 
 export * from "./intraledger"
 export * from "./lightning"
 export * from "./lnurl"
 export * from "./onchain"
 export * from "./spark"
+export * from "./unified"
 
 export const parseDestination = async ({
   rawInput,
@@ -65,6 +67,30 @@ export const parseDestination = async ({
       return resolveLightningDestination(parsedDestination)
     }
     case PaymentType.Onchain: {
+      // BIP-21 unified URIs carrying a lightning=LNURL param end up here because
+      // parsePaymentDestination only resolves bolt11 lightning params. Prefer the
+      // lightning option and keep the onchain address as fallback.
+      const lnurl = getLnurlFromUnifiedUri(rawInput)
+      if (lnurl) {
+        try {
+          const lnurlDestination = await resolveLnurlDestination({
+            parsedLnurlDestination: {
+              paymentType: PaymentType.Lnurl,
+              valid: true,
+              lnurl,
+              isMerchant: false,
+            },
+            lnurlDomains,
+            accountDefaultWalletQuery,
+            myWalletIds,
+          })
+          if (lnurlDestination.valid) {
+            return lnurlDestination
+          }
+        } catch {
+          // fall back to the onchain destination on any resolution failure
+        }
+      }
       return resolveOnchainDestination(parsedDestination)
     }
     default: {

--- a/app/screens/send-bitcoin-screen/payment-destination/unified.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/unified.ts
@@ -1,0 +1,22 @@
+import { utils } from "lnurl-pay"
+
+// Extracts an LNURL from the `lightning=` param of a BIP-21 unified URI.
+// Returns undefined when there is no lightning param or it is not an LNURL
+// (e.g. bolt11 invoices, which parsePaymentDestination already handles).
+// Matching is case-insensitive: BTCPay QR codes are often fully uppercase,
+// which parsePaymentDestination misses and classifies as plain onchain.
+export const getLnurlFromUnifiedUri = (rawInput: string): string | undefined => {
+  const match = rawInput.match(/[?&]lightning=([^&\s]+)/i)
+  if (!match) {
+    return undefined
+  }
+
+  let value = match[1]
+  try {
+    value = decodeURIComponent(value)
+  } catch {
+    // keep the raw value on malformed percent-encoding
+  }
+
+  return utils.parseLnUrl(value) ?? undefined
+}


### PR DESCRIPTION
Fixes #3964

## Problem

Scanning a BTCPay unified BIP-21 QR (`bitcoin:bc1q...?lightning=LNURL1...`) lands on the Send screen with the **onchain** address pre-selected; the LNURL is silently dropped.

Root cause is in `@blinkbitcoin/blink-client@0.6.0`:
- `parsePaymentDestination` classifies the URI as `Unified`, but its unified resolver only decodes **bolt11** `lightning=` values; an **LNURL** value fails the `^lnbc` network-prefix check and falls back to the onchain address.
- Fully-uppercase QR content (`BITCOIN:...?LIGHTNING=...`, the common BTCPay shape) is never classified as `Unified` at all — the library reads the param case-sensitively — so it goes straight to `Onchain`.

`?lightning=lnbc...` (bolt11) already worked; only LNURL values were affected.

## Solution

App-side interception in `parseDestination`, gated on the parser returning `Onchain` (which covers both broken shapes):

- New `getLnurlFromUnifiedUri` helper extracts the `lightning=` param case-insensitively and validates it with `lnurl-pay`'s `utils.parseLnUrl` (returns `undefined` for bolt11, leaving the library's existing unified behavior untouched).
- When an LNURL is present, resolve it through the existing `resolveLnurlDestination` (so Blink-owned LNURLs still collapse to intraledger and lnurl-withdraw still yields a Receive destination) and fall back to the onchain destination on any resolution failure.

Upstream fix requested in blinkbitcoin/blink-client#49; once released, this interception can shrink to a `Unified`-aware switch case.

## Testing

- New `__tests__/payment-destination/unified-bip21.spec.ts` (13 tests, TDD): LNURL preferred over onchain, uppercase BTCPay QR shape, fallback to onchain on LNURL resolution failure (soft + hard), plain onchain URIs untouched, bolt11 `lightning=` regression guard, and unit tests for the extraction helper.
- Existing `lnurl` / `onchain` / `resolve-destination` specs still green (34/34 across the five suites), `tsc -p .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Same unified BIP-21 URI pasted on the scan screen (iPhone 16 Pro simulator, mainnet). The QR content is the one from #3964 with a live LNURL substituted for the expired BTCPay invoice LNURL: `bitcoin:BC1QCV...?lightning=LNURL1...` (`hello@getalby.com`).

| Before (main) | After (this PR) |
| --- | --- |
| <img src="https://gist.githubusercontent.com/grimen/9098258013ed13dea6a233c3422ff4ed/raw/15b3a0fbe76489c914b12c62dac28b2785ce4e13/before-3964.png" width="320" alt="Before: Destination - Onchain with bc1q address" /> | <img src="https://gist.githubusercontent.com/grimen/9098258013ed13dea6a233c3422ff4ed/raw/15b3a0fbe76489c914b12c62dac28b2785ce4e13/after-3964.png" width="320" alt="After: Destination - Lightning with LNURL and Sats for Alby note" /> |

Before: the `lightning=` param is dropped and the onchain address is pre-selected. After: the LNURL is preferred — Destination shows Lightning with the LNURL and the pay request's "Sats for Alby" description.
