### PR TITLE
fix(send): treat user@domain input as lightning address, not phone number

### DIFF
--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -501,6 +501,162 @@ describe("SendBitcoinDestinationScreen", () => {
     await flushEffects()
   })
 
+  it("routes a tapped phone-number contact into the phone flow", async () => {
+    mockedDestinationData = {
+      ...mockedDestinationData,
+      me: {
+        ...mockedDestinationData.me,
+        contacts: [
+          {
+            id: "contact-id",
+            handle: "+50370000000",
+            username: "+50370000000",
+            alias: null,
+            transactionsCount: 1,
+          },
+        ],
+      },
+    }
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: "lnurl",
+        isMerchant: false,
+        lnurlParams: createLnurlPayParams("+50370000000"),
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+    await flushAsync()
+
+    fireEvent.press(screen.getByText("+50370000000@blink.sv"))
+    await flushAsync()
+
+    // the phone contact is validated as its international phone number,
+    // not as handle@domain
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "+50370000000" }),
+    )
+  })
+
+  it("treats a tapped lightning-address contact as a lightning address", async () => {
+    mockedDestinationData = {
+      ...mockedDestinationData,
+      me: {
+        ...mockedDestinationData.me,
+        contacts: [
+          {
+            id: "contact-id",
+            handle: "70000000@bitzed.xyz",
+            username: null,
+            alias: null,
+            transactionsCount: 1,
+          },
+        ],
+      },
+    }
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: "lnurl",
+        isMerchant: false,
+        lnurlParams: createLnurlPayParams("70000000@bitzed.xyz"),
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+    await flushAsync()
+
+    fireEvent.press(screen.getByText("70000000@bitzed.xyz"))
+    await flushAsync()
+
+    // the phone-valid local part must not divert the contact into the phone flow
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "70000000@bitzed.xyz" }),
+    )
+  })
+
+  it("validates a lightning address handed over via route params as a destination", async () => {
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Lnurl,
+        lnurl: "lnurl",
+        isMerchant: false,
+        lnurlParams: createLnurlPayParams("70000000@bitzed.xyz"),
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    const { rerender } = render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+    // let the phone input publish its detected country before the param arrives,
+    // mirroring a QR scan handoff on a fully mounted screen
+    await flushAsync()
+
+    rerender(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen
+          route={{
+            ...sendBitcoinDestination,
+            params: { payment: "70000000@bitzed.xyz", username: "" },
+          }}
+        />
+      </ContextForScreen>,
+    )
+    await flushAsync()
+
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "70000000@bitzed.xyz" }),
+    )
+  })
+
+  it("routes a phone number handed over via route params to the phone input", async () => {
+    const { rerender } = render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+    await flushAsync()
+
+    rerender(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen
+          route={{
+            ...sendBitcoinDestination,
+            params: { payment: "+50370000000", username: "" },
+          }}
+        />
+      </ContextForScreen>,
+    )
+    await flushAsync()
+
+    expect(parseDestinationMock).not.toHaveBeenCalled()
+    // the phone input shows the national number; +503 lives in the country picker
+    expect(screen.getByLabelText("telephoneNumber").props.value).toBe("70000000")
+  })
+
   it.each([
     {
       name: "shows username does not exist error",

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -450,6 +450,19 @@ describe("SendBitcoinDestinationScreen", () => {
       input: "newuser",
       expectPhoneNotAllowed: false,
     },
+    {
+      // https://github.com/blinkbitcoin/blink-wip/issues/917 — the local part
+      // is a valid phone number for the detected country (SV in this suite),
+      // but user@domain input must be treated as a lightning address
+      name: "accepts lightning addresses whose local part is a valid phone number",
+      input: "70000000@bitzed.xyz",
+      expectPhoneNotAllowed: false,
+    },
+    {
+      name: "accepts lightning addresses with alphanumeric local parts",
+      input: "u66474248@rurbit.mooo.com",
+      expectPhoneNotAllowed: false,
+    },
   ])("$name", async ({ input, expectPhoneNotAllowed }) => {
     parseDestinationMock.mockResolvedValue({
       valid: true,

--- a/__tests__/utils/phone.spec.ts
+++ b/__tests__/utils/phone.spec.ts
@@ -28,6 +28,32 @@ describe("parseValidPhoneNumber", () => {
   it("returns null for invalid country code combination", () => {
     expect(parseValidPhoneNumber("123", "US")).toBeNull()
   })
+
+  it("returns null for lightning addresses whose local part is a valid phone number", () => {
+    // https://github.com/blinkbitcoin/blink-wip/issues/917 — libphonenumber
+    // extracts the phone number out of the surrounding text unless told not to,
+    // so user@domain lightning addresses were misdetected as phone numbers
+    expect(parseValidPhoneNumber("0777491011@bitzed.xyz", "ZM")).toBeNull()
+    expect(parseValidPhoneNumber("70000000@bitzed.xyz", "SV")).toBeNull()
+    expect(parseValidPhoneNumber("+256777491011@bitzed.xyz", "ZM")).toBeNull()
+    expect(parseValidPhoneNumber("+50370000000@blink.sv")).toBeNull()
+    // https://github.com/blinkbitcoin/blink-mobile/issues/4021 — Flash (Benin)
+    // uses phone numbers as lightning address usernames; BJ is the only detected
+    // country for which this local part parses as a valid phone number
+    expect(parseValidPhoneNumber("2290161757483@bitcoinflash.xyz", "BJ")).toBeNull()
+  })
+
+  it("returns null for lightning addresses with alphanumeric local parts", () => {
+    expect(parseValidPhoneNumber("u66474248@rurbit.mooo.com", "ZM")).toBeNull()
+  })
+
+  it("still parses phone numbers with common formatting characters", () => {
+    expect(parseValidPhoneNumber("+260 777 491 011")?.number).toBe("+260777491011")
+    expect(parseValidPhoneNumber("077-749-1011", "ZM")?.number).toBe("+260777491011")
+    expect(parseValidPhoneNumber("(077) 749 1011", "ZM")?.number).toBe("+260777491011")
+    // the bare number behind #4021's lightning address still parses
+    expect(parseValidPhoneNumber("2290161757483", "BJ")?.number).toBe("+2290161757483")
+  })
 })
 
 describe("isPhoneNumber", () => {
@@ -46,6 +72,11 @@ describe("isPhoneNumber", () => {
   it("returns false for usernames that look like numbers", () => {
     expect(isPhoneNumber("user123")).toBe(false)
     expect(isPhoneNumber("test@blink.sv")).toBe(false)
+  })
+
+  it("returns false for lightning addresses whose local part is a valid phone number", () => {
+    expect(isPhoneNumber("+50370000000@blink.sv")).toBe(false)
+    expect(isPhoneNumber("+14155552671@bitzed.xyz")).toBe(false)
   })
 
   it("returns false for valid phone numbers without plus sign even when format is recognized", () => {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -651,9 +651,11 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
       const handle = item?.handle?.trim() ?? ""
       const displayHandle =
         handle && !handle.includes("@") ? `${handle}@${lnAddressHostname}` : handle
-      // parse the raw handle: a phone contact should enter the phone flow, but a
-      // handle that is already a lightning address never should, even when its
-      // local part looks like a phone number
+      /**
+       * parse the raw handle: a phone contact should enter the phone flow, but a
+       * handle that is already a lightning address never should, even when its
+       * local part looks like a phone number
+       */
       const parsePhone = parseValidPhone(handle)
 
       if (parsePhone?.isValid() && activeInputRef.current === InputType.Search) {

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -651,7 +651,10 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
       const handle = item?.handle?.trim() ?? ""
       const displayHandle =
         handle && !handle.includes("@") ? `${handle}@${lnAddressHostname}` : handle
-      const parsePhone = parseValidPhone(displayHandle)
+      // parse the raw handle: a phone contact should enter the phone flow, but a
+      // handle that is already a lightning address never should, even when its
+      // local part looks like a phone number
+      const parsePhone = parseValidPhone(handle)
 
       if (parsePhone?.isValid() && activeInputRef.current === InputType.Search) {
         onFocusedInput(InputType.Phone)

--- a/app/utils/phone.ts
+++ b/app/utils/phone.ts
@@ -9,8 +9,10 @@ export const parseValidPhoneNumber = (
   countryCode?: CountryCode,
 ): PhoneNumber | null => {
   try {
-    // extract: false stops libphonenumber from pulling a phone number out of
-    // surrounding text, e.g. lightning addresses like 0777491011@bitzed.xyz
+    /**
+     * extract: false stops libphonenumber from pulling a phone number out of
+     * surrounding text, e.g. lightning addresses like 0777491011@bitzed.xyz
+     */
     const parsed = parsePhoneNumber(input, {
       defaultCountry: countryCode,
       extract: false,

--- a/app/utils/phone.ts
+++ b/app/utils/phone.ts
@@ -9,7 +9,12 @@ export const parseValidPhoneNumber = (
   countryCode?: CountryCode,
 ): PhoneNumber | null => {
   try {
-    const parsed = parsePhoneNumber(input, countryCode)
+    // extract: false stops libphonenumber from pulling a phone number out of
+    // surrounding text, e.g. lightning addresses like 0777491011@bitzed.xyz
+    const parsed = parsePhoneNumber(input, {
+      defaultCountry: countryCode,
+      extract: false,
+    })
     if (parsed && parsed.isValid()) {
       return parsed
     }
@@ -29,7 +34,7 @@ export const sanitizePhoneNumber = (input: string): string => {
 export const isPhoneNumber = (phoneNumber: string): boolean => {
   try {
     if (isValidPhoneNumber(phoneNumber)) return true
-    const parsed = parsePhoneNumber(phoneNumber)
+    const parsed = parsePhoneNumber(phoneNumber, { extract: false })
     return parsed?.isValid() ?? false
   } catch {
     return false


### PR DESCRIPTION
## Summary

Fixes the Send-to field rejecting valid Lightning Addresses like `0777491011@bitzed.xyz` with *"This field does not accept phone numbers"*.

Fixes blinkbitcoin/blink-wip#917
Fixes #4021

## Root cause

The bug is in the mobile app, not in blink-client — both blink-client 0.6.0 (currently shipped) and 1.1.0 parse the reported addresses as valid LNURL, so blink-client#43 (closed) and blink-client#46 did not address this.

`validateDestination` runs the raw input through `parseValidPhoneNumber` (`app/utils/phone.ts`) before destination parsing, and `libphonenumber-js` **extracts** a phone number out of surrounding text by default. It strips `@bitzed.xyz` — and even letters — so:

- `0777491011@bitzed.xyz` → `+260777491011`, a valid ZM phone → rejected
- `u66474248@rurbit.mooo.com` → `66474248` → `+50366474248`, a valid SV phone → rejected (the second report in the issue)

This also explains why the bug seemed version-specific in the issue thread: the check depends on the user's detected country. For a country where the extracted digits aren't a valid phone number, the same address goes through fine.

## Also fixes #4021 (Benin / Flash)

#4021 is the same defect reported from a different country. Flash (bitcoinflash.xyz), a mobile money ↔ Lightning exchange in Benin, uses phone numbers as Lightning address usernames, so `2290161757483@bitcoinflash.xyz` was rejected. Verified against the installed `libphonenumber-js/mobile`:

| input | detected country | before | after |
| --- | --- | --- | --- |
| `2290161757483@bitcoinflash.xyz` | **BJ** | `+2290161757483` → rejected | `null` → reaches the LNURL parser |
| `2290161757483@bitcoinflash.xyz` | SV / US / ZM / none | `null` | `null` |
| `2290161757483` (bare number) | BJ | `+2290161757483` | `+2290161757483` (unchanged) |

BJ is the only detected country for which that local part parses as a valid number, which is why the issue could not be reproduced from other countries.

## Fix

Pass `extract: false` to `parsePhoneNumber` in `parseValidPhoneNumber` and in the fallback parse of `isPhoneNumber` (same extraction bug, used for contact filtering). Actual phone input still parses — spaces, dashes, parentheses and `+` prefixes are unaffected — but text containing anything else (like `@domain`) is no longer treated as a phone number. Since all input paths (typed, QR scan, deeplink) funnel through `parseValidPhoneNumber`, one fix covers them all.

A second commit fixes a path the first change would have regressed: tapping a **phone contact** relied on libphonenumber extracting the number back out of the `handle@domain` display string. `handleContactPress` now parses the raw handle instead — phone contacts still enter the phone flow, while contacts whose handle is already a lightning address never do, even with a phone-like local part.

## Tests

- `__tests__/utils/phone.spec.ts`: LN addresses with phone-valid local parts return null (`0777491011@bitzed.xyz` ZM, `70000000@bitzed.xyz` SV, `+256777491011@bitzed.xyz`, `+50370000000@blink.sv`, `2290161757483@bitcoinflash.xyz` BJ for #4021); alphanumeric local part (`u66474248@rurbit.mooo.com`); formatting regression guards (spaced/dashed/parenthesized numbers still parse, and the bare `2290161757483` BJ number still parses); `isPhoneNumber` returns false for phone-valid local parts.
- `__tests__/screens/send-destination.spec.tsx`: screen-level regression tests — `70000000@bitzed.xyz` (valid phone local part for the suite's mocked SV country) and `u66474248@rurbit.mooo.com` must not show the phone-not-allowed error and must reach `parseDestination`.
- Coverage for every `parseValidPhone` call site in the screen:
  - typed search input: the two cases above
  - route-param handoff (QR scan/deeplink): a lightning address is validated as a destination; a real phone number still routes to the phone input
  - contact taps: a phone contact enters the phone flow (validated as its international number); a lightning-address contact with a phone-like local part is validated as the full address

All new tests were written first and observed failing against the unfixed code (the QR-path, contact-path and BJ tests verified by temporarily reverting `app/utils/phone.ts` to origin/main). Full suites green locally: `phone.spec.ts` + `send-destination.spec.tsx` 51/51. ESLint + `tsc --noEmit` clean.

## Out of scope

- The "Try Again" crash loop reported in the blink-wip#917 comments is a separate error-recovery bug and should be split into its own issue.
- The `isInt(rawInput)` half of the Search-input guard is unchanged: a bare numeric username with no domain is still rejected, which is intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
