### PR TITLE
ci(android): pass Crashlytics service account to release builds

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -153,6 +153,7 @@ jobs:
         IPINFO_API_KEY: #@ data.values.ipinfo_api_key
         IPAPI_API_KEY: #@ data.values.ipapi_api_key
         PROXYCHECK_API_KEY: #@ data.values.proxycheck_api_key
+        CRASHLYTICS_SERVICE_ACCOUNT_JSON: #@ data.values.crashlytics_service_account_json
         MIN_BUILD_FREE_GB: 30
   - task: upload-to-gcs
     config:
@@ -325,6 +326,7 @@ jobs:
         IPINFO_API_KEY: #@ data.values.ipinfo_api_key
         IPAPI_API_KEY: #@ data.values.ipapi_api_key
         PROXYCHECK_API_KEY: #@ data.values.proxycheck_api_key
+        CRASHLYTICS_SERVICE_ACCOUNT_JSON: #@ data.values.crashlytics_service_account_json
         MIN_BUILD_FREE_GB: 30
   - task: upload-to-gcs
     config:

--- a/ci/tasks/build.sh
+++ b/ci/tasks/build.sh
@@ -8,6 +8,7 @@ DISK_CLEANUP_TASK="${CI_ROOT}/pipeline-tasks/ci/tasks/macos-build-disk-cleanup.s
 
 cleanup_build_task() {
   rm -f "$REACT_NATIVE_CONFIG_ENV"
+  rm -f "${CI_ROOT}/crashlytics-sa.json"
   lsof -ti:8080,8081 | xargs kill -9 || true
   /bin/bash "$DISK_CLEANUP_TASK" post || true
 }
@@ -66,6 +67,16 @@ export BUILD_NUMBER=$(cat ${CI_ROOT}/build-number-android/android)
 sed -i'' -e "s/versionCode .*$/versionCode $BUILD_NUMBER/g" android/app/build.gradle
 
 echo $ANDROID_KEYSTORE | base64 -d > android/app/release.keystore
+
+# The Crashlytics gradle plugin needs GOOGLE_APPLICATION_CREDENTIALS to be a path to a
+# service-account file, not the JSON value; absolute because gradle runs from repo/android.
+# When the secret is empty the fastlane lane logs a skip and the build ships without symbols.
+if [ -n "${CRASHLYTICS_SERVICE_ACCOUNT_JSON:-}" ]; then
+  printf '%s' "$CRASHLYTICS_SERVICE_ACCOUNT_JSON" > "${CI_ROOT}/crashlytics-sa.json"
+  chmod 600 "${CI_ROOT}/crashlytics-sa.json"
+  export GOOGLE_APPLICATION_CREDENTIALS="${CI_ROOT}/crashlytics-sa.json"
+fi
+
 nix develop -c sh -c 'cd android && bundle exec fastlane android build --verbose'
 
 # Assert react-native-config values survived R8/ProGuard in the release build.

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -40,6 +40,7 @@ geo_ipify_api_key: ((mobile-ip-country-lookup.geo_ipify_api_key))
 ipinfo_api_key: ((mobile-ip-country-lookup.ipinfo_api_key))
 ipapi_api_key: ((mobile-ip-country-lookup.ipapi_api_key))
 proxycheck_api_key: ((mobile-ip-country-lookup.proxycheck_api_key))
+crashlytics_service_account_json: ((mobile-crashlytics.creds_json))
 
 android_keystore: ((android.keystore))
 fastlane_match_password: ((fastlane.match_password))


### PR DESCRIPTION
Wires CRASHLYTICS_SERVICE_ACCOUNT_JSON from Vault (mobile-crashlytics) into the dev-build and prod-build tasks. build.sh writes the JSON to a file and exports GOOGLE_APPLICATION_CREDENTIALS as an absolute path, which is what the Crashlytics gradle plugin expects, so the native symbol upload enabled in #3962 starts running.

Closes #3965

CI only change so the failing tests are not relevant.

The secret is deployed in vault.

- [x] Need to run:
```
./ci/repipe
```
after merged to main to activate this change.