### PR TITLE
fix(settings): change footer text to remove Galoy

### DIFF
--- a/__tests__/components/version/version.spec.tsx
+++ b/__tests__/components/version/version.spec.tsx
@@ -22,7 +22,7 @@ jest.mock("@app/i18n/i18n-react", () => ({
         unknown: () => "Unknown",
       },
       GetStartedScreen: {
-        headline: () => "Bitcoin is money",
+        headline: () => "Wallet powered by Blink",
       },
     },
   }),
@@ -57,6 +57,15 @@ describe("VersionComponent", () => {
     const { getByText } = render(<VersionComponent />)
 
     expect(getByText(/Registered: US · Detected: SE/)).toBeTruthy()
+  })
+
+  it("shows the headline below the countries", () => {
+    mockUsePhoneCountryCode.mockReturnValue("US")
+    mockUseIpCountryCode.mockReturnValue("SE")
+
+    const { getByText } = render(<VersionComponent />)
+
+    expect(getByText(/Wallet powered by Blink/)).toBeTruthy()
   })
 
   it("shows unknown as registered country when there is no phone-derived country", () => {

--- a/__tests__/i18n/brand-name.spec.ts
+++ b/__tests__/i18n/brand-name.spec.ts
@@ -1,0 +1,51 @@
+import fs from "fs"
+import path from "path"
+
+import en from "@app/i18n/en"
+
+const TRANSLATIONS_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "app",
+  "i18n",
+  "raw-i18n",
+  "translations",
+)
+
+// "Galoy" is still a legitimate internal identifier (screen names, config keys).
+// It must never surface in a value a user can read.
+const LEGACY_BRAND = /galoy/i
+
+type AnyTranslation = Record<string, unknown>
+
+const collectLegacyBrandValues = (node: unknown, prefix = ""): string[] => {
+  if (typeof node === "string")
+    return LEGACY_BRAND.test(node) ? [`${prefix}: ${node}`] : []
+  if (node === null || typeof node !== "object") return []
+  const obj = node as AnyTranslation
+  return Object.keys(obj).flatMap((key) =>
+    collectLegacyBrandValues(obj[key], prefix ? `${prefix}.${key}` : key),
+  )
+}
+
+const localeFiles = fs
+  .readdirSync(TRANSLATIONS_DIR)
+  .filter((name) => name.endsWith(".json"))
+  .sort()
+
+describe("legacy brand name", () => {
+  it("does not appear in any user-facing string in the English source", () => {
+    expect(collectLegacyBrandValues(en)).toEqual([])
+  })
+
+  localeFiles.forEach((localeFile) => {
+    it(`does not appear in any user-facing string in ${localeFile}`, () => {
+      const parsed = JSON.parse(
+        fs.readFileSync(path.join(TRANSLATIONS_DIR, localeFile), "utf8"),
+      ) as AnyTranslation
+
+      expect(collectLegacyBrandValues(parsed)).toEqual([])
+    })
+  })
+})

--- a/__tests__/i18n/footer-headline.spec.ts
+++ b/__tests__/i18n/footer-headline.spec.ts
@@ -1,0 +1,24 @@
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+
+describe("GetStartedScreen.headline", () => {
+  it("reads 'Wallet powered by Blink' in English", () => {
+    loadLocale("en")
+
+    expect(i18nObject("en").GetStartedScreen.headline()).toBe("Wallet powered by Blink")
+  })
+
+  it("reads 'Billetera desarrollada por Blink' in Spanish", () => {
+    loadLocale("es")
+
+    expect(i18nObject("es").GetStartedScreen.headline()).toBe(
+      "Billetera desarrollada por Blink",
+    )
+  })
+
+  it("reads 'Portofel oferit de Blink' in Romanian", () => {
+    loadLocale("ro")
+
+    expect(i18nObject("ro").GetStartedScreen.headline()).toBe("Portofel oferit de Blink")
+  })
+})

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2049,7 +2049,7 @@
     "login": "Meld aan",
     "loginOrRestore": "Teken in / Herstel",
     "logBackInWith": "Teken weer in met",
-    "headline": "Beursie deur Galoy gebou",
+    "headline": "Beursie deur Blink gebou",
     "startTrialAccount": "Begin met 'n proefrekening",
     "startWithTrialAccount": "Begin met 'n proefrekening",
     "registerPhoneAccount": "Registreer 'n selfoonrekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2049,7 +2049,7 @@
     "login": "تسجيل الدخول",
     "loginOrRestore": "تسجيل الدخول / استعادة",
     "logBackInWith": "Log back in with",
-    "headline": "المحفظة مشغلة بواسطة Galoy",
+    "headline": "المحفظة مشغلة بواسطة Blink",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2049,7 +2049,7 @@
     "login": "Inicia sessió",
     "loginOrRestore": "Iniciar sessió / Restaurar",
     "logBackInWith": "Torna a iniciar sessió amb",
-    "headline": "Moneder desenvolupat per Galoy",
+    "headline": "Moneder desenvolupat per Blink",
     "startTrialAccount": "Comença amb un compte de prova",
     "startWithTrialAccount": "començar amb el compte de prova",
     "registerPhoneAccount": "Registra el compte de telèfon",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2049,7 +2049,7 @@
     "login": "Přihlásit se",
     "loginOrRestore": "Přihlásit se / Obnovit",
     "logBackInWith": "Přihlaste se zpět pomocí",
-    "headline": "Peněženka od společnosti Galoy",
+    "headline": "Peněženka od společnosti Blink",
     "startTrialAccount": "Začněte se zkušebním účtem",
     "startWithTrialAccount": "Začněte s demo účtem",
     "registerPhoneAccount": "Registrace telefonního účtu",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2049,7 +2049,7 @@
     "login": "Log ind",
     "loginOrRestore": "Log ind / Gendan",
     "logBackInWith": "Log ind igen med",
-    "headline": "Tegnebogen er drevet af Galoy",
+    "headline": "Tegnebogen er drevet af Blink",
     "startTrialAccount": "Start med en prøvekonto",
     "startWithTrialAccount": "Start med en prøvekonto",
     "registerPhoneAccount": "Registrer telefonkonto",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2049,7 +2049,7 @@
         "login": "Anmelden",
         "loginOrRestore": "Anmelden / Wiederherstellen",
         "logBackInWith": "Wieder einloggen mit",
-        "headline": "Wallet zur Verfügung gestellt von Galoy",
+        "headline": "Wallet zur Verfügung gestellt von Blink",
         "startTrialAccount": "Mit einem Demo-Account beginnen",
         "startWithTrialAccount": "Mit Demo-Account starten",
         "registerPhoneAccount": "Telefon-Account registrieren",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2049,7 +2049,7 @@
     "login": "Σύνδεση",
     "loginOrRestore": "Σύνδεση / Επαναφορά",
     "logBackInWith": "Συνδεθείτε ξανά με",
-    "headline": "Πορτοφόλι που παρέχεται από την Galoy",
+    "headline": "Πορτοφόλι που παρέχεται από την Blink",
     "startTrialAccount": "Ξεκινήστε με έναν δοκιμαστικό λογαριασμό",
     "startWithTrialAccount": "Ξεκινήστε μ' έναν δοκιμαστικό λογαριασμό",
     "registerPhoneAccount": "Καταχώριση λογαριασμού τηλεφώνου",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2049,7 +2049,7 @@
         "logBackInWith": "Reinicia sesión con",
         "login": "Iniciar sesión",
         "loginOrRestore": "Iniciar sesión / Restaurar",
-        "headline": "El banco con dinero sólido",
+        "headline": "Billetera desarrollada por Blink",
         "startTrialAccount": "Empieza con una cuenta de prueba.",
         "startWithTrialAccount": "Empezar con la cuenta de prueba",
         "registerPhoneAccount": "Registra cuenta de teléfono",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2049,7 +2049,7 @@
         "login": "Connexion",
         "loginOrRestore": "Connexion / Restaurer",
         "logBackInWith": "Se reconnecter avec ",
-        "headline": "Portefeuille développé par Galoy",
+        "headline": "Portefeuille développé par Blink",
         "startTrialAccount": "Débuter avec un compte test",
         "startWithTrialAccount": "Débuter avec un compte test",
         "registerPhoneAccount": "Enregistrer le téléphone du compte",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2049,7 +2049,7 @@
     "login": "Prijava",
     "loginOrRestore": "Prijava / Obnova",
     "logBackInWith": "Prijavi se ponovo s",
-    "headline": "Novčanik koji pokreće Galoy",
+    "headline": "Novčanik koji pokreće Blink",
     "startTrialAccount": "Započni s probnim računom",
     "startWithTrialAccount": "Započni s probnim računom",
     "registerPhoneAccount": "Registrirajte telefonski račun",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2049,7 +2049,7 @@
     "login": "Bejelentkezés",
     "loginOrRestore": "Bejelentkezés / Visszaállítás",
     "logBackInWith": "Újra bejelentkezés ezzel:",
-    "headline": "A Galoy által biztosított tárca",
+    "headline": "A Blink által biztosított tárca",
     "startTrialAccount": "Kezdés próba fiókkal",
     "startWithTrialAccount": "Kezdés próba fiókkal",
     "registerPhoneAccount": "Telefon alapú fiók regisztrálása",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2049,7 +2049,7 @@
     "login": "Մուտք գործել",
     "loginOrRestore": "Մուտք գործել / վերականգնել",
     "logBackInWith": "Մուտք գործել գործածելով",
-    "headline": "Դրամապանակն աջակցվում է Galoy-ի կողմից",
+    "headline": "Դրամապանակն աջակցվում է Blink-ի կողմից",
     "startTrialAccount": "Սկսել փորձնական հաշվով ",
     "startWithTrialAccount": "Սկսել փորձնական հաշվով ",
     "registerPhoneAccount": "Գրանցել հեռախոսահամարը ",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2049,7 +2049,7 @@
     "login": "Masuk",
     "loginOrRestore": "Masuk / Pulihkan",
     "logBackInWith": "Masuk kembali dengan",
-    "headline": "Dompet didukung oleh Galoy",
+    "headline": "Dompet didukung oleh Blink",
     "startTrialAccount": "Mulai dengan akun percobaan",
     "startWithTrialAccount": "Mulai dengan akun percobaan",
     "registerPhoneAccount": "Daftar akun telepon",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2049,7 +2049,7 @@
         "login": "Accedi",
         "loginOrRestore": "Accedi / Ripristina",
         "logBackInWith": "Accedi nuovamente con",
-        "headline": "Wallet creato da Galoy",
+        "headline": "Wallet creato da Blink",
         "startTrialAccount": "Inizia con un conto di prova",
         "startWithTrialAccount": "Inizia con un account di prova",
         "registerPhoneAccount": "Registra account telefonico",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2049,7 +2049,7 @@
         "login": "ログイン",
         "loginOrRestore": "ログイン / 復元",
         "logBackInWith": "再ログイン：",
-        "headline": "Galoyが提供するウォレット",
+        "headline": "Blinkが提供するウォレット",
         "startTrialAccount": "トライアルウォレットで始める",
         "startWithTrialAccount": "トライアルウォレットで始める",
         "registerPhoneAccount": "電話番号でウォレット登録する",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2049,7 +2049,7 @@
     "login": "Yingira",
     "loginOrRestore": "Yingira / Zzaawo",
     "logBackInWith": "Ddamu oyingire ne",
-    "headline": "Waleti ewagidwa Galoy",
+    "headline": "Waleti ewagidwa Blink",
     "startTrialAccount": "Tandika ne akawunti y'okugezesa",
     "startWithTrialAccount": "Tandika ne akawunti y'okugezesa",
     "registerPhoneAccount": "Wandiisa essimu ya akawunti",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2049,7 +2049,7 @@
     "login": "Log masuk",
     "loginOrRestore": "Log masuk / Pulihkan",
     "logBackInWith": "Log masuk semula dengan",
-    "headline": "Dompet dikuasakan oleh Galoy",
+    "headline": "Dompet dikuasakan oleh Blink",
     "startTrialAccount": "Mulakan dengan akaun percubaan",
     "startWithTrialAccount": "Mulakan dengan akaun percubaan",
     "registerPhoneAccount": "Daftarkan nombor telefon",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2049,7 +2049,7 @@
     "login": "Inloggen",
     "loginOrRestore": "Inloggen / Herstellen",
     "logBackInWith": "Log opnieuw in met",
-    "headline": "Wallet mogelijk gemaakt door Galoy",
+    "headline": "Wallet mogelijk gemaakt door Blink",
     "startTrialAccount": "Begin met een proefaccount",
     "startWithTrialAccount": "Begin met een proefaccount",
     "registerPhoneAccount": "Registreer telefoonaccount",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -423,7 +423,7 @@
                             "Sim. O Bitcoin geralmente é hackeado nos feriados, quando os bancos tradicionais estão fechados."
                         ],
                         "feedback": [
-                            "Isso está correto. A rede bitcoin nunca foi comprometida. No entanto, é importante fazer você usar uma carteira digital segura (como Galoy!) para manter seus bitcoins pessoais seguros o tempo todo.",
+                            "Isso está correto. A rede bitcoin nunca foi comprometida. No entanto, é importante fazer você usar uma carteira digital segura para manter seus bitcoins pessoais seguros o tempo todo.",
                             "Errado. Por favor, tente novamente.",
                             "Não bobo, você sabe que não é a resposta correta."
                         ],
@@ -2049,7 +2049,7 @@
         "login": "Entrar",
         "loginOrRestore": "Entrar / Restaurar",
         "logBackInWith": "Faça login novamente com",
-        "headline": "Carteira desenvolvida pela Galoy",
+        "headline": "Carteira desenvolvida pela Blink",
         "startTrialAccount": "Comece com uma conta teste",
         "startWithTrialAccount": "Comece com uma conta teste",
         "registerPhoneAccount": "Registe um número de telefone",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2049,7 +2049,7 @@
     "login": "Yaykuy",
     "loginOrRestore": "Yaykuy / Kutichiy",
     "logBackInWith": "Log back in with",
-    "headline": "Galoyta kawsayninkunawan kuskan.",
+    "headline": "Blinkta kawsayninkunawan kuskan.",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2049,7 +2049,7 @@
     "login": "Yaykuy",
     "loginOrRestore": "Yaykuy / Kutichiy",
     "logBackInWith": "Log back in with",
-    "headline": "Blinkta kawsayninkunawan kuskan.",
+    "headline": "Blinkta kawsayninkunawan kuskan",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2049,7 +2049,7 @@
     "login": "Autentificare",
     "loginOrRestore": "Autentificare / Restaurare",
     "logBackInWith": "Conectați-vă din nou cu",
-    "headline": "Wallet powered by Blink",
+    "headline": "Portofel oferit de Blink",
     "startTrialAccount": "Începeți cu un cont de încercare",
     "startWithTrialAccount": "Începeți cu un cont de încercare",
     "registerPhoneAccount": "Înregistrați contul de telefon",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2049,7 +2049,7 @@
     "login": "Autentificare",
     "loginOrRestore": "Autentificare / Restaurare",
     "logBackInWith": "Conectați-vă din nou cu",
-    "headline": "Wallet powered by Galoy",
+    "headline": "Wallet powered by Blink",
     "startTrialAccount": "Începeți cu un cont de încercare",
     "startWithTrialAccount": "Începeți cu un cont de încercare",
     "registerPhoneAccount": "Înregistrați contul de telefon",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2049,7 +2049,7 @@
     "login": "Prihlásiť sa",
     "loginOrRestore": "Prihlásiť sa / Obnoviť",
     "logBackInWith": "Prihláste sa späť pomocou",
-    "headline": "Peňaženka od spoločnosti Galoy",
+    "headline": "Peňaženka od spoločnosti Blink",
     "startTrialAccount": "Začnite so skúšobným účtom",
     "startWithTrialAccount": "Začnite s demo účtom",
     "registerPhoneAccount": "Registrácia telefónneho účtu",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2049,7 +2049,7 @@
     "login": "Пријава",
     "loginOrRestore": "Пријава / Обнова",
     "logBackInWith": "Log back in with",
-    "headline": "Новчаник омогућен од стране „Galoy“",
+    "headline": "Новчаник омогућен од стране „Blink“",
     "startTrialAccount": "Почните са пробним налогом",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Региструјте налог са бројем телефона",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2049,7 +2049,7 @@
     "login": "Ingia",
     "loginOrRestore": "Ingia / Rejesha",
     "logBackInWith": "Ingia tena na",
-    "headline": "Pochi limewezeshwa na Blink.",
+    "headline": "Pochi limewezeshwa na Blink",
     "startTrialAccount": "Anza na akaunti ya majaribio",
     "startWithTrialAccount": "Anza na akaunti ya majaribio",
     "registerPhoneAccount": "Jisajili akaunti ya simu",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2049,7 +2049,7 @@
     "login": "Ingia",
     "loginOrRestore": "Ingia / Rejesha",
     "logBackInWith": "Ingia tena na",
-    "headline": "Pochi limewezeshwa na Galoy.",
+    "headline": "Pochi limewezeshwa na Blink.",
     "startTrialAccount": "Anza na akaunti ya majaribio",
     "startWithTrialAccount": "Anza na akaunti ya majaribio",
     "registerPhoneAccount": "Jisajili akaunti ya simu",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2049,7 +2049,7 @@
     "login": "เข้าสู่ระบบ",
     "loginOrRestore": "เข้าสู่ระบบ / กู้คืน",
     "logBackInWith": "Log back in with",
-    "headline": "สนับสนุนโดย Galoy",
+    "headline": "สนับสนุนโดย Blink",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2049,7 +2049,7 @@
     "login": "Giriş yap",
     "loginOrRestore": "Giriş yap / Geri yükle",
     "logBackInWith": "Şununla tekrar giriş yap",
-    "headline": "Cüzdan Galoy tarafından çalıştırılmakta",
+    "headline": "Cüzdan Blink tarafından çalıştırılmakta",
     "startTrialAccount": "Bir deneme hesabı ile başla",
     "startWithTrialAccount": "Denem hesabı ile başla",
     "registerPhoneAccount": "Telefon numaranı kaydet",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2049,7 +2049,7 @@
     "login": "Đăng nhập",
     "loginOrRestore": "Đăng nhập / Khôi phục",
     "logBackInWith": "Log back in with",
-    "headline": "Ví được cung cấp bởi Galoy",
+    "headline": "Ví được cung cấp bởi Blink",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2049,7 +2049,7 @@
     "login": "Ngena",
     "loginOrRestore": "Ngena / Buyisela",
     "logBackInWith": "Ngena kwakhona nge",
-    "headline": "Isipaji siqhutywa nguGaloy",
+    "headline": "Isipaji siqhutywa nguBlink",
     "startTrialAccount": "Start with a trial account",
     "startWithTrialAccount": "Start with trial account",
     "registerPhoneAccount": "Register phone account",


### PR DESCRIPTION
Fixes blinkbitcoin/blink-wip#1012 (cross-repo — please close the issue manually on merge).

## Summary

The Settings screen footer renders `GetStartedScreen.headline`, whose English source already reads "Wallet powered by Blink" — but every other locale still credited Galoy, and Spanish carried an unrelated old tagline ("El banco con dinero sólido"). This aligns all language variants with EN:

- **26 locales**: brand swap Galoy → Blink in the existing translated sentence, preserving each language's grammatical inflection on the name (hy `Blink-ի`, xh `nguBlink`, qu `Blinkta`, sr `„Blink“`).
- **es**: retranslated to `Billetera desarrollada por Blink` to match the EN meaning.
- **pt (bonus, found while sweeping)**: a quiz feedback string still said "…carteira digital segura (como Galoy!)…"; EN dropped that parenthetical entirely, so it is removed here too.

Only `app/i18n/raw-i18n/translations/*.json` change (29 lines across 28 files). `en/index.ts` is untouched, so no generated-type churn.

## Verification

- `grep -rn Galoy app/i18n/raw-i18n/translations/` → only internal key names (`GaloyAddressScreen`, `galoyInstance`) remain; zero user-facing string values.
- All 28 JSONs parse.
- `yarn jest --runTestsByPath __tests__/components/version/version.spec.tsx` → 3/3 green.
- `yarn update-translations` → no diff (CI `check:translations` unaffected).