### PR TITLE
test(home): complete the remote-config mock with real defaults

### DIFF
--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -97,7 +97,19 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
 }))
 
 jest.mock("@app/config/feature-flags-context", () => {
-  const actual = jest.requireActual("@app/config/feature-flags-context")
+  const actual = jest.requireActual<typeof import("@app/config/feature-flags-context")>(
+    "@app/config/feature-flags-context",
+  )
+  /**
+   * Typed against the real hook and spread from the real defaults so tsc fails
+   * when the mock misses a new remote-config key or keeps a removed one — a
+   * stale partial mock crashed the whole suite when #3977 landed.
+   */
+  const remoteConfig: ReturnType<typeof actual.useRemoteConfig> = {
+    ...actual.defaultRemoteConfig,
+    custodialDollarBalanceBlockedCountries: [],
+    selfCustodialDollarBalanceBlockedCountries: [],
+  }
   return {
     ...actual,
     useFeatureFlags: () =>
@@ -105,19 +117,7 @@ jest.mock("@app/config/feature-flags-context", () => {
         nonCustodialEnabled: false,
         stableBalanceEnabled: false,
       },
-    useRemoteConfig: () => ({
-      // Real defaults keep this mock complete when new remote-config keys land.
-      ...actual.defaultRemoteConfig,
-      loading: false,
-      remoteConfigReady: true,
-      feeReimbursementMemo: "fee reimbursement",
-      featureFlags: {
-        nonCustodialEnabled: false,
-        stableBalanceEnabled: false,
-      },
-      custodialDollarBalanceBlockedCountries: [],
-      selfCustodialDollarBalanceBlockedCountries: [],
-    }),
+    useRemoteConfig: () => remoteConfig,
   }
 })
 
@@ -1930,5 +1930,22 @@ describe("HomeScreen layout under font scaling (blink-wip#931)", () => {
     expect(getByTestId("home-username").props.maxFontSizeMultiplier).toBeLessThanOrEqual(
       1.5,
     )
+  })
+})
+
+describe("useRemoteConfig mock completeness", () => {
+  it("covers every real remote-config key so a new key cannot crash unrelated tests", () => {
+    const actual = jest.requireActual<typeof import("@app/config/feature-flags-context")>(
+      "@app/config/feature-flags-context",
+    )
+    const mocked = jest.requireMock<typeof import("@app/config/feature-flags-context")>(
+      "@app/config/feature-flags-context",
+    )
+
+    const missingKeys = Object.keys(actual.defaultRemoteConfig).filter(
+      (key) => !(key in mocked.useRemoteConfig()),
+    )
+
+    expect(missingKeys).toEqual([])
   })
 })

--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -106,6 +106,8 @@ jest.mock("@app/config/feature-flags-context", () => {
         stableBalanceEnabled: false,
       },
     useRemoteConfig: () => ({
+      // Real defaults keep this mock complete when new remote-config keys land.
+      ...actual.defaultRemoteConfig,
       loading: false,
       remoteConfigReady: true,
       feeReimbursementMemo: "fee reimbursement",


### PR DESCRIPTION
## Summary

Since #3977 merged, `home.spec.tsx` fails on main — and on every PR's merge CI — with:

```
TypeError: Cannot read properties of undefined (reading 'includes')
  at isBlockedCountry (app/hooks/use-device-location.ts:22)
```

#3977 added the `offboardOnlyCountries` remote-config key, and `HomeScreen` now reads it unconditionally via `useWindDownHomeNudges → useOffboardOnlyBulletin`. The hand-rolled `useRemoteConfig` mock in `home.spec.tsx` predates the key, so `isBlockedCountry` receives `undefined`. The crash fires in every test where the mocked settings query resolves a phone number (truthy `phoneCountry` defeats the `countryCode &&` short-circuit).

## Fix

Spread the exported `defaultRemoteConfig` into the mock ahead of the explicit overrides. This fixes the immediate breakage and removes the failure class: future remote-config keys inherit their real defaults instead of silently going stale in the mock.

No assertion changes — the test phone is `+503` (SV), which is not in the `["AE", "NP", "DZ"]` offboard default.

## Guard against recurrence

The mock's return value is now typed as `ReturnType<typeof actual.useRemoteConfig>`, and a completeness test compares the mock's keys against `defaultRemoteConfig`. Since ts-jest type-checks the suite, a key the mock misses (or keeps after removal) fails the Tests check with a named `TS2740` error listing the missing `RemoteConfig` properties — instead of 60+ unrelated tests crashing on an opaque `TypeError`. Verified by temporarily removing the defaults spread: the suite fails immediately with the named error.

This also surfaced that the mock's `loading` / `remoteConfigReady` / `featureFlags` keys were dead — they belong to `useFeatureFlags`, not `useRemoteConfig` — so they are dropped.

## Verification

- Reproduced the failure on a clean `origin/main` checkout before the fix.
- After: all 65 `home.spec.tsx` tests pass (64 existing + new completeness test); eslint clean on the file.
- Negative check: removing the defaults spread fails the suite with `TS2740`, naming the missing keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)