### PR TITLE
fix(lnurl-withdraw): show pending state and poll for payment status

### DIFF
--- a/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
+++ b/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
@@ -245,6 +245,39 @@ describe("useLnurlWithdrawRedemption — self-custodial branch", () => {
     expect(mockRedeemingError).not.toHaveBeenCalled()
   })
 
+  it("falls back to redeemingError when the self-custodial adapter rejects outright", async () => {
+    mockLnurlWithdraw.mockRejectedValueOnce(new Error("adapter exploded"))
+
+    const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+    await flushEffects()
+
+    expect(result.current.errorMessage).toBe("fallback-redeeming-error")
+    expect(result.current.paid).toBe(false)
+  })
+
+  it("ignores an adapter rejection that lands after unmount (rejection cancellation guard)", async () => {
+    let rejectAdapter: (err: Error) => void = () => {}
+    mockLnurlWithdraw.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectAdapter = reject
+        }),
+    )
+
+    const { unmount } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+    await flushEffects()
+
+    unmount()
+
+    await act(async () => {
+      rejectAdapter(new Error("late failure"))
+      await flushEffects()
+    })
+
+    expect(mockRedeemingError).not.toHaveBeenCalled()
+  })
+
   it("sets pending=true (no error) when the self-custodial adapter resolves Pending (C2)", async () => {
     mockLnurlWithdraw.mockResolvedValue({ status: PaymentResultStatus.Pending })
 
@@ -396,6 +429,16 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
 
     expect(result.current.paid).toBe(true)
     expect(mockApolloRefetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("surfaces an error when the mutation resolves without data (no-data contract)", async () => {
+    mockLnInvoiceCreate.mockResolvedValueOnce({ data: undefined })
+
+    const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+    await flushEffects()
+
+    expect(result.current.errorMessage).toContain("No data returned from lnInvoiceCreate")
   })
 
   it("sets the localized error message when the mutation returns errors[]", async () => {
@@ -652,6 +695,57 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
         })
         await flushEffects()
         expect(result.current.paid).toBe(true)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("ignores a stale poll response that resolves after the payment was already confirmed", async () => {
+      arrangeAcceptedWithdrawal()
+      let resolvePoll: (value: unknown) => void = () => {}
+      mockApolloQuery.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePoll = resolve
+          }),
+      )
+
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { result, rerender } = renderHook(
+          (props: typeof defaultParams) => useLnurlWithdrawRedemption(props),
+          { initialProps: defaultParams },
+        )
+
+        await flushEffects()
+        await flushEffects()
+        expect(result.current.pending).toBe(true)
+
+        // A poll tick fires and its query stays in flight...
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        expect(mockApolloQuery).toHaveBeenCalledTimes(1)
+
+        // ...then the websocket confirms the payment first (cleanup cancels the poll)
+        mockUseLnUpdateHashPaid.mockReturnValue("hash-A")
+        rerender(defaultParams)
+        await flushEffects()
+        expect(result.current.paid).toBe(true)
+        expect(mockApolloRefetch).toHaveBeenCalledTimes(1)
+
+        // The stale response must be ignored: no extra state churn or refetches
+        await act(async () => {
+          resolvePoll({ data: { lnInvoicePaymentStatusByHash: { status: "PAID" } } })
+          await flushEffects()
+        })
+
+        expect(result.current.paid).toBe(true)
+        expect(mockApolloRefetch).toHaveBeenCalledTimes(1)
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(9_000)
+        })
+        expect(mockApolloQuery).toHaveBeenCalledTimes(1)
       } finally {
         jest.useRealTimers()
       }

--- a/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
+++ b/__tests__/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.spec.tsx
@@ -14,6 +14,7 @@ const mockSubmissionError = jest.fn(() => "submission-error")
 const mockWalletNotConnected = jest.fn(() => "wallet-not-connected")
 const mockLnInvoiceCreate = jest.fn()
 const mockApolloRefetch = jest.fn()
+const mockApolloQuery = jest.fn()
 const mockUseLnUpdateHashPaid = jest.fn(() => "no-match-hash")
 const mockFetch = jest.fn()
 
@@ -69,11 +70,18 @@ jest.mock("@app/graphql/ln-update-context", () => ({
   useLnUpdateHashPaid: () => mockUseLnUpdateHashPaid(),
 }))
 
+// The real Apollo client is referentially stable across renders; the mock must
+// be too, or effects keyed on the client identity re-fire on every render.
+const mockApolloClientInstance = {
+  refetchQueries: (...args: unknown[]) => mockApolloRefetch(...args),
+  query: (...args: unknown[]) => mockApolloQuery(...args),
+}
+
 jest.mock("@apollo/client", () => {
   const actual = jest.requireActual("@apollo/client")
   return {
     ...actual,
-    useApolloClient: () => ({ refetchQueries: mockApolloRefetch }),
+    useApolloClient: () => mockApolloClientInstance,
   }
 })
 
@@ -313,6 +321,9 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
     mockLnInvoiceCreate.mockResolvedValue({
       data: { lnInvoiceCreate: { invoice: null, errors: [] } },
     })
+    mockApolloQuery.mockResolvedValue({
+      data: { lnInvoicePaymentStatusByHash: { status: "PENDING" } },
+    })
   })
 
   afterEach(() => {
@@ -480,5 +491,191 @@ describe("useLnurlWithdrawRedemption — custodial branch", () => {
     expect(result.current.paid).toBe(false)
     expect(result.current.errorMessage).toBe("")
     expect(result.current.lnServiceErrorReason).toBe("")
+  })
+
+  describe("pending state and payment-status polling fallback (#3564)", () => {
+    const invoice = { paymentRequest: "lnbc-bolt11-string", paymentHash: "hash-A" }
+
+    const arrangeAcceptedWithdrawal = () => {
+      mockLnInvoiceCreate.mockResolvedValueOnce({
+        data: { lnInvoiceCreate: { invoice, errors: [] } },
+      })
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ status: "OK" }) })
+    }
+
+    it("sets pending=true (paid=false) once the LNURL callback accepts the withdraw request", async () => {
+      arrangeAcceptedWithdrawal()
+
+      const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+      await flushEffects()
+      await flushEffects()
+
+      expect(result.current.pending).toBe(true)
+      expect(result.current.paid).toBe(false)
+      expect(result.current.errorMessage).toBe("")
+    })
+
+    it("clears pending and flips paid=true when the LN update hash confirms the payment", async () => {
+      arrangeAcceptedWithdrawal()
+      mockUseLnUpdateHashPaid.mockReturnValue("hash-A")
+
+      const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+      await flushEffects()
+      await flushEffects()
+
+      expect(result.current.paid).toBe(true)
+      expect(result.current.pending).toBe(false)
+      expect(mockApolloRefetch).toHaveBeenCalledTimes(1)
+    })
+
+    it("stays pending=false when the LNURL callback rejects the request, and never starts polling", async () => {
+      mockLnInvoiceCreate.mockResolvedValueOnce({
+        data: { lnInvoiceCreate: { invoice, errors: [] } },
+      })
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "ERROR", reason: "voucher already used" }),
+      })
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+        await flushEffects()
+        await flushEffects()
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(9_000)
+        })
+
+        expect(result.current.pending).toBe(false)
+        expect(mockApolloQuery).not.toHaveBeenCalled()
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("flips paid=true via the status poll when the websocket update never arrives (the #3564 bug)", async () => {
+      arrangeAcceptedWithdrawal()
+      mockApolloQuery.mockResolvedValue({
+        data: { lnInvoicePaymentStatusByHash: { status: "PAID" } },
+      })
+
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+        await flushEffects()
+        await flushEffects()
+        expect(result.current.pending).toBe(true)
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        await flushEffects()
+
+        expect(mockApolloQuery).toHaveBeenCalledTimes(1)
+        expect(mockApolloQuery.mock.calls[0][0].variables).toEqual({
+          input: { paymentHash: "hash-A" },
+        })
+        expect(result.current.paid).toBe(true)
+        expect(result.current.pending).toBe(false)
+        expect(mockApolloRefetch).toHaveBeenCalledTimes(1)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("keeps polling while the invoice is unpaid and stops once the poll reports PAID", async () => {
+      arrangeAcceptedWithdrawal()
+      mockApolloQuery
+        .mockResolvedValueOnce({
+          data: { lnInvoicePaymentStatusByHash: { status: "PENDING" } },
+        })
+        .mockResolvedValueOnce({
+          data: { lnInvoicePaymentStatusByHash: { status: "PAID" } },
+        })
+
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+        await flushEffects()
+        await flushEffects()
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        expect(result.current.paid).toBe(false)
+        expect(result.current.pending).toBe(true)
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        await flushEffects()
+        expect(result.current.paid).toBe(true)
+        expect(mockApolloQuery).toHaveBeenCalledTimes(2)
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(9_000)
+        })
+        expect(mockApolloQuery).toHaveBeenCalledTimes(2)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("survives a transient poll error and succeeds on a later tick", async () => {
+      arrangeAcceptedWithdrawal()
+      mockApolloQuery
+        .mockRejectedValueOnce(new Error("network hiccup"))
+        .mockResolvedValueOnce({
+          data: { lnInvoicePaymentStatusByHash: { status: "PAID" } },
+        })
+
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { result } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+        await flushEffects()
+        await flushEffects()
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        expect(result.current.paid).toBe(false)
+        expect(result.current.errorMessage).toBe("")
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(3_000)
+        })
+        await flushEffects()
+        expect(result.current.paid).toBe(true)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("stops polling on unmount (interval cleanup)", async () => {
+      arrangeAcceptedWithdrawal()
+
+      jest.useFakeTimers({ doNotFake: ["setImmediate"] })
+      try {
+        const { unmount } = renderHook(() => useLnurlWithdrawRedemption(defaultParams))
+
+        await flushEffects()
+        await flushEffects()
+
+        unmount()
+
+        await act(async () => {
+          await jest.advanceTimersByTimeAsync(9_000)
+        })
+        expect(mockApolloQuery).not.toHaveBeenCalled()
+      } finally {
+        jest.useRealTimers()
+      }
+    })
   })
 })

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1441,6 +1441,13 @@ query level {
   }
 }
 
+query lnInvoicePaymentStatusByHash($input: LnInvoicePaymentStatusByHashInput!) {
+  lnInvoicePaymentStatusByHash(input: $input) {
+    status
+    __typename
+  }
+}
+
 query migration {
   migration {
     preview {

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -3701,6 +3701,13 @@ export type MyLnUpdatesSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
 export type MyLnUpdatesSubscription = { readonly __typename: 'Subscription', readonly myUpdates: { readonly __typename: 'MyUpdatesPayload', readonly errors: ReadonlyArray<{ readonly __typename: 'GraphQLApplicationError', readonly message: string }>, readonly update?: { readonly __typename: 'IntraLedgerUpdate' } | { readonly __typename: 'LnUpdate', readonly paymentHash: string, readonly status: InvoicePaymentStatus } | { readonly __typename: 'OnChainUpdate' } | { readonly __typename: 'Price' } | { readonly __typename: 'RealtimePrice' } | null } };
 
+export type LnInvoicePaymentStatusByHashQueryVariables = Exact<{
+  input: LnInvoicePaymentStatusByHashInput;
+}>;
+
+
+export type LnInvoicePaymentStatusByHashQuery = { readonly __typename: 'Query', readonly lnInvoicePaymentStatusByHash: { readonly __typename: 'LnInvoicePaymentStatus', readonly status?: InvoicePaymentStatus | null } };
+
 export type ScanningQrCodeScreenQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -7674,6 +7681,46 @@ export function useMyLnUpdatesSubscription(baseOptions?: Apollo.SubscriptionHook
       }
 export type MyLnUpdatesSubscriptionHookResult = ReturnType<typeof useMyLnUpdatesSubscription>;
 export type MyLnUpdatesSubscriptionResult = Apollo.SubscriptionResult<MyLnUpdatesSubscription>;
+export const LnInvoicePaymentStatusByHashDocument = gql`
+    query lnInvoicePaymentStatusByHash($input: LnInvoicePaymentStatusByHashInput!) {
+  lnInvoicePaymentStatusByHash(input: $input) {
+    status
+  }
+}
+    `;
+
+/**
+ * __useLnInvoicePaymentStatusByHashQuery__
+ *
+ * To run a query within a React component, call `useLnInvoicePaymentStatusByHashQuery` and pass it any options that fit your needs.
+ * When your component renders, `useLnInvoicePaymentStatusByHashQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useLnInvoicePaymentStatusByHashQuery({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useLnInvoicePaymentStatusByHashQuery(baseOptions: Apollo.QueryHookOptions<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables> & ({ variables: LnInvoicePaymentStatusByHashQueryVariables; skip?: boolean; } | { skip: boolean; }) ) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>(LnInvoicePaymentStatusByHashDocument, options);
+      }
+export function useLnInvoicePaymentStatusByHashLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>(LnInvoicePaymentStatusByHashDocument, options);
+        }
+export function useLnInvoicePaymentStatusByHashSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>(LnInvoicePaymentStatusByHashDocument, options);
+        }
+export type LnInvoicePaymentStatusByHashQueryHookResult = ReturnType<typeof useLnInvoicePaymentStatusByHashQuery>;
+export type LnInvoicePaymentStatusByHashLazyQueryHookResult = ReturnType<typeof useLnInvoicePaymentStatusByHashLazyQuery>;
+export type LnInvoicePaymentStatusByHashSuspenseQueryHookResult = ReturnType<typeof useLnInvoicePaymentStatusByHashSuspenseQuery>;
+export type LnInvoicePaymentStatusByHashQueryResult = Apollo.QueryResult<LnInvoicePaymentStatusByHashQuery, LnInvoicePaymentStatusByHashQueryVariables>;
 export const ScanningQrCodeScreenDocument = gql`
     query scanningQRCodeScreen {
   globals {

--- a/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts
+++ b/app/screens/redeem-lnurl-withdrawal-screen/hooks/use-lnurl-withdraw-redemption.ts
@@ -1,8 +1,14 @@
 import fetch from "cross-fetch"
 import { useEffect, useState } from "react"
-import { useApolloClient } from "@apollo/client"
+import { gql, useApolloClient } from "@apollo/client"
 
-import { HomeAuthedDocument, useLnInvoiceCreateMutation } from "@app/graphql/generated"
+import {
+  HomeAuthedDocument,
+  InvoicePaymentStatus,
+  LnInvoicePaymentStatusByHashDocument,
+  LnInvoicePaymentStatusByHashQuery,
+  useLnInvoiceCreateMutation,
+} from "@app/graphql/generated"
 import { useLnUpdateHashPaid } from "@app/graphql/ln-update-context"
 import { usePayments } from "@app/hooks/use-payments"
 import { useI18nContext } from "@app/i18n/i18n-react"
@@ -10,6 +16,14 @@ import { useTranslateSdkError } from "@app/self-custodial/hooks"
 import { PaymentResultStatus } from "@app/types/payment"
 import { AccountType } from "@app/types/wallet"
 import { satsToMsats } from "@app/utils/amounts"
+
+gql`
+  query lnInvoicePaymentStatusByHash($input: LnInvoicePaymentStatusByHashInput!) {
+    lnInvoicePaymentStatusByHash(input: $input) {
+      status
+    }
+  }
+`
 
 type WithdrawalInvoice = {
   paymentRequest: string
@@ -44,6 +58,7 @@ type SelfCustodialParams = {
 }
 
 const WALLET_CONNECT_TIMEOUT_MS = 10_000
+const PAYMENT_STATUS_POLL_INTERVAL_MS = 3_000
 
 const useSelfCustodialRedemption = ({
   enabled,
@@ -163,6 +178,8 @@ const useCustodialRedemption = ({
   const [withdrawalInvoice, setWithdrawalInvoice] = useState<WithdrawalInvoice | null>(
     null,
   )
+  const [callbackAccepted, setCallbackAccepted] = useState(false)
+  const [paidViaPoll, setPaidViaPoll] = useState(false)
   const [errorMessage, setErrorMessage] = useState("")
   const [lnServiceErrorReason, setLnServiceErrorReason] = useState("")
 
@@ -212,7 +229,10 @@ const useCustodialRedemption = ({
 
       if (result.ok) {
         const lnurlResponse = await result.json()
-        if (lnurlResponse?.status?.toLowerCase() !== "ok") {
+        if (lnurlResponse?.status?.toLowerCase() === "ok") {
+          // The service accepted the withdraw request; payment is now in flight
+          setCallbackAccepted(true)
+        } else {
           console.error(lnurlResponse, "error with redeeming")
           setErrorMessage(LL.RedeemBitcoinScreen.redeemingError())
           if (lnurlResponse?.reason) setLnServiceErrorReason(lnurlResponse.reason)
@@ -227,14 +247,51 @@ const useCustodialRedemption = ({
   }, [enabled, withdrawalInvoice, callback, k1, LL])
 
   const paid =
-    enabled && withdrawalInvoice !== null && withdrawalInvoice.paymentHash === lastHash
+    enabled &&
+    withdrawalInvoice !== null &&
+    (withdrawalInvoice.paymentHash === lastHash || paidViaPoll)
+
+  // The websocket update can be missed (disconnects, timing gaps), leaving the
+  // screen stuck on pending forever. Poll the invoice status as a fallback.
+  useEffect(() => {
+    if (!enabled || !callbackAccepted || paid || !withdrawalInvoice) return
+
+    let cancelled = false
+
+    const poll = async () => {
+      try {
+        const { data } = await apolloClient.query<LnInvoicePaymentStatusByHashQuery>({
+          query: LnInvoicePaymentStatusByHashDocument,
+          variables: { input: { paymentHash: withdrawalInvoice.paymentHash } },
+          fetchPolicy: "no-cache",
+        })
+        if (cancelled) return
+        if (data?.lnInvoicePaymentStatusByHash?.status === InvoicePaymentStatus.Paid) {
+          setPaidViaPoll(true)
+        }
+      } catch {
+        // Transient poll errors are ignored; the next tick retries
+      }
+    }
+
+    const interval = setInterval(poll, PAYMENT_STATUS_POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [enabled, callbackAccepted, paid, withdrawalInvoice, apolloClient])
 
   useEffect(() => {
     if (!paid) return
     apolloClient.refetchQueries({ include: [HomeAuthedDocument] })
   }, [paid, apolloClient])
 
-  return { paid, pending: false, errorMessage, lnServiceErrorReason }
+  return {
+    paid,
+    pending: callbackAccepted && !paid,
+    errorMessage,
+    lnServiceErrorReason,
+  }
 }
 
 export const useLnurlWithdrawRedemption = (params: Params): LnurlWithdrawRedemption => {


### PR DESCRIPTION
Fixes #3564
Supersedes #3571 (predates the #3824 refactor and no longer applies)

## Problem

After redeeming an LNURL-withdraw voucher on a custodial account, the success checkmark often never appears — the spinner runs forever even though the sats arrived. Success was detected **only** via the websocket `myUpdates` subscription (`useLnUpdateHashPaid`); a disconnect or missed `PAID` event left the screen with no terminal state. The LNURL callback's `{status: "OK"}` acceptance signal was ignored except for error detection, and `useCustodialRedemption` returned a hard-coded `pending: false`.

## Solution

Both changes confined to `useCustodialRedemption` (the self-custodial branch already handles pending via `PaymentResultStatus.Pending`, and the screen already renders the pending UI from #3824 — no screen or i18n changes):

- **Pending state**: when the LNURL callback responds `{status: "OK"}`, surface `pending: true` until the payment is confirmed, so the user sees "request accepted, payment in flight" instead of a bare spinner.
- **Polling fallback**: while pending, poll `lnInvoicePaymentStatusByHash` every 3 s via a new query document; a `PAID` result flips the screen to success even if the websocket update never arrives. This is the actual fix for the filed bug — the two-stage pattern suggested in the issue discussion, plus the "belt-and-suspenders" polling path.

`paid` now means: websocket hash match **or** poll confirmation; the Home refetch fires once for either path.

## Testing

- `use-lnurl-withdraw-redemption.ts` is at **100% statement / branch / function / line coverage** (11 new cases, 30 total in the hook spec).
- New custodial cases: pending on callback acceptance; pending cleared on websocket confirmation; **paid via poll when the websocket never fires (the #3564 scenario)**; poll lifecycle (keeps polling while unpaid, stops after PAID, none before acceptance, cleanup on unmount); transient poll errors tolerated; stale poll response ignored after the websocket already confirmed; `lnInvoiceCreate` no-data contract.
- New self-custodial cases (pre-existing gaps): adapter rejection while mounted and after unmount.
- All 19 pre-existing hook cases, the result-screen and detail-screen specs, and the `use-payments` spec still green; `tsc -p .` clean; eslint clean.
- One test-only mock fix: the spec's `useApolloClient` mock now returns a referentially stable client (like the real one), so effects keyed on client identity don't re-fire per render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)