### PR TITLE
chore(test): disable max-lines-per-function for the HomeScreen describe

### DIFF
--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -740,6 +740,7 @@ const runRestrictionInvariantCase = async ({
   }
 }
 
+// eslint-disable-next-line max-lines-per-function
 describe("HomeScreen", () => {
   beforeEach(() => {
     currentMocks = []


### PR DESCRIPTION
## What

`#3973` grew the `describe("HomeScreen")` block in `__tests__/screens/home.spec.tsx` to 751 lines, one over the `max-lines-per-function` limit of 750. That makes `eslint:check` (and therefore the **Check Code** job) fail on `main` and on every open PR that merges with it.

## Change

Add `// eslint-disable-next-line max-lines-per-function` above the describe, matching the existing pattern in `__tests__/screens/send-destination.spec.tsx`. No test logic changed.

## Verification

- `yarn eslint:check` (whole repo): 0 errors
- `yarn tsc:check`: pass
- `yarn jest __tests__/screens/home.spec.tsx`: 64 passed