### PR TITLE
fix(send): display canonical lightning address for Blink LNURL destinations

### DIFF
--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -173,6 +173,44 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
     expect(detail.setSuccessAction).toBeDefined()
   })
 
+  describe("setters recreate the detail", () => {
+    it("setConvertMoneyAmount swaps the conversion function", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      const newConvert = jest.fn((amount, target) => ({
+        amount: amount.amount,
+        currency: target,
+        currencyCode: target,
+      }))
+      const updated = detail.setConvertMoneyAmount(newConvert)
+      expect(updated.convertMoneyAmount).toBe(newConvert)
+    })
+
+    it("setInvoice recreates an equivalent lnurl detail", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (detail.paymentType !== PaymentType.Lnurl) throw new Error("expected lnurl")
+      const updated = detail.setInvoice({} as never)
+      expect(updated.paymentType).toBe(PaymentType.Lnurl)
+      expect(updated.destination).toBe(detail.destination)
+    })
+
+    it("setSuccessAction carries the success action onto the new detail", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (detail.paymentType !== PaymentType.Lnurl) throw new Error("expected lnurl")
+      const successAction = {
+        tag: "message" as const,
+        message: "Thanks!",
+        description: null,
+        url: null,
+        ciphertext: null,
+        iv: null,
+        decipher: () => null,
+      }
+      const updated = detail.setSuccessAction(successAction)
+      expect(updated.paymentType).toBe(PaymentType.Lnurl)
+      expect(updated.successAction).toBe(successAction)
+    })
+  })
+
   describe("amount handling", () => {
     it("locks the amount when min === max (destination-specified amount)", () => {
       const detail = createSelfCustodialLnurlPaymentDetails(
@@ -184,6 +222,20 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       expect(detail.destinationSpecifiedAmount).toEqual(
         expect.objectContaining({ amount: 5000, currency: WalletCurrency.Btc }),
       )
+    })
+
+    it("cannot send or quote a fee while the amount is still zero", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          unitOfAccountAmount: {
+            amount: 0,
+            currency: WalletCurrency.Btc,
+            currencyCode: WalletCurrency.Btc,
+          },
+        }),
+      )
+      expect(detail.canSendPayment).toBe(false)
+      expect(detail.canGetFee).toBe(false)
     })
 
     it("allows amount changes when min !== max", () => {
@@ -269,6 +321,24 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
           tokenIdentifier: undefined,
           conversionOptions: undefined,
           feePolicy: undefined,
+        }),
+      )
+    })
+
+    it("falls back to an empty payRequest domain when lnurlParams has none", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ domain: undefined }),
+        }),
+      )
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      await detail.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          payRequest: expect.objectContaining({ domain: "" }),
         }),
       )
     })
@@ -377,6 +447,7 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       expect(result.status).toBe(PaymentSendResult.Success)
       expect(result.extraInfo?.successAction?.tag).toBe("message")
       expect(result.extraInfo?.successAction?.message).toBe("Thanks!")
+      expect(result.extraInfo?.successAction?.decipher("any-preimage")).toBeNull()
     })
 
     it("converts a URL successAction to the lnurl-pay shape", async () => {
@@ -394,6 +465,7 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       expect(result.extraInfo?.successAction?.tag).toBe("url")
       expect(result.extraInfo?.successAction?.url).toBe("https://r.example/1")
       expect(result.extraInfo?.successAction?.description).toBe("Receipt")
+      expect(result.extraInfo?.successAction?.decipher("any-preimage")).toBeNull()
     })
 
     it("carries the decrypted plaintext on `message` (not via decipher) for AES Decrypted", async () => {

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -126,6 +126,33 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
     expect(detail.destination).toBe("user@example.com")
   })
 
+  it("canonicalizes a pay.blink.sv identifier to blink.sv for display", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(
+      createParams({
+        lnurlParams: baseLnurlParams({ identifier: "user@pay.blink.sv" }),
+      }),
+    )
+    expect(detail.destination).toBe("user@blink.sv")
+  })
+
+  it("canonicalizes the legacy pay.bbw.sv alias to blink.sv for display", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(
+      createParams({
+        lnurlParams: baseLnurlParams({ identifier: "user@pay.bbw.sv" }),
+      }),
+    )
+    expect(detail.destination).toBe("user@blink.sv")
+  })
+
+  it("keeps an already-canonical blink.sv identifier unchanged", () => {
+    const detail = createSelfCustodialLnurlPaymentDetails(
+      createParams({
+        lnurlParams: baseLnurlParams({ identifier: "user@blink.sv" }),
+      }),
+    )
+    expect(detail.destination).toBe("user@blink.sv")
+  })
+
   it("falls back to the bech32 lnurl when no identifier is present (raw LNURL pay)", () => {
     const detail = createSelfCustodialLnurlPaymentDetails(
       createParams({

--- a/__tests__/utils/pay-links.spec.ts
+++ b/__tests__/utils/pay-links.spec.ts
@@ -114,6 +114,14 @@ describe("canonicalizeLightningAddress", () => {
       "alice@bob@pay.blink.sv",
     )
   })
+
+  it("leaves input with an empty username untouched", () => {
+    expect(canonicalizeLightningAddress("@pay.blink.sv")).toBe("@pay.blink.sv")
+  })
+
+  it("leaves input with an empty domain untouched", () => {
+    expect(canonicalizeLightningAddress("alice@")).toBe("alice@")
+  })
 })
 
 describe("extractLightningAddressUsername", () => {

--- a/__tests__/utils/pay-links.spec.ts
+++ b/__tests__/utils/pay-links.spec.ts
@@ -1,4 +1,5 @@
 import {
+  canonicalizeLightningAddress,
   extractLightningAddressUsername,
   getDonationButtonUrl,
   getLightningAddress,
@@ -64,6 +65,54 @@ describe("getLightningAddress", () => {
 
   it("appends @hostname when the address has no @", () => {
     expect(getLightningAddress("blink.sv", "alice")).toBe("alice@blink.sv")
+  })
+})
+
+describe("canonicalizeLightningAddress", () => {
+  it("rewrites the pay.blink.sv alias to the canonical domain", () => {
+    expect(canonicalizeLightningAddress("alice@pay.blink.sv")).toBe("alice@blink.sv")
+  })
+
+  it("rewrites the legacy pay.bbw.sv alias to the canonical domain", () => {
+    expect(canonicalizeLightningAddress("alice@pay.bbw.sv")).toBe("alice@blink.sv")
+  })
+
+  it("is a no-op for an already-canonical address", () => {
+    expect(canonicalizeLightningAddress("alice@blink.sv")).toBe("alice@blink.sv")
+  })
+
+  it("matches alias domains case-insensitively", () => {
+    expect(canonicalizeLightningAddress("alice@PAY.BLINK.SV")).toBe("alice@blink.sv")
+  })
+
+  it("leaves non-Blink addresses untouched", () => {
+    expect(canonicalizeLightningAddress("alice@walletofsatoshi.com")).toBe(
+      "alice@walletofsatoshi.com",
+    )
+  })
+
+  // Staging is self-consistent: its lnAddressHostname is pay.staging.blink.sv,
+  // so the staging domain is intentionally not treated as an alias.
+  it("leaves the staging domain untouched", () => {
+    expect(canonicalizeLightningAddress("alice@pay.staging.blink.sv")).toBe(
+      "alice@pay.staging.blink.sv",
+    )
+  })
+
+  it("leaves a bech32 lnurl string untouched", () => {
+    expect(canonicalizeLightningAddress("lnurl1dp68gurn8ghj7mrww4exctnxd3shg6tr")).toBe(
+      "lnurl1dp68gurn8ghj7mrww4exctnxd3shg6tr",
+    )
+  })
+
+  it("leaves an empty string untouched", () => {
+    expect(canonicalizeLightningAddress("")).toBe("")
+  })
+
+  it("leaves multi-@ input untouched", () => {
+    expect(canonicalizeLightningAddress("alice@bob@pay.blink.sv")).toBe(
+      "alice@bob@pay.blink.sv",
+    )
   })
 })
 

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -31,6 +31,7 @@ import {
   type WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { ConvertDirection } from "@app/types/payment"
+import { canonicalizeLightningAddress } from "@app/utils/pay-links"
 
 import {
   buildConversionType,
@@ -259,7 +260,9 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
     })
 
   return {
-    destination: lnurlParams.identifier || lnurl,
+    destination: lnurlParams.identifier
+      ? canonicalizeLightningAddress(lnurlParams.identifier)
+      : lnurl,
     memo,
     convertMoneyAmount,
     setConvertMoneyAmount,

--- a/app/utils/pay-links.ts
+++ b/app/utils/pay-links.ts
@@ -1,3 +1,5 @@
+import { BLINK_DOMAIN, LNURL_DOMAINS } from "@app/config/appinfo"
+
 const DONATION_BUTTON_URL = "https://donation-button.blink.sv"
 
 // The point of sale and its printable QR are served by the standalone terminal for
@@ -33,6 +35,23 @@ export const getLightningAddress = (
 ): string => {
   if (address.includes("@")) return address
   return `${address}@${lnAddressHostname}`
+}
+
+/**
+ * The pay-server advertises LNURL identifiers under its own hostname
+ * (user@pay.blink.sv), while the address we show users everywhere else is
+ * user@blink.sv. Rewrites addresses on a Blink alias domain to the canonical
+ * form; anything else — non-Blink addresses, bech32 lnurl strings, malformed
+ * values — passes through unchanged.
+ */
+export const canonicalizeLightningAddress = (address: string): string => {
+  const parts = address.split("@")
+  if (parts.length !== 2) return address
+  const [username, domain] = parts
+  if (!username || !domain) return address
+  return LNURL_DOMAINS.includes(domain.toLowerCase())
+    ? `${username}@${BLINK_DOMAIN}`
+    : address
 }
 
 export const extractLightningAddressUsername = (


### PR DESCRIPTION
Fixes blinkbitcoin/blink-wip#1034

## Problem

Scanning a custodial receive-flow paycode QR with a **self-custodial (Spark)** wallet shows the destination as `user@pay.blink.sv` instead of the canonical `user@blink.sv` shown on the receive screen.

The receive paycode QR encodes a bech32 LNURL of `https://pay.blink.sv/.well-known/lnurlp/<username>`, and the pay-server's LNURL metadata advertises the identifier under its own hostname (`user@pay.blink.sv`). The custodial send path is unaffected (its scan context collapses Blink LNURLs to intraledger via `lnurlDomains`), but the self-custodial path intentionally has `lnurlDomains: []` — it pays Blink users over real Lightning — so `createSelfCustodialLnurlPaymentDetails` displayed the raw identifier verbatim. The same string was copied to clipboard and persisted as the auto-saved contact handle.

## Fix

- New pure helper `canonicalizeLightningAddress` in `app/utils/pay-links.ts`: rewrites addresses whose domain is a Blink alias (the existing `LNURL_DOMAINS` list: `blink.sv`, `pay.blink.sv`, `pay.bbw.sv`) to `user@blink.sv` (`BLINK_DOMAIN`). Non-Blink addresses, bech32 `lnurl1...` strings, and malformed input pass through unchanged; the rewrite is idempotent.
- Applied at the single production call site: the `destination` assignment in `app/self-custodial/payment-details/lnurl.ts`. This also fixes copy-to-clipboard and the saved contact handle, which read `paymentDetail.destination`.

Deliberately untouched: `lnurlParamsToPayRequest` (the Breez SDK payload keeps the server-provided identifier), the shared custodial `resolveLnurlDestination`/`createLnurlPaymentDetails`, and the scan contexts. Populating `lnurlDomains` for self-custodial instead was considered and rejected: the intraledger collapse would produce a custodial GraphQL destination a Spark wallet cannot pay.

## Tests

- `__tests__/self-custodial/payment-details/lnurl.spec.ts`: regression cases for `pay.blink.sv` → `blink.sv`, legacy `pay.bbw.sv` → `blink.sv`, and canonical passthrough (existing non-Blink and bech32-fallback cases unchanged).
- `__tests__/utils/pay-links.spec.ts`: helper coverage — alias mappings, case-insensitive domain match, non-Blink/staging/bech32/empty/multi-`@`/empty-username/empty-domain passthrough.
- A final commit closes pre-existing coverage gaps in the touched files (the three setters that were only asserted as defined, the message/url success-action `decipher` stubs, and the empty-domain / zero-amount fallbacks).

Both changed production files are now at **100% statements, branches, functions and lines**:

```
File       | % Stmts | % Branch | % Funcs | % Lines
lnurl.ts   |     100 |      100 |     100 |     100
pay-links.ts|    100 |      100 |     100 |     100
```

`tsc --noEmit`, `eslint`, and `prettier --check` all clean.

## Out of scope / follow-up

The root advertisement lives in the pay-server's LNURL metadata (`text/identifier`); fixing it there would correct every third-party wallet, not just Blink mobile. Left as a potential backend follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)