### PR TITLE
copy(bottom-bar): rename "Earn" tab to "Learn" (#4014)

### DIFF
--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2038,7 +2038,7 @@ const en: BaseTranslation = {
     satAccumulated: "Sats accumulated",
     satsEarned: "{formattedNumber | sats} earned",
     sectionsCompleted: "You've completed",
-    title: "Earn",
+    title: "Learn",
     unlockQuestion: "To unlock, answer the question:",
     youEarned: "You Earned",
     registerTitle: "Need to upgrade your account",
@@ -4077,7 +4077,7 @@ const en: BaseTranslation = {
     noAccountDescription:
       "{featureName: string} requires a Blink custodial account.",
     featureCircles: "Circles",
-    featureEarn: "Earn",
+    featureEarn: "Learn",
     featureCard: "Card",
   },
   FeatureUnavailable: {

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6305,7 +6305,7 @@ type RootTranslation = {
 		 */
 		sectionsCompleted: string
 		/**
-		 * E​a​r​n
+		 * L​e​a​r​n
 		 */
 		title: string
 		/**
@@ -12929,7 +12929,7 @@ type RootTranslation = {
 		 */
 		featureCircles: string
 		/**
-		 * E​a​r​n
+		 * L​e​a​r​n
 		 */
 		featureEarn: string
 		/**
@@ -19263,7 +19263,7 @@ export type TranslationFunctions = {
 		 */
 		sectionsCompleted: () => LocalizedString
 		/**
-		 * Earn
+		 * Learn
 		 */
 		title: () => LocalizedString
 		/**
@@ -25736,7 +25736,7 @@ export type TranslationFunctions = {
 		 */
 		featureCircles: () => LocalizedString
 		/**
-		 * Earn
+		 * Learn
 		 */
 		featureEarn: () => LocalizedString
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulated",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "You've completed",
-        "title": "Earn",
+        "title": "Learn",
         "unlockQuestion": "To unlock, answer the question:",
         "youEarned": "You Earned",
         "registerTitle": "Need to upgrade your account",
@@ -3895,7 +3895,7 @@
         "noAccountTitle": "Custodial account required",
         "noAccountDescription": "{featureName: string} requires a Blink custodial account.",
         "featureCircles": "Circles",
-        "featureEarn": "Earn",
+        "featureEarn": "Learn",
         "featureCard": "Card"
     },
     "FeatureUnavailable": {

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats bymekaargemaak",
     "satsEarned": "{formattedNumber | sats} verdien",
     "sectionsCompleted": "Jy het dit voltooi",
-    "title": "Verdien",
+    "title": "Leer",
     "unlockQuestion": "Om te ontsluit moet jy die vraag beantwoord:",
     "youEarned": "Jy het verdien: ",
     "registerTitle": "Opgradeer jou rekening",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Leer",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "ساتس تم تجميعها",
     "satsEarned": "{formattedNumber | sats}\nحصلت عليها",
     "sectionsCompleted": "لقد أتممت",
-    "title": "إكسب",
+    "title": "تعلّم",
     "unlockQuestion": "لتفتح القفل، قم بلإجابة عن السؤال:",
     "youEarned": "لقد كسبت",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "تعلّم",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats acumulats",
     "satsEarned": "{formattedNumber | sats} guanyats",
     "sectionsCompleted": "Has completat",
-    "title": "Guanya",
+    "title": "Aprendre",
     "unlockQuestion": "Per desbloquejar, respon la pregunta:",
     "youEarned": "Has guanyat",
     "registerTitle": "Necessites actualitzar el teu compte",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Aprendre",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Nahromaděné saty",
     "satsEarned": "{formattedNumber | sats} získáno",
     "sectionsCompleted": "Dokončil jste",
-    "title": "Získej saty",
+    "title": "Učit se",
     "unlockQuestion": "Pro odemčení odpovězte na otázku:",
     "youEarned": "Získal jste",
     "registerTitle": "Musíme aktualizovat váš účet",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Učit se",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats akkumuleret",
     "satsEarned": "{formattedNumber | sats} optjent",
     "sectionsCompleted": "Du har fuldført",
-    "title": "Optjen",
+    "title": "Lær",
     "unlockQuestion": "For at låse op, besvar spørgsmålet:",
     "youEarned": "Du har tjent",
     "registerTitle": "Din konto skal opgraderes",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Lær",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats gesammelt",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "Du bist fertig",
-        "title": "Verdienen",
+        "title": "Lernen",
         "unlockQuestion": "Beantworte folgende Frage zum Entsperren:",
         "youEarned": "Du hast",
         "registerTitle": "Account Upgrade benötigt",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Custodial-Konto erforderlich",
         "noAccountDescription": "{featureName} benötigt ein Blink custodial-Konto.",
         "featureCircles": "Circles",
-        "featureEarn": "Verdienen",
+        "featureEarn": "Lernen",
         "featureCard": "Karte"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Συσσωρευμένα sats ",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Ολοκληρώσατε",
-    "title": "Κερδίστε ",
+    "title": "Μάθηση",
     "unlockQuestion": "Για να ξεκλειδώσετε, απαντήστε στην ερώτηση:",
     "youEarned": "Έχετε κερδίσει",
     "registerTitle": "Χρειάζεται να αναβαθμίσετε τον λογαριασμό σας",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Μάθηση",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Satoshis acumulados",
         "satsEarned": "{formattedNumber | sats} ganados",
         "sectionsCompleted": "Has completado",
-        "title": "Ganar",
+        "title": "Aprender",
         "unlockQuestion": "Para desbloquear, responda la pregunta:",
         "youEarned": "Has Ganado",
         "registerTitle": "Necesitas actualizar tu cuenta",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Cuenta custodial requerida",
         "noAccountDescription": "{featureName} requiere una cuenta custodial de Blink.",
         "featureCircles": "Círculos",
-        "featureEarn": "Aprende",
+        "featureEarn": "Aprender",
         "featureCard": "Tarjeta"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulés",
         "satsEarned": "{formattedNumber | sats} gagnés",
         "sectionsCompleted": "Vous avez terminé",
-        "title": "Quiz",
+        "title": "Apprendre",
         "unlockQuestion": "Pour dévérouiller, répondez à la question :",
         "youEarned": "Vous avez gagné",
         "registerTitle": "Besoin de mettre à jour votre compte",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Compte custodial requis",
         "noAccountDescription": "{featureName} nécessite un compte custodial Blink.",
         "featureCircles": "Cercles",
-        "featureEarn": "Gagner",
+        "featureEarn": "Apprendre",
         "featureCard": "Carte"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sat akumulirani",
     "satsEarned": "{formattedNumber | sats} osvojeno",
     "sectionsCompleted": "Završili ste",
-    "title": "Zaradi",
+    "title": "Učenje",
     "unlockQuestion": "Za otključavanje odgovorite na pitanje:",
     "youEarned": "Zaradio si",
     "registerTitle": "Morate nadograditi svoj račun",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Učenje",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Keresett satoshik",
     "satsEarned": "{formattedNumber | sats}-ot kaptál",
     "sectionsCompleted": "Befejezett szakaszok",
-    "title": "Kvíz",
+    "title": "Tanulás",
     "unlockQuestion": "Feloldáshoz, válaszolj a kérdésre:",
     "youEarned": "Kerestél",
     "registerTitle": "A magasabb szintű számlára kell váltanod",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Tanulás",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Սատերը կուտակվել են",
     "satsEarned": "{formattedNumber | sats} վաստակել եք",
     "sectionsCompleted": "Դուք ավարտել եք",
-    "title": "Վաստակել",
+    "title": "Սովորել",
     "unlockQuestion": "Բացելու համար՝ պատասխանեք հարցին",
     "youEarned": "Դուք վաստակեցիք",
     "registerTitle": "Հարկավոր է թարմացնել Ձեր հաշիվը։ ",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Պահառու հաշիվ է պահանջվում",
     "noAccountDescription": "{featureName: string}-ի համար անհրաժեշտ է Blink պահառու հաշիվ։",
     "featureCircles": "Circles",
-    "featureEarn": "Վաստակել",
+    "featureEarn": "Սովորել",
     "featureCard": "Քարտ"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats terkumpul",
     "satsEarned": "{formattedNumber | sats} diperoleh",
     "sectionsCompleted": "Anda telah menyelesaikan",
-    "title": "Dapatkan",
+    "title": "Belajar",
     "unlockQuestion": "Untuk membuka, jawab pertanyaannya:",
     "youEarned": "Anda Mendapatkan",
     "registerTitle": "Perlu memperbaharui akun Anda",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Belajar",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulati",
         "satsEarned": "{formattedNumber | sats} guadagnati",
         "sectionsCompleted": "L'hai completato",
-        "title": "Guadagna",
+        "title": "Impara",
         "unlockQuestion": "Per sbloccarlo, rispondi alla domanda:",
         "youEarned": "Hai guadagnato",
         "registerTitle": "Devi aggiornare il tuo account",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Account custodial richiesto",
         "noAccountDescription": "{featureName} richiede un account custodial Blink.",
         "featureCircles": "Circoli",
-        "featureEarn": "Guadagna",
+        "featureEarn": "Impara",
         "featureCard": "Carta"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "累計 sats",
         "satsEarned": "{formattedNumber | sats}を獲得しました",
         "sectionsCompleted": "完了しました",
-        "title": "獲得する",
+        "title": "学ぶ",
         "unlockQuestion": "アンロックするには、質問に答えてください：",
         "youEarned": "獲得額",
         "registerTitle": "ウォレットのアップグレードが必要です",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Custodial account required",
         "noAccountDescription": "{featureName} requires a Blink custodial account.",
         "featureCircles": "Circles",
-        "featureEarn": "Earn",
+        "featureEarn": "学ぶ",
         "featureCard": "Card"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats ezikuŋŋaanyiziddwa",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Omaze",
-    "title": "Kolera Empeera",
+    "title": "Yiga",
     "unlockQuestion": "Okugulawo, ddamu ekibuuzo:",
     "youEarned": "Okolede Empeera",
     "registerTitle": "W'etaaga okwongera omutindo gwa akawunti yo",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Yiga",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "sats telah dikumpul",
     "satsEarned": "{format nombor dalam |sats: string} telah diperolehi",
     "sectionsCompleted": "Dah selesai",
-    "title": "Dapat",
+    "title": "Belajar",
     "unlockQuestion": "Untuk membuka kunci, sila jawab soalan:",
     "youEarned": "Anda telah memperolehi",
     "registerTitle": "Anda perlulah naik taraf akaun anda",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Belajar",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats verzameld",
     "satsEarned": "{formattedNumber | sats} verdiend",
     "sectionsCompleted": "Je hebt voltooid",
-    "title": "Verdien",
+    "title": "Leren",
     "unlockQuestion": "Beantwoord de vraag om te ontgrendelen:",
     "youEarned": "Jij hebt verdiend",
     "registerTitle": "U moet uw account upgraden",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Leren",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats acumulados",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "Você concluiu",
-        "title": "Ganhar",
+        "title": "Aprender",
         "unlockQuestion": "Para desbloquear, responda a pergunta:",
         "youEarned": "Você ganhou",
         "registerTitle": "Precisa atualizar sua conta",
@@ -3832,7 +3832,7 @@
         "noAccountTitle": "Conta custodial necessária",
         "noAccountDescription": "{featureName} requer uma conta custodial da Blink.",
         "featureCircles": "Círculos",
-        "featureEarn": "Aprenda",
+        "featureEarn": "Aprender",
         "featureCard": "Cartão"
     },
     "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Kuskanchik sats",
     "satsEarned": "{formattedNumber | sats} kuskan.",
     "sectionsCompleted": "Ima sumaq kani",
-    "title": "Kuskan",
+    "title": "Yachay",
     "unlockQuestion": "Qhipaqaqmi, chaymantam yanapaqmi, chaymantam riyqanichu:",
     "youEarned": "Kuskan",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Yachay",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats acumulați",
     "satsEarned": "{formattedNumber | sats} câștigați",
     "sectionsCompleted": "Ați finalizat",
-    "title": "Câștigați",
+    "title": "Învață",
     "unlockQuestion": "Pentru a debloca, răspundeți la întrebarea:",
     "youEarned": "Ați câștigat",
     "registerTitle": "Trebuie să faceți upgrade contului",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Învață",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Nahromadené sats",
     "satsEarned": "{formattedNumber | sats} zarobené",
     "sectionsCompleted": "Dokončili ste",
-    "title": "Získajte saty",
+    "title": "Učiť sa",
     "unlockQuestion": "Na odomknutie odpovedzte na otázku:",
     "youEarned": "Získali ste",
     "registerTitle": "Potrebujete upgradovať účet",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Učiť sa",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Сати сакупљени",
     "satsEarned": "Зарадили сте {formattedNumber | sats}",
     "sectionsCompleted": "Завршили сте",
-    "title": "Заради",
+    "title": "Учи",
     "unlockQuestion": "Да откључате, одговорите на питање:",
     "youEarned": "Зарадили сте",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Учи",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats kusanyiko",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Umekamilisha",
-    "title": "Pata",
+    "title": "Jifunze",
     "unlockQuestion": "Ili kufungua, jibu swali:",
     "youEarned": "Umechuma",
     "registerTitle": "Unahitaji kuboresha akaunti yako",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Jifunze",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "การรวบรวม sats เสร็จสิ้น",
     "satsEarned": "ได้รับ {formattedNumber | sats}",
     "sectionsCompleted": "คุณทำแบบทดสอบเสร็จสิ้น",
-    "title": "รับเงิน",
+    "title": "เรียนรู้",
     "unlockQuestion": "ตอบคำถามเพื่อปลดล็อค:",
     "youEarned": "คุณได้รับ",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "เรียนรู้",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Biriktirilen satsler",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Tamamladınız",
-    "title": "Kazan",
+    "title": "Öğren",
     "unlockQuestion": "Kilidi açmak için soruya cevap ver:",
     "youEarned": "Kazandınız",
     "registerTitle": "Hesabınızı güncellemeniz gerekiyor",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Öğren",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats đã tích lũy",
     "satsEarned": "{formattedNumber | sats} kiếm được",
     "sectionsCompleted": "Bạn vừa hoàn thành",
-    "title": "Kiếm được",
+    "title": "Học",
     "unlockQuestion": "Để mở khóa, hãy trả lời câu hỏi:",
     "youEarned": "Bạn đã kiếm được",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Học",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "IiSats ziqokelelene",
     "satsEarned": "{formattedNumber | sats} efunyenweyo",
     "sectionsCompleted": "Ugqibile",
-    "title": "Zuza",
+    "title": "Funda",
     "unlockQuestion": "Ukuvula, phendula umbuzo:",
     "youEarned": "Uzuzile",
     "registerTitle": "Need to upgrade your account",
@@ -3832,7 +3832,7 @@
     "noAccountTitle": "Custodial account required",
     "noAccountDescription": "{featureName} requires a Blink custodial account.",
     "featureCircles": "Circles",
-    "featureEarn": "Earn",
+    "featureEarn": "Funda",
     "featureCard": "Card"
   },
   "WalletCreationScreen": {


### PR DESCRIPTION
Fixes #4014

## What

EN-based copy change: the bottom navigation bar tab formerly labeled **Earn** now reads **Learn**, matching its graduation-cap icon (`LearnIcon`). Translated per locale in all 28 translation files.

## Scope notes

- **`BackendFeatureGate.featureEarn` is included**: the same screen's signed-out gate interpolates this as the feature name ("Sign in to your custodial account to use *Earn*."). Leaving it would make the tab say "Learn" while its own gate still said "use Earn".
- **fr previously deviated** with `title: "Quiz"` (hu likewise with "Kvíz"); both now use their language's word for Learn (`Apprendre` / `Tanulás`) for consistency with the EN source.
- Key names (`EarnScreen.title`, `featureEarn`), the `Earn` route name, and the `earn` deep link are unchanged — they are code identifiers/published URLs, not user-facing copy.
- `tabBarAccessibilityLabel` and `tabBarButtonTestID` derive from the same key and follow automatically; no test references it.

## Verification

- `yarn check:translations` clean after commit (no generated-file drift)
- `yarn tsc --noEmit` clean
- `yarn jest __tests__/screens/earn-map-screen.spec.tsx __tests__/screens/earns-quiz.spec.tsx` — 4/4 pass
- Spot-checked per-file JSON indentation (mixed 2-/4-space styles preserved)

## Screenshots

| Before | After |
|---|---|
| ![bottom bar before](https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4022-assets/bottom-bar-before.png) | ![bottom bar after](https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4022-assets/bottom-bar-after.png) |

<details><summary>Full home screen (before / after)</summary>

| Before | After |
|---|---|
| ![home before](https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4022-assets/home-before.png) | ![home after](https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4022-assets/home-after.png) |

</details>

*iPhone 16 Pro simulator, same build and account for both states (before = `app/i18n` from `origin/main`, after = this branch). The in-progress balance shimmer appears in both shots and is unrelated (staging API).*
