### PR TITLE
fix(receive): show the real onchain deposit fee above 1M sats

### DIFF
--- a/__tests__/components/contextual-info.spec.tsx
+++ b/__tests__/components/contextual-info.spec.tsx
@@ -67,6 +67,11 @@ jest.mock("@app/i18n/i18n-react", () => ({
           overFee: string
         }) =>
           `Deposit fee: ${fee} SAT for amounts under ${threshold} SAT or ${overFee} SAT for deposits over ${threshold} SAT`,
+        depositFeeTiers: ({ tiers }: { tiers: string }) => `Deposit fees: ${tiers}`,
+        depositFeeTierUpTo: ({ fee, max }: { fee: string; max: string }) =>
+          `${fee} SAT up to ${max} SAT`,
+        depositFeeTierAbove: ({ fee, min }: { fee: string; min: string }) =>
+          `${fee} SAT above ${min} SAT`,
         autoConvertMinAmount: ({
           minSats,
           minFiat,
@@ -214,6 +219,33 @@ describe("ContextualInfo", () => {
       expect(
         getByText(
           "Deposit fee: 2,500 SAT for amounts under 1M SAT or 0 SAT for deposits over 1M SAT",
+        ),
+      ).toBeTruthy()
+    })
+
+    it("names every tier when the API returns more than two", () => {
+      const { getByText } = render(
+        <ContextualInfo
+          {...defaultProps}
+          type={Invoice.OnChain}
+          canSetExpirationTime={false}
+          feesInformation={{
+            deposit: {
+              minBankFee: "2500",
+              minBankFeeThreshold: "1000000",
+              tiers: [
+                { maxAmount: "1000000", amount: "2500" },
+                { maxAmount: "5000000", amount: "4000" },
+                { maxAmount: null, amount: "5000" },
+              ],
+            },
+          }}
+        />,
+      )
+
+      expect(
+        getByText(
+          "Deposit fees: 2,500 SAT up to 1M SAT, 4,000 SAT up to 5M SAT, 5,000 SAT above 5M SAT",
         ),
       ).toBeTruthy()
     })

--- a/__tests__/components/contextual-info.spec.tsx
+++ b/__tests__/components/contextual-info.spec.tsx
@@ -173,7 +173,14 @@ describe("ContextualInfo", () => {
           type={Invoice.OnChain}
           canSetExpirationTime={false}
           feesInformation={{
-            deposit: { minBankFee: "2500", minBankFeeThreshold: "1000000", ratio: "50" },
+            deposit: {
+              minBankFee: "2500",
+              minBankFeeThreshold: "1000000",
+              tiers: [
+                { maxAmount: "1000000", amount: "2500" },
+                { maxAmount: null, amount: "5000" },
+              ],
+            },
           }}
         />,
       )
@@ -185,14 +192,21 @@ describe("ContextualInfo", () => {
       ).toBeTruthy()
     })
 
-    it("renders a zero over-threshold fee when the ratio is zero", () => {
+    it("renders a zero over-threshold fee when the unbounded tier is free", () => {
       const { getByText } = render(
         <ContextualInfo
           {...defaultProps}
           type={Invoice.OnChain}
           canSetExpirationTime={false}
           feesInformation={{
-            deposit: { minBankFee: "2500", minBankFeeThreshold: "1000000", ratio: "0" },
+            deposit: {
+              minBankFee: "2500",
+              minBankFeeThreshold: "1000000",
+              tiers: [
+                { maxAmount: "1000000", amount: "2500" },
+                { maxAmount: null, amount: "0" },
+              ],
+            },
           }}
         />,
       )
@@ -211,7 +225,14 @@ describe("ContextualInfo", () => {
           type={Invoice.OnChain}
           canSetExpirationTime={false}
           feesInformation={{
-            deposit: { minBankFee: "2500", minBankFeeThreshold: "1000000", ratio: "50" },
+            deposit: {
+              minBankFee: "2500",
+              minBankFeeThreshold: "1000000",
+              tiers: [
+                { maxAmount: "1000000", amount: "2500" },
+                { maxAmount: null, amount: "5000" },
+              ],
+            },
           }}
         />,
       )

--- a/__tests__/receive-bitcoin/hooks/use-wallet-resolution.spec.ts
+++ b/__tests__/receive-bitcoin/hooks/use-wallet-resolution.spec.ts
@@ -118,7 +118,11 @@ describe("useWalletResolution", () => {
         globals: {
           network: Network.Mainnet,
           feesInformation: {
-            deposit: { minBankFee: "0", minBankFeeThreshold: "0", ratio: "0" },
+            deposit: {
+              minBankFee: "0",
+              minBankFeeThreshold: "0",
+              tiers: [{ maxAmount: null, amount: "0" }],
+            },
           },
         },
       },

--- a/__tests__/screens/receive.spec.tsx
+++ b/__tests__/screens/receive.spec.tsx
@@ -20,7 +20,14 @@ const makeQueryResult = (defaultWalletId = "btc-wallet-id") => ({
       __typename: "Globals" as const,
       network: "signet" as const,
       feesInformation: {
-        deposit: { minBankFee: "3000", minBankFeeThreshold: "1000000", ratio: "50" },
+        deposit: {
+          minBankFee: "3000",
+          minBankFeeThreshold: "1000000",
+          tiers: [
+            { maxAmount: "1000000", amount: "3000" },
+            { maxAmount: null, amount: "5000" },
+          ],
+        },
       },
     },
     me: {

--- a/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
@@ -211,6 +211,49 @@ describe("FeeRatesScreen", () => {
     expect(queryByText("Unable to fetch fees at this time")).toBeNull()
   })
 
+  it("renders a row per tier when the API returns more than two", async () => {
+    const threeTierMocks = [
+      {
+        request: { query: FeeRatesDocument },
+        result: {
+          data: {
+            globals: {
+              __typename: "Globals",
+              feesInformation: {
+                __typename: "FeesInformation",
+                deposit: {
+                  __typename: "DepositFeesInformation",
+                  minBankFee: "2500",
+                  minBankFeeThreshold: "1000000",
+                  tiers: [
+                    {
+                      __typename: "DepositFeeTier",
+                      maxAmount: "1000000",
+                      amount: "2500",
+                    },
+                    {
+                      __typename: "DepositFeeTier",
+                      maxAmount: "5000000",
+                      amount: "4000",
+                    },
+                    { __typename: "DepositFeeTier", maxAmount: null, amount: "5000" },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    ]
+
+    const { findByText } = renderWithApolloMocks(threeTierMocks)
+
+    expect(await findByText("Onchain below 1M SAT")).toBeTruthy()
+    expect(await findByText("Onchain between 1M and 5M SAT")).toBeTruthy()
+    expect(await findByText("Onchain above 5M SAT")).toBeTruthy()
+    expect(await findByText("4,000 SAT")).toBeTruthy()
+  })
+
   it("renders a zero over-threshold fee when the unbounded tier is free", async () => {
     const zeroOverFeeMocks = [
       {

--- a/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
+++ b/__tests__/screens/settings-screen/fee-rates-screen.spec.tsx
@@ -187,7 +187,14 @@ describe("FeeRatesScreen", () => {
                   __typename: "DepositFeesInformation",
                   minBankFee: "2500",
                   minBankFeeThreshold: "1000000",
-                  ratio: "50",
+                  tiers: [
+                    {
+                      __typename: "DepositFeeTier",
+                      maxAmount: "1000000",
+                      amount: "2500",
+                    },
+                    { __typename: "DepositFeeTier", maxAmount: null, amount: "5000" },
+                  ],
                 },
               },
             },
@@ -204,8 +211,8 @@ describe("FeeRatesScreen", () => {
     expect(queryByText("Unable to fetch fees at this time")).toBeNull()
   })
 
-  it("renders a zero over-threshold fee when the API reports a zero ratio", async () => {
-    const zeroRatioMocks = [
+  it("renders a zero over-threshold fee when the unbounded tier is free", async () => {
+    const zeroOverFeeMocks = [
       {
         request: { query: FeeRatesDocument },
         result: {
@@ -218,7 +225,14 @@ describe("FeeRatesScreen", () => {
                   __typename: "DepositFeesInformation",
                   minBankFee: "2500",
                   minBankFeeThreshold: "1000000",
-                  ratio: "0",
+                  tiers: [
+                    {
+                      __typename: "DepositFeeTier",
+                      maxAmount: "1000000",
+                      amount: "2500",
+                    },
+                    { __typename: "DepositFeeTier", maxAmount: null, amount: "0" },
+                  ],
                 },
               },
             },
@@ -227,7 +241,7 @@ describe("FeeRatesScreen", () => {
       },
     ]
 
-    const { findByText } = renderWithApolloMocks(zeroRatioMocks)
+    const { findByText } = renderWithApolloMocks(zeroOverFeeMocks)
 
     expect(await findByText("2,500 SAT")).toBeTruthy()
     expect(await findByText("0 SAT")).toBeTruthy()

--- a/__tests__/utils/deposit-fees.spec.ts
+++ b/__tests__/utils/deposit-fees.spec.ts
@@ -1,6 +1,6 @@
-import { formatDepositFees } from "@app/utils/deposit-fees"
+import { formatDepositFeeTiers } from "@app/utils/deposit-fees"
 
-describe("formatDepositFees", () => {
+describe("formatDepositFeeTiers", () => {
   const deposit = {
     minBankFee: "2500",
     minBankFeeThreshold: "1000000",
@@ -10,64 +10,98 @@ describe("formatDepositFees", () => {
     ],
   }
 
-  it("formats the minimum fee, compact threshold and over-threshold tier fee", () => {
-    expect(formatDepositFees(deposit)).toEqual({
-      fee: "2,500",
-      threshold: "1M",
-      overFee: "5,000",
-    })
+  it("formats each tier with its own bounds", () => {
+    expect(formatDepositFeeTiers(deposit)).toEqual([
+      { amount: "2,500", minAmount: null, maxAmount: "1M" },
+      { amount: "5,000", minAmount: "1M", maxAmount: null },
+    ])
   })
 
-  it("reads the over-threshold fee from the unbounded tier wherever it sits", () => {
+  it("gives a middle tier both bounds so it can be labelled as a range", () => {
     expect(
-      formatDepositFees({
+      formatDepositFeeTiers({
         ...deposit,
         tiers: [
-          { maxAmount: null, amount: "7500" },
+          { maxAmount: "1000000", amount: "2500" },
+          { maxAmount: "5000000", amount: "4000" },
+          { maxAmount: null, amount: "5000" },
+        ],
+      }),
+    ).toEqual([
+      { amount: "2,500", minAmount: null, maxAmount: "1M" },
+      { amount: "4,000", minAmount: "1M", maxAmount: "5M" },
+      { amount: "5,000", minAmount: "5M", maxAmount: null },
+    ])
+  })
+
+  it("sorts tiers ascending with the unbounded tier last", () => {
+    expect(
+      formatDepositFeeTiers({
+        ...deposit,
+        tiers: [
+          { maxAmount: null, amount: "5000" },
+          { maxAmount: "5000000", amount: "4000" },
           { maxAmount: "1000000", amount: "2500" },
         ],
-      }).overFee,
-    ).toBe("7,500")
+      }).map((tier) => tier.amount),
+    ).toEqual(["2,500", "4,000", "5,000"])
   })
 
-  it("keeps a legitimate zero tier amount as a zero fee instead of the fallback", () => {
+  it("keeps a legitimate zero amount instead of falling back", () => {
     expect(
-      formatDepositFees({
+      formatDepositFeeTiers({
         ...deposit,
         tiers: [{ maxAmount: null, amount: "0" }],
-      }).overFee,
-    ).toBe("0")
+      }),
+    ).toEqual([{ amount: "0", minAmount: null, maxAmount: null }])
   })
 
-  it("falls back to the default over-threshold fee when there is no unbounded tier", () => {
+  it("drops a tier whose amount is not numeric", () => {
     expect(
-      formatDepositFees({
+      formatDepositFeeTiers({
         ...deposit,
-        tiers: [{ maxAmount: "1000000", amount: "2500" }],
-      }).overFee,
-    ).toBe("5,000")
+        tiers: [
+          { maxAmount: "1000000", amount: "2500" },
+          { maxAmount: null, amount: "oops" },
+        ],
+      }),
+    ).toEqual([{ amount: "2,500", minAmount: null, maxAmount: "1M" }])
   })
 
-  it("falls back to the default over-threshold fee when tiers are missing", () => {
-    expect(formatDepositFees({ ...deposit, tiers: undefined }).overFee).toBe("5,000")
-  })
-
-  it("falls back to the default over-threshold fee when the tier amount is not numeric", () => {
+  it("treats a blank amount as missing rather than as zero", () => {
     expect(
-      formatDepositFees({
+      formatDepositFeeTiers({
         ...deposit,
-        tiers: [{ maxAmount: null, amount: "oops" }],
-      }).overFee,
-    ).toBe("5,000")
+        tiers: [{ maxAmount: null, amount: "  " }],
+      }),
+    ).toEqual([
+      { amount: "2,500", minAmount: null, maxAmount: "1M" },
+      { amount: "5,000", minAmount: "1M", maxAmount: null },
+    ])
   })
 
-  it("falls back to the default minimum fee when minBankFee is not numeric", () => {
-    expect(formatDepositFees({ ...deposit, minBankFee: "oops" }).fee).toBe("2,500")
-  })
+  describe("when tiers are unusable", () => {
+    it("falls back to the legacy minBankFee shape", () => {
+      expect(formatDepositFeeTiers({ ...deposit, tiers: [] })).toEqual([
+        { amount: "2,500", minAmount: null, maxAmount: "1M" },
+        { amount: "5,000", minAmount: "1M", maxAmount: null },
+      ])
+    })
 
-  it("falls back to the default threshold when minBankFeeThreshold is not numeric", () => {
-    expect(formatDepositFees({ ...deposit, minBankFeeThreshold: "oops" }).threshold).toBe(
-      "1M",
-    )
+    it("falls back to the default minimum fee when minBankFee is not numeric", () => {
+      expect(
+        formatDepositFeeTiers({ ...deposit, minBankFee: "oops", tiers: [] })[0].amount,
+      ).toBe("2,500")
+    })
+
+    it("falls back to the default threshold when minBankFeeThreshold is not numeric", () => {
+      expect(
+        formatDepositFeeTiers({
+          ...deposit,
+          minBankFeeThreshold: "oops",
+          tiers: [],
+        })[0].maxAmount,
+      ).toBe("1M")
+    })
   })
 })

--- a/__tests__/utils/deposit-fees.spec.ts
+++ b/__tests__/utils/deposit-fees.spec.ts
@@ -4,10 +4,13 @@ describe("formatDepositFees", () => {
   const deposit = {
     minBankFee: "2500",
     minBankFeeThreshold: "1000000",
-    ratio: "50",
+    tiers: [
+      { maxAmount: "1000000", amount: "2500" },
+      { maxAmount: null, amount: "5000" },
+    ],
   }
 
-  it("formats the minimum fee, compact threshold and derived over-threshold fee", () => {
+  it("formats the minimum fee, compact threshold and over-threshold tier fee", () => {
     expect(formatDepositFees(deposit)).toEqual({
       fee: "2,500",
       threshold: "1M",
@@ -15,22 +18,47 @@ describe("formatDepositFees", () => {
     })
   })
 
-  it("rounds the derived over-threshold fee", () => {
-    expect(formatDepositFees({ ...deposit, ratio: "33" }).overFee).toBe("3,300")
+  it("reads the over-threshold fee from the unbounded tier wherever it sits", () => {
+    expect(
+      formatDepositFees({
+        ...deposit,
+        tiers: [
+          { maxAmount: null, amount: "7500" },
+          { maxAmount: "1000000", amount: "2500" },
+        ],
+      }).overFee,
+    ).toBe("7,500")
   })
 
-  it("keeps a legitimate zero ratio as a zero fee instead of the fallback", () => {
-    expect(formatDepositFees({ ...deposit, ratio: "0" }).overFee).toBe("0")
+  it("keeps a legitimate zero tier amount as a zero fee instead of the fallback", () => {
+    expect(
+      formatDepositFees({
+        ...deposit,
+        tiers: [{ maxAmount: null, amount: "0" }],
+      }).overFee,
+    ).toBe("0")
   })
 
-  it("falls back to the default over-threshold fee when the ratio is not numeric", () => {
-    expect(formatDepositFees({ ...deposit, ratio: "not-a-number" }).overFee).toBe("5,000")
+  it("falls back to the default over-threshold fee when there is no unbounded tier", () => {
+    expect(
+      formatDepositFees({
+        ...deposit,
+        tiers: [{ maxAmount: "1000000", amount: "2500" }],
+      }).overFee,
+    ).toBe("5,000")
   })
 
-  it("falls back to the default over-threshold fee when the threshold is not numeric", () => {
-    expect(formatDepositFees({ ...deposit, minBankFeeThreshold: "oops" }).overFee).toBe(
-      "5,000",
-    )
+  it("falls back to the default over-threshold fee when tiers are missing", () => {
+    expect(formatDepositFees({ ...deposit, tiers: undefined }).overFee).toBe("5,000")
+  })
+
+  it("falls back to the default over-threshold fee when the tier amount is not numeric", () => {
+    expect(
+      formatDepositFees({
+        ...deposit,
+        tiers: [{ maxAmount: null, amount: "oops" }],
+      }).overFee,
+    ).toBe("5,000")
   })
 
   it("falls back to the default minimum fee when minBankFee is not numeric", () => {

--- a/app/components/contextual-info/contextual-info.tsx
+++ b/app/components/contextual-info/contextual-info.tsx
@@ -7,14 +7,55 @@ import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 import { ExpirationTimeModal } from "@app/components/expiration-time-chooser/expiration-time-modal"
 import { WalletCurrency } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
+import { TranslationFunctions } from "@app/i18n/i18n-types"
 import {
   Invoice,
   InvoiceType,
 } from "@app/screens/receive-bitcoin-screen/payment/index.types"
-import { DepositFeesInformation, formatDepositFees } from "@app/utils/deposit-fees"
+import {
+  DepositFeesInformation,
+  FormattedDepositFeeTier,
+  formatDepositFeeTiers,
+} from "@app/utils/deposit-fees"
 
 type FeesInformation = {
   deposit: DepositFeesInformation
+}
+
+/**
+ * Two tiers — the only shape in production — keep the long-standing sentence
+ * so the 28 existing translations stay accurate. Any other tier count is
+ * composed from per-tier fragments instead of being silently misreported.
+ */
+const depositFeeText = (
+  LL: TranslationFunctions,
+  tiers: readonly FormattedDepositFeeTier[],
+): string => {
+  const [first, last] = [tiers[0], tiers[tiers.length - 1]]
+
+  if (tiers.length === 2 && first.maxAmount !== null && last.maxAmount === null) {
+    return LL.ReceiveScreen.depositFee({
+      fee: first.amount,
+      threshold: first.maxAmount,
+      overFee: last.amount,
+    })
+  }
+
+  return LL.ReceiveScreen.depositFeeTiers({
+    tiers: tiers
+      .map((tier) =>
+        tier.maxAmount === null
+          ? LL.ReceiveScreen.depositFeeTierAbove({
+              fee: tier.amount,
+              min: tier.minAmount ?? "0",
+            })
+          : LL.ReceiveScreen.depositFeeTierUpTo({
+              fee: tier.amount,
+              max: tier.maxAmount,
+            }),
+      )
+      .join(", "),
+  })
 }
 
 type ContextualInfoProps = {
@@ -101,14 +142,12 @@ export const ContextualInfo: React.FC<ContextualInfoProps> = ({
   }
 
   if (type === Invoice.OnChain && feesInformation) {
-    const { fee, threshold, overFee } = formatDepositFees(feesInformation.deposit)
+    const tiers = formatDepositFeeTiers(feesInformation.deposit)
 
     return (
       <View style={styles.depositFeeContainer}>
         <GaloyIcon name="warning" size={16} color={colors.grey1} />
-        <Text style={styles.depositFeeText}>
-          {LL.ReceiveScreen.depositFee({ fee, threshold, overFee })}
-        </Text>
+        <Text style={styles.depositFeeText}>{depositFeeText(LL, tiers)}</Text>
       </View>
     )
   }

--- a/app/graphql/generated.gql
+++ b/app/graphql/generated.gql
@@ -1311,7 +1311,11 @@ query feeRates {
       deposit {
         minBankFee
         minBankFeeThreshold
-        ratio
+        tiers {
+          maxAmount
+          amount
+          __typename
+        }
         __typename
       }
       __typename
@@ -1604,7 +1608,11 @@ query paymentRequest {
       deposit {
         minBankFee
         minBankFeeThreshold
-        ratio
+        tiers {
+          maxAmount
+          amount
+          __typename
+        }
         __typename
       }
       __typename

--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -885,13 +885,25 @@ export type CurrencyConversionEstimation = {
   readonly usdCentAmount: Scalars['CentAmount']['output'];
 };
 
+export type DepositFeeTier = {
+  readonly __typename: 'DepositFeeTier';
+  readonly amount: Scalars['String']['output'];
+  /** highest amount this tier applies to, null when unbounded */
+  readonly maxAmount?: Maybe<Scalars['String']['output']>;
+};
+
 export type DepositFeesInformation = {
   readonly __typename: 'DepositFeesInformation';
   readonly minBankFee: Scalars['String']['output'];
   /** below this amount minBankFee will be charged */
   readonly minBankFeeThreshold: Scalars['String']['output'];
-  /** ratio to charge as basis points above minBankFeeThreshold amount */
+  /**
+   * ratio to charge as basis points above minBankFeeThreshold amount
+   * @deprecated fees are a flat amount per tier, use tiers
+   */
   readonly ratio: Scalars['String']['output'];
+  /** amount charged per tier, in ascending order of maxAmount */
+  readonly tiers: ReadonlyArray<DepositFeeTier>;
 };
 
 export type DeviceNotificationTokenCreateInput = {
@@ -3703,7 +3715,7 @@ export type LnUsdInvoiceCreateMutation = { readonly __typename: 'Mutation', read
 export type PaymentRequestQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PaymentRequestQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network, readonly feesInformation: { readonly __typename: 'FeesInformation', readonly deposit: { readonly __typename: 'DepositFeesInformation', readonly minBankFee: string, readonly minBankFeeThreshold: string, readonly ratio: string } } } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWalletId: string, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> } } | null };
+export type PaymentRequestQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly network: Network, readonly feesInformation: { readonly __typename: 'FeesInformation', readonly deposit: { readonly __typename: 'DepositFeesInformation', readonly minBankFee: string, readonly minBankFeeThreshold: string, readonly tiers: ReadonlyArray<{ readonly __typename: 'DepositFeeTier', readonly maxAmount?: string | null, readonly amount: string }> } } } | null, readonly me?: { readonly __typename: 'User', readonly id: string, readonly username?: string | null, readonly defaultAccount: { readonly __typename: 'ConsumerAccount', readonly id: string, readonly defaultWalletId: string, readonly wallets: ReadonlyArray<{ readonly __typename: 'BTCWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency } | { readonly __typename: 'UsdWallet', readonly id: string, readonly balance: number, readonly walletCurrency: WalletCurrency }> } } | null };
 
 export type MyLnUpdatesSubscriptionVariables = Exact<{ [key: string]: never; }>;
 
@@ -3915,7 +3927,7 @@ export type AccountUpdateDisplayCurrencyMutation = { readonly __typename: 'Mutat
 export type FeeRatesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FeeRatesQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly feesInformation: { readonly __typename: 'FeesInformation', readonly deposit: { readonly __typename: 'DepositFeesInformation', readonly minBankFee: string, readonly minBankFeeThreshold: string, readonly ratio: string } } } | null };
+export type FeeRatesQuery = { readonly __typename: 'Query', readonly globals?: { readonly __typename: 'Globals', readonly feesInformation: { readonly __typename: 'FeesInformation', readonly deposit: { readonly __typename: 'DepositFeesInformation', readonly minBankFee: string, readonly minBankFeeThreshold: string, readonly tiers: ReadonlyArray<{ readonly __typename: 'DepositFeeTier', readonly maxAmount?: string | null, readonly amount: string }> } } } | null };
 
 export type LanguageQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -7657,7 +7669,10 @@ export const PaymentRequestDocument = gql`
       deposit {
         minBankFee
         minBankFeeThreshold
-        ratio
+        tiers {
+          maxAmount
+          amount
+        }
       }
     }
   }
@@ -9068,7 +9083,10 @@ export const FeeRatesDocument = gql`
       deposit {
         minBankFee
         minBankFeeThreshold
-        ratio
+        tiers {
+          maxAmount
+          amount
+        }
       }
     }
   }
@@ -10076,6 +10094,7 @@ export type ResolversTypes = {
   Currency: ResolverTypeWrapper<Currency>;
   CurrencyConversionEstimation: ResolverTypeWrapper<CurrencyConversionEstimation>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  DepositFeeTier: ResolverTypeWrapper<DepositFeeTier>;
   DepositFeesInformation: ResolverTypeWrapper<DepositFeesInformation>;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: ResolverTypeWrapper<Scalars['DisplayCurrency']['output']>;
@@ -10379,6 +10398,7 @@ export type ResolversParentTypes = {
   Currency: Currency;
   CurrencyConversionEstimation: CurrencyConversionEstimation;
   DateTime: Scalars['DateTime']['output'];
+  DepositFeeTier: DepositFeeTier;
   DepositFeesInformation: DepositFeesInformation;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: Scalars['DisplayCurrency']['output'];
@@ -11017,10 +11037,17 @@ export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversT
   name: 'DateTime';
 }
 
+export type DepositFeeTierResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeeTier'] = ResolversParentTypes['DepositFeeTier']> = {
+  amount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  maxAmount?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type DepositFeesInformationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeesInformation'] = ResolversParentTypes['DepositFeesInformation']> = {
   minBankFee?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   minBankFeeThreshold?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ratio?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tiers?: Resolver<ReadonlyArray<ResolversTypes['DepositFeeTier']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -12073,6 +12100,7 @@ export type Resolvers<ContextType = any> = {
   Currency?: CurrencyResolvers<ContextType>;
   CurrencyConversionEstimation?: CurrencyConversionEstimationResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
+  DepositFeeTier?: DepositFeeTierResolvers<ContextType>;
   DepositFeesInformation?: DepositFeesInformationResolvers<ContextType>;
   DisplayCurrency?: GraphQLScalarType;
   Email?: EmailResolvers<ContextType>;

--- a/app/graphql/mocks.ts
+++ b/app/graphql/mocks.ts
@@ -437,7 +437,18 @@ const mocks = [
               __typename: "DepositFeesInformation",
               minBankFee: "2500",
               minBankFeeThreshold: "1000000",
-              ratio: "50",
+              tiers: [
+                {
+                  __typename: "DepositFeeTier",
+                  maxAmount: "1000000",
+                  amount: "2500",
+                },
+                {
+                  __typename: "DepositFeeTier",
+                  maxAmount: null,
+                  amount: "5000",
+                },
+              ],
             },
           },
         },
@@ -457,6 +468,10 @@ const mocks = [
             deposit: {
               minBankFee: "3000",
               minBankFeeThreshold: "1000000",
+              tiers: [
+                { maxAmount: "1000000", amount: "3000" },
+                { maxAmount: null, amount: "5000" },
+              ],
             },
           },
         },

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2205,6 +2205,9 @@ const en: BaseTranslation = {
     bitcoinOnchain: "Bitcoin onchain",
     depositFee:
       "Deposit fee: {fee: string} SAT for amounts under {threshold: string} SAT or {overFee: string} SAT for deposits over {threshold} SAT",
+    depositFeeTiers: "Deposit fees: {tiers: string}",
+    depositFeeTierUpTo: "{fee: string} SAT up to {max: string} SAT",
+    depositFeeTierAbove: "{fee: string} SAT above {min: string} SAT",
     autoConvertMinAmount:
       "Amounts below {minSats: number} SAT / {minFiat: string} can't be converted to Dollar automatically. You'll receive Bitcoin instead.",
     autoConvertFailed: "Payment received but the conversion failed.",
@@ -2653,6 +2656,8 @@ const en: BaseTranslation = {
     lightningTransactions: "Lightning transactions",
     onchainBelowThreshold: "Onchain below {threshold: string} SAT",
     onchainAboveThreshold: "Onchain above {threshold: string} SAT",
+    onchainBetweenThresholds:
+      "Onchain between {lower: string} and {upper: string} SAT",
     transferFee: "Transfer fee",
     noFee: "no fee",
     lightningSendFee: "{fee: string} + ~{routingFee: string} routing fee",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6866,6 +6866,23 @@ type RootTranslation = {
 		 */
 		depositFee: RequiredParams<'fee' | 'overFee' | 'threshold' | 'threshold'>
 		/**
+		 * D​e​p​o​s​i​t​ ​f​e​e​s​:​ ​{​t​i​e​r​s​}
+		 * @param {string} tiers
+		 */
+		depositFeeTiers: RequiredParams<'tiers'>
+		/**
+		 * {​f​e​e​}​ ​S​A​T​ ​u​p​ ​t​o​ ​{​m​a​x​}​ ​S​A​T
+		 * @param {string} fee
+		 * @param {string} max
+		 */
+		depositFeeTierUpTo: RequiredParams<'fee' | 'max'>
+		/**
+		 * {​f​e​e​}​ ​S​A​T​ ​a​b​o​v​e​ ​{​m​i​n​}​ ​S​A​T
+		 * @param {string} fee
+		 * @param {string} min
+		 */
+		depositFeeTierAbove: RequiredParams<'fee' | 'min'>
+		/**
 		 * A​m​o​u​n​t​s​ ​b​e​l​o​w​ ​{​m​i​n​S​a​t​s​}​ ​S​A​T​ ​/​ ​{​m​i​n​F​i​a​t​}​ ​c​a​n​'​t​ ​b​e​ ​c​o​n​v​e​r​t​e​d​ ​t​o​ ​D​o​l​l​a​r​ ​a​u​t​o​m​a​t​i​c​a​l​l​y​.​ ​Y​o​u​'​l​l​ ​r​e​c​e​i​v​e​ ​B​i​t​c​o​i​n​ ​i​n​s​t​e​a​d​.
 		 * @param {string} minFiat
 		 * @param {number} minSats
@@ -8339,6 +8356,12 @@ type RootTranslation = {
 		 * @param {string} threshold
 		 */
 		onchainAboveThreshold: RequiredParams<'threshold'>
+		/**
+		 * O​n​c​h​a​i​n​ ​b​e​t​w​e​e​n​ ​{​l​o​w​e​r​}​ ​a​n​d​ ​{​u​p​p​e​r​}​ ​S​A​T
+		 * @param {string} lower
+		 * @param {string} upper
+		 */
+		onchainBetweenThresholds: RequiredParams<'lower' | 'upper'>
 		/**
 		 * T​r​a​n​s​f​e​r​ ​f​e​e
 		 */
@@ -19814,6 +19837,18 @@ export type TranslationFunctions = {
 		 */
 		depositFee: (arg: { fee: string, overFee: string, threshold: string }) => LocalizedString
 		/**
+		 * Deposit fees: {tiers}
+		 */
+		depositFeeTiers: (arg: { tiers: string }) => LocalizedString
+		/**
+		 * {fee} SAT up to {max} SAT
+		 */
+		depositFeeTierUpTo: (arg: { fee: string, max: string }) => LocalizedString
+		/**
+		 * {fee} SAT above {min} SAT
+		 */
+		depositFeeTierAbove: (arg: { fee: string, min: string }) => LocalizedString
+		/**
 		 * Amounts below {minSats} SAT / {minFiat} can't be converted to Dollar automatically. You'll receive Bitcoin instead.
 		 */
 		autoConvertMinAmount: (arg: { minFiat: string, minSats: number }) => LocalizedString
@@ -21237,6 +21272,10 @@ export type TranslationFunctions = {
 		 * Onchain above {threshold} SAT
 		 */
 		onchainAboveThreshold: (arg: { threshold: string }) => LocalizedString
+		/**
+		 * Onchain between {lower} and {upper} SAT
+		 */
+		onchainBetweenThresholds: (arg: { lower: string, upper: string }) => LocalizedString
 		/**
 		 * Transfer fee
 		 */

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Lightning invoice",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Deposit fee: {fee: string} SAT for amounts under {threshold: string} SAT or {overFee: string} SAT for deposits over {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Amounts below {minSats: number} SAT / {minFiat: string} can't be converted to Dollar automatically. You'll receive Bitcoin instead.",
         "autoConvertFailed": "Payment received but the conversion failed.",
         "pleaseWaitForConversion": "Please wait until the conversion is done"
@@ -2559,6 +2562,7 @@
         "lightningTransactions": "Lightning transactions",
         "onchainBelowThreshold": "Onchain below {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain above {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Transfer fee",
         "noFee": "no fee",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} routing fee",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning-faktuur",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Deposito-fooi: {fee} SAT vir bedrae onder {threshold} SAT of {overFee} SAT vir deposito's oor {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Bedrae onder {minSats: number} sats / {minFiat: string} kan nie outomaties na Dollar omgeskakel word nie. Jy sal eerder Bitcoin ontvang.",
     "autoConvertFailed": "Betaling ontvang maar die omskakeling het misluk.",
     "pleaseWaitForConversion": "Wag asseblief totdat die omskakeling voltooi is"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning-transaksies",
     "onchainBelowThreshold": "Onchain onder {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain bo {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Oordragfooi",
     "noFee": "geen fooi",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} roeteringsfooi",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "فاتورة lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "رسوم الإيداع: {fee} SAT للمبالغ تحت {threshold} SAT أو {overFee} SAT للإيداعات فوق {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "لا يمكن تحويل المبالغ الأقل من {minSats: number} ساتوشي / {minFiat: string} إلى دولار تلقائيًا. ستتلقى بيتكوين بدلاً من ذلك.",
     "autoConvertFailed": "تم استلام الدفعة لكن فشل التحويل.",
     "pleaseWaitForConversion": "يرجى الانتظار حتى اكتمال التحويل"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "معاملات Lightning",
     "onchainBelowThreshold": "Onchain أقل من {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain أكثر من {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "رسوم التحويل",
     "noFee": "بدون رسوم",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} رسوم توجيه",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Factura lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Comissió de dipòsit: {fee} SAT per a imports inferiors a {threshold} SAT o {overFee} SAT per a dipòsits superiors a {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Les quantitats inferiors a {minSats: number} sats / {minFiat: string} no es poden convertir a Dòlar automàticament. Rebràs Bitcoin.",
     "autoConvertFailed": "Pagament rebut però la conversió ha fallat.",
     "pleaseWaitForConversion": "Si us plau, espera fins que la conversió s'hagi completat"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Transaccions Lightning",
     "onchainBelowThreshold": "Onchain per sota de {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain per sobre de {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Comissió de transferència",
     "noFee": "sense comissió",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} de comissió d'encaminament",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning faktura",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Poplatek za vklad: {fee} SAT pro částky pod {threshold} SAT nebo {overFee} SAT pro vklady nad {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Částky pod {minSats: number} satoshi / {minFiat: string} nelze automaticky převést na dolary. Obdržíte místo toho Bitcoin.",
     "autoConvertFailed": "Platba přijata, ale konverze selhala.",
     "pleaseWaitForConversion": "Počkejte, prosím, dokud se převod nedokončí"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning transakce",
     "onchainBelowThreshold": "Onchain pod {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain nad {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Poplatek za převod",
     "noFee": "bez poplatku",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} směrovací poplatek",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning-faktura",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Indbetalingsgebyr: {fee} SAT for beløb under {threshold} SAT eller {overFee} SAT for indbetalinger over {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Beløb under {minSats: number} sats / {minFiat: string} kan ikke automatisk konverteres til Dollar. Du modtager Bitcoin i stedet.",
     "autoConvertFailed": "Betaling modtaget, men konverteringen mislykkedes.",
     "pleaseWaitForConversion": "Vent venligst, indtil konverteringen er færdig"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning-transaktioner",
     "onchainBelowThreshold": "Onchain under {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain over {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Overførselsgebyr",
     "noFee": "intet gebyr",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} routinggebyr",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Lightning-Rechnung",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Einzahlungsgebühr: {fee} SAT für Beträge unter {threshold} SAT oder {overFee} SAT für Einzahlungen über {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Beträge unter {minSats: number} Sats / {minFiat: string} können nicht automatisch in Dollar umgewandelt werden. Du erhältst stattdessen Bitcoin.",
         "autoConvertFailed": "Zahlung empfangen, aber die Umwandlung ist fehlgeschlagen.",
         "pleaseWaitForConversion": "Bitte warte, bis die Umwandlung abgeschlossen ist"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "Lightning-Transaktionen",
         "onchainBelowThreshold": "Onchain unter {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain über {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Übertragungsgebühr",
         "noFee": "keine Gebühr",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} Routing-Gebühr",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Τιμολόγιο lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Χρέωση κατάθεσης: {fee} SAT για ποσά κάτω από {threshold} SAT ή {overFee} SAT για καταθέσεις πάνω από {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Ποσά κάτω από {minSats: number} sats / {minFiat: string} δεν μπορούν να μετατραπούν αυτόματα σε Δολάρια. Θα λάβετε Bitcoin.",
     "autoConvertFailed": "Η πληρωμή ελήφθη αλλά η μετατροπή απέτυχε.",
     "pleaseWaitForConversion": "Παρακαλούμε περιμένετε μέχρι να ολοκληρωθεί η μετατροπή"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Συναλλαγές Lightning",
     "onchainBelowThreshold": "Onchain κάτω από {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain πάνω από {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Τέλος μεταφοράς",
     "noFee": "χωρίς τέλη",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} τέλος δρομολόγησης",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Factura lightning",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Comisión de depósito: {fee} SAT para montos menores a {threshold} SAT o {overFee} SAT para depósitos mayores a {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Los montos por debajo de {minSats: number} sats / {minFiat: string} no pueden convertirse a Dólar automáticamente. Recibirás Bitcoin.",
         "autoConvertFailed": "Pago recibido pero la conversión falló.",
         "pleaseWaitForConversion": "Por favor espera hasta que la conversión se complete"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "Transacciones Lightning",
         "onchainBelowThreshold": "Onchain por debajo de {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain por encima de {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Comisión por transferencia",
         "noFee": "sin comisión",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} de comisión de enrutamiento",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Facture lightning",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Frais de dépôt : {fee} SAT pour les montants inférieurs à {threshold} SAT ou {overFee} SAT pour les dépôts supérieurs à {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Les montants inférieurs à {minSats: number} sats / {minFiat: string} ne peuvent pas être convertis en Dollar automatiquement. Vous recevrez des Bitcoins.",
         "autoConvertFailed": "Paiement reçu mais la conversion a échoué.",
         "pleaseWaitForConversion": "Veuillez patienter jusqu'à ce que la conversion soit terminée"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "Transactions Lightning",
         "onchainBelowThreshold": "Onchain en dessous de {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain au-dessus de {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Frais de transfert",
         "noFee": "aucuns frais",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} de frais de routage",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning račun",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Naknada za polog: {fee} SAT za iznose ispod {threshold} SAT ili {overFee} SAT za pologe iznad {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Iznosi manji od {minSats: number} satoshija / {minFiat: string} ne mogu se automatski pretvoriti u Dolare. Primit ćete Bitcoin.",
     "autoConvertFailed": "Uplata primljena, ali konverzija nije uspjela.",
     "pleaseWaitForConversion": "Pričekajte dok se konverzija ne dovrši"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning transakcije",
     "onchainBelowThreshold": "Onchain ispod {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain iznad {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Naknada za prijenos",
     "noFee": "bez naknade",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} naknada za usmjeravanje",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning számla",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Befizetési díj: {fee} SAT az {threshold} SAT alatti összegekre vagy {overFee} SAT az {threshold} SAT feletti befizetésekre",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "A {minSats: number} satoshi / {minFiat: string} alatti összegek nem konvertálhatók automatikusan Dollárra. Bitcoint fogsz kapni helyette.",
     "autoConvertFailed": "Fizetés beérkezett, de a konverzió nem sikerült.",
     "pleaseWaitForConversion": "Kérjük, várjon, amíg a konverzió befejeződik"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning tranzakciók",
     "onchainBelowThreshold": "Onchain {threshold: string} SAT alatt",
     "onchainAboveThreshold": "Onchain {threshold: string} SAT felett",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Átutalási díj",
     "noFee": "díjmentes",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} útválasztási díj",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "lightning վճարման հարցում",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Ավանդի վճար: {fee} SAT մինչև {threshold} SAT գումարների համար կամ {overFee} SAT {threshold} SAT-ից բարձր ավանդների համար",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "{minSats: number} սաթ / {minFiat: string}-ից պակաս գումարները չեն կարող ավտոմատ կերպով փոխարկվել Դոլարի։ Դուք կստանաք Bitcoin։",
     "autoConvertFailed": "Վճարումը ստացվեց, սակայն փոխարկումը չհաջողվեց։",
     "pleaseWaitForConversion": "Խնդրում ենք սպասել, մինչև փոխարկումն ավարտվի"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning գործարքներ",
     "onchainBelowThreshold": "Onchain {threshold: string} SAT-ից ցածր",
     "onchainAboveThreshold": "Onchain {threshold: string} SAT-ից բարձր",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Փոխանցման վճար",
     "noFee": "առանց վճարի",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} երթուղավորման վճար",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Faktur lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Biaya deposit: {fee} SAT untuk jumlah di bawah {threshold} SAT atau {overFee} SAT untuk deposit di atas {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Jumlah di bawah {minSats: number} sats / {minFiat: string} tidak dapat dikonversi ke Dolar secara otomatis. Anda akan menerima Bitcoin.",
     "autoConvertFailed": "Pembayaran diterima tetapi konversi gagal.",
     "pleaseWaitForConversion": "Mohon tunggu sampai konversi selesai"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Transaksi Lightning",
     "onchainBelowThreshold": "Onchain di bawah {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain di atas {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Biaya transfer",
     "noFee": "tanpa biaya",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} biaya routing",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Fattura lightning",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Commissione di deposito: {fee} SAT per importi inferiori a {threshold} SAT o {overFee} SAT per depositi superiori a {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Gli importi inferiori a {minSats: number} sats / {minFiat: string} non possono essere convertiti in Dollari automaticamente. Riceverai Bitcoin.",
         "autoConvertFailed": "Pagamento ricevuto ma la conversione è fallita.",
         "pleaseWaitForConversion": "Attendi finché la conversione non è completata"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "Transazioni Lightning",
         "onchainBelowThreshold": "Onchain sotto {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain sopra {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Commissione di trasferimento",
         "noFee": "nessuna commissione",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} di commissione di routing",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Lightningインボイス",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "入金手数料：{threshold} SAT未満は{fee} SAT、{threshold} SAT以上の入金は{overFee} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "{minSats: number} sats / {minFiat: string}未満の金額はドルに自動変換できません。代わりにビットコインを受け取ります。",
         "autoConvertFailed": "支払いは受け取りましたが、変換に失敗しました。",
         "pleaseWaitForConversion": "変換が完了するまでお待ちください"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "ライトニング取引",
         "onchainBelowThreshold": "オンチェーン {threshold: string} SAT未満",
         "onchainAboveThreshold": "オンチェーン {threshold: string} SAT超",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "振替手数料",
         "noFee": "手数料なし",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} ルーティング手数料",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Invoisi ya lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Ssente z'okuteekawo: {fee} SAT ku muwendo gw'okuwandiika {threshold} SAT oba {overFee} SAT ku biteekawo ebisukka {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Omuwendo ogutasukka mu {minSats: number} sats / {minFiat: string} tegusobola kukyusibwa mu Doola nga byekka. Ojja kufuna Bitcoin.",
     "autoConvertFailed": "Okusasula kutuuse naye okukyusa kulemye.",
     "pleaseWaitForConversion": "Lindako okutuusa ng'okukyusa kuwedde"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Emirimu gya Lightning",
     "onchainBelowThreshold": "Onchain wansi wa {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain waggulu wa {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Ekisale ky'okuweereza",
     "noFee": "tewali kisale",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} ekisale ky'okutambuza",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Invois lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Yuran deposit: {fee} SAT untuk jumlah di bawah {threshold} SAT atau {overFee} SAT untuk deposit melebihi {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Jumlah di bawah {minSats: number} sats / {minFiat: string} tidak boleh ditukar kepada Dolar secara automatik. Anda akan menerima Bitcoin.",
     "autoConvertFailed": "Pembayaran diterima tetapi penukaran gagal.",
     "pleaseWaitForConversion": "Sila tunggu sehingga penukaran selesai"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Transaksi Lightning",
     "onchainBelowThreshold": "Onchain bawah {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain atas {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Caj pindahan",
     "noFee": "tiada caj",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} caj penghalaan",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning-factuur",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Stortingskosten: {fee} SAT voor bedragen onder {threshold} SAT of {overFee} SAT voor stortingen boven {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Bedragen onder {minSats: number} sats / {minFiat: string} kunnen niet automatisch worden omgezet naar Dollar. Je ontvangt Bitcoin in plaats daarvan.",
     "autoConvertFailed": "Betaling ontvangen maar de conversie is mislukt.",
     "pleaseWaitForConversion": "Wacht tot de omzetting is voltooid"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning-transacties",
     "onchainBelowThreshold": "Onchain onder {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain boven {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Overschrijvingskosten",
     "noFee": "geen kosten",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} routeringskosten",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2163,6 +2163,9 @@
         "lightningInvoice": "Fatura lightning",
         "bitcoinOnchain": "Bitcoin onchain",
         "depositFee": "Taxa de depósito: {fee} SAT para valores abaixo de {threshold} SAT ou {overFee} SAT para depósitos acima de {threshold} SAT",
+        "depositFeeTiers": "Deposit fees: {tiers: string}",
+        "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+        "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
         "autoConvertMinAmount": "Valores abaixo de {minSats: number} sats / {minFiat: string} não podem ser convertidos em Dólar automaticamente. Você receberá Bitcoin.",
         "autoConvertFailed": "Pagamento recebido mas a conversão falhou.",
         "pleaseWaitForConversion": "Por favor aguarde até que a conversão seja concluída"
@@ -2546,6 +2549,7 @@
         "lightningTransactions": "Transações Lightning",
         "onchainBelowThreshold": "Onchain abaixo de {threshold: string} SAT",
         "onchainAboveThreshold": "Onchain acima de {threshold: string} SAT",
+        "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
         "transferFee": "Taxa de transferência",
         "noFee": "sem taxa",
         "lightningSendFee": "{fee: string} + ~{routingFee: string} de taxa de roteamento",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning invoice",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Waqaychay qullqi: {fee} SAT {threshold} SAT uray kaqkunapaq utaq {overFee} SAT {threshold} SAT hawapi waqaychaykunapaq",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "{minSats: number} sats / {minFiat: string} manta pisi kaqkunaqa mana automatikumantachu Dólarman tikrasqa kanman. Bitcointa chaskinki.",
     "autoConvertFailed": "Qullqi chaskikun ichaqa tikrachiymi mana allintachu ruwakurqan.",
     "pleaseWaitForConversion": "Ama hina kaspa, tikrachiy tukukunankama suyay"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning ruraykuna",
     "onchainBelowThreshold": "Onchain {threshold: string} SAT uraypi",
     "onchainAboveThreshold": "Onchain {threshold: string} SAT hawapi",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Astaypa chanin",
     "noFee": "mana chaniyuq",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} purichiy chanin",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Factură lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Taxă de depunere: {fee} SAT pentru sume sub {threshold} SAT sau {overFee} SAT pentru depuneri peste {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Sumele sub {minSats: number} sats / {minFiat: string} nu pot fi convertite automat în Dolari. Veți primi Bitcoin în schimb.",
     "autoConvertFailed": "Plata primită, dar conversia a eșuat.",
     "pleaseWaitForConversion": "Vă rugăm să așteptați până când conversia este finalizată"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Tranzacții Lightning",
     "onchainBelowThreshold": "Onchain sub {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain peste {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Taxă de transfer",
     "noFee": "fără taxă",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} taxă de rutare",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning faktúra",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Poplatok za vklad: {fee} SAT pre sumy pod {threshold} SAT alebo {overFee} SAT pre vklady nad {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Sumy pod {minSats: number} satoshi / {minFiat: string} nemožno automaticky previesť na Doláre. Namiesto toho dostanete Bitcoin.",
     "autoConvertFailed": "Platba prijatá, ale konverzia zlyhala.",
     "pleaseWaitForConversion": "Počkajte, prosím, kým sa prevod nedokončí"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning transakcie",
     "onchainBelowThreshold": "Onchain pod {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain nad {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Poplatok za prevod",
     "noFee": "bez poplatku",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} smerovací poplatok",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning faktura",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Накнада за депозит: {fee} SAT за износе испод {threshold} SAT или {overFee} SAT за депозите преко {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Износи мањи од {minSats: number} сатошија / {minFiat: string} не могу се аутоматски конвертовати у Доларе. Добићете Биткоин уместо тога.",
     "autoConvertFailed": "Уплата примљена, али конверзија није успела.",
     "pleaseWaitForConversion": "Сачекајте док се конверзија не заврши"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning трансакције",
     "onchainBelowThreshold": "Onchain испод {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain изнад {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Накнада за пренос",
     "noFee": "без накнаде",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} накнада за рутирање",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Ankara ya lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Ada ya amana: {fee} SAT kwa kiasi chini ya {threshold} SAT au {overFee} SAT kwa amana zaidi ya {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Viwango vilivyo chini ya sats {minSats: number} / {minFiat: string} haviwezi kubadilishwa kwa Dola kiotomatiki. Utapokea Bitcoin badala yake.",
     "autoConvertFailed": "Malipo yamepokelewa lakini ubadilishaji umeshindwa.",
     "pleaseWaitForConversion": "Tafadhali subiri hadi ubadilishaji ukamilike"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Miamala ya Lightning",
     "onchainBelowThreshold": "Onchain chini ya {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain zaidi ya {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Ada ya uhamisho",
     "noFee": "hakuna ada",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} ada ya uelekezaji",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "ใบแจ้งหนี้ lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "ค่าธรรมเนียมการฝาก: {fee} SAT สำหรับจำนวนต่ำกว่า {threshold} SAT หรือ {overFee} SAT สำหรับการฝากมากกว่า {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "จำนวนต่ำกว่า {minSats: number} satoshi / {minFiat: string} ไม่สามารถแปลงเป็นดอลลาร์อัตโนมัติได้ คุณจะได้รับ Bitcoin แทน",
     "autoConvertFailed": "รับการชำระเงินแล้ว แต่การแปลงล้มเหลว",
     "pleaseWaitForConversion": "โปรดรอจนกว่าการแปลงจะเสร็จสิ้น"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "ธุรกรรม Lightning",
     "onchainBelowThreshold": "Onchain ต่ำกว่า {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain มากกว่า {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "ค่าธรรมเนียมการโอน",
     "noFee": "ไม่มีค่าธรรมเนียม",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} ค่าธรรมเนียมการกำหนดเส้นทาง",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Lightning faturası",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Yatırma ücreti: {threshold} SAT altındaki tutarlar için {fee} SAT veya {threshold} SAT üzerindeki yatırmalar için {overFee} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "{minSats: number} sats / {minFiat: string} altındaki tutarlar otomatik olarak Dolara çevrilemez. Bunun yerine Bitcoin alacaksınız.",
     "autoConvertFailed": "Ödeme alındı ancak dönüşüm başarısız oldu.",
     "pleaseWaitForConversion": "Lütfen dönüştürme tamamlanana kadar bekleyin"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Lightning işlemleri",
     "onchainBelowThreshold": "Onchain {threshold: string} SAT altı",
     "onchainAboveThreshold": "Onchain {threshold: string} SAT üzeri",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Transfer ücreti",
     "noFee": "ücretsiz",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} yönlendirme ücreti",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "Hóa đơn lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Phí nạp tiền: {fee} SAT cho số tiền dưới {threshold} SAT hoặc {overFee} SAT cho các khoản nạp trên {threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Số tiền dưới {minSats: number} sats / {minFiat: string} không thể chuyển đổi tự động sang Đô la. Bạn sẽ nhận Bitcoin thay thế.",
     "autoConvertFailed": "Đã nhận thanh toán nhưng chuyển đổi thất bại.",
     "pleaseWaitForConversion": "Vui lòng đợi cho đến khi quá trình chuyển đổi hoàn tất"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Giao dịch Lightning",
     "onchainBelowThreshold": "Onchain dưới {threshold: string} SAT",
     "onchainAboveThreshold": "Onchain trên {threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Phí chuyển khoản",
     "noFee": "miễn phí",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} phí định tuyến",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2163,6 +2163,9 @@
     "lightningInvoice": "I-invoyisi ye-lightning",
     "bitcoinOnchain": "Bitcoin onchain",
     "depositFee": "Imali yokufaka: {fee} SAT kwimali engaphantsi kwe-{threshold} SAT okanye {overFee} SAT kwimali efakwe engaphezulu kwe-{threshold} SAT",
+    "depositFeeTiers": "Deposit fees: {tiers: string}",
+    "depositFeeTierUpTo": "{fee: string} SAT up to {max: string} SAT",
+    "depositFeeTierAbove": "{fee: string} SAT above {min: string} SAT",
     "autoConvertMinAmount": "Amaxabiso angaphantsi kwe-{minSats: number} sats / {minFiat: string} awanakho ukuguqulelwa ngokuzenzekelayo kwi-Dollar. Uya kufumana i-Bitcoin endaweni yoko.",
     "autoConvertFailed": "Intlawulo ifumenekile kodwa ukuguqulwa kusilele.",
     "pleaseWaitForConversion": "Nceda linda de ukuguqulwa kugqitywe"
@@ -2546,6 +2549,7 @@
     "lightningTransactions": "Iintengiselwano ze-Lightning",
     "onchainBelowThreshold": "I-Onchain ngaphantsi kwe-{threshold: string} SAT",
     "onchainAboveThreshold": "I-Onchain ngaphezulu kwe-{threshold: string} SAT",
+    "onchainBetweenThresholds": "Onchain between {lower: string} and {upper: string} SAT",
     "transferFee": "Umrhumo wokudlulisela",
     "noFee": "akukho mrhumo",
     "lightningSendFee": "{fee: string} + ~{routingFee: string} umrhumo wokuthumela",

--- a/app/screens/receive-bitcoin-screen/hooks/use-wallet-resolution.ts
+++ b/app/screens/receive-bitcoin-screen/hooks/use-wallet-resolution.ts
@@ -19,7 +19,10 @@ gql`
         deposit {
           minBankFee
           minBankFeeThreshold
-          ratio
+          tiers {
+            maxAmount
+            amount
+          }
         }
       }
     }

--- a/app/screens/settings-screen/fee-rates-screen.tsx
+++ b/app/screens/settings-screen/fee-rates-screen.tsx
@@ -6,7 +6,8 @@ import { Screen } from "@app/components/screen"
 import { useRemoteConfig } from "@app/config/feature-flags-context"
 import { useFeeRatesQuery } from "@app/graphql/generated"
 import { useI18nContext } from "@app/i18n/i18n-react"
-import { formatDepositFees } from "@app/utils/deposit-fees"
+import { TranslationFunctions } from "@app/i18n/i18n-types"
+import { formatDepositFeeTiers } from "@app/utils/deposit-fees"
 import { makeStyles, Text, useTheme } from "@rn-vui/themed"
 
 import { SettingsGroup } from "./group"
@@ -30,6 +31,25 @@ gql`
 
 const formatBps = (bps: number): string =>
   `${(bps / 100).toLocaleString("en-US", { maximumFractionDigits: 2 })}%`
+
+// A tier is bounded below by the previous tier's ceiling and above by its own;
+// the first tier has no lower bound and the last has no upper one.
+const depositTierLabel = (
+  LL: TranslationFunctions,
+  minAmount: string | null,
+  maxAmount: string | null,
+): string => {
+  if (maxAmount === null) {
+    return LL.FeeRatesScreen.onchainAboveThreshold({ threshold: minAmount ?? "0" })
+  }
+  if (minAmount === null) {
+    return LL.FeeRatesScreen.onchainBelowThreshold({ threshold: maxAmount })
+  }
+  return LL.FeeRatesScreen.onchainBetweenThresholds({
+    lower: minAmount,
+    upper: maxAmount,
+  })
+}
 
 // Remote-config contract: a negative rate hides its row (and the section when
 // no rows remain), 0 renders as "no fee", positive values render the rate.
@@ -185,25 +205,16 @@ export const FeeRatesScreen: React.FC = () => {
       },
     ]
     if (deposit) {
-      const { fee, threshold, overFee } = formatDepositFees(deposit)
-      items.push(
-        function OnchainBelowRow() {
+      // One row per tier, so a tier added server-side shows up on its own
+      // instead of being folded into a neighbour's range.
+      formatDepositFeeTiers(deposit).forEach(({ amount, minAmount, maxAmount }) => {
+        const label = depositTierLabel(LL, minAmount, maxAmount)
+        items.push(function OnchainTierRow() {
           return (
-            <FeeRateRow
-              label={LL.FeeRatesScreen.onchainBelowThreshold({ threshold })}
-              value={LL.FeeRatesScreen.satAmount({ amount: fee })}
-            />
+            <FeeRateRow label={label} value={LL.FeeRatesScreen.satAmount({ amount })} />
           )
-        },
-        function OnchainAboveRow() {
-          return (
-            <FeeRateRow
-              label={LL.FeeRatesScreen.onchainAboveThreshold({ threshold })}
-              value={LL.FeeRatesScreen.satAmount({ amount: overFee })}
-            />
-          )
-        },
-      )
+        })
+      })
     } else if (loading) {
       // Wrapped so SettingsGroup's `x({})` filter call creates the element
       // without executing LoadingRow's hooks in the group's render.

--- a/app/screens/settings-screen/fee-rates-screen.tsx
+++ b/app/screens/settings-screen/fee-rates-screen.tsx
@@ -18,7 +18,10 @@ gql`
         deposit {
           minBankFee
           minBankFeeThreshold
-          ratio
+          tiers {
+            maxAmount
+            amount
+          }
         }
       }
     }

--- a/app/self-custodial/hooks/types.ts
+++ b/app/self-custodial/hooks/types.ts
@@ -5,6 +5,7 @@ import {
   PaymentRequestStateType,
 } from "@app/screens/receive-bitcoin-screen/payment/index.types"
 import { MoneyAmount, WalletOrDisplayCurrency } from "@app/types/amounts"
+import { DepositFeesInformation } from "@app/utils/deposit-fees"
 
 type UriParams = { uppercase?: boolean; prefix?: boolean }
 
@@ -44,15 +45,7 @@ export type SelfCustodialPaymentRequestState = {
   btcWalletId?: string
   usdWalletId?: string
   lnAddressHostname: string
-  feesInformation:
-    | {
-        deposit: {
-          minBankFee: string
-          minBankFeeThreshold: string
-          ratio: string
-        }
-      }
-    | undefined
+  feesInformation: { deposit: DepositFeesInformation } | undefined
   info?: { data?: InvoiceData }
   onchainAddress?: string
   getOnchainFullUriFn?: (params: UriParams) => string

--- a/app/utils/deposit-fees.ts
+++ b/app/utils/deposit-fees.ts
@@ -2,10 +2,15 @@ const DEFAULT_MIN_BANK_FEE = 2500
 const DEFAULT_THRESHOLD = 1_000_000
 const DEFAULT_OVER_FEE = 5000
 
+export type DepositFeeTier = {
+  maxAmount?: string | null
+  amount: string
+}
+
 export type DepositFeesInformation = {
   minBankFee: string
   minBankFeeThreshold: string
-  ratio: string
+  tiers?: readonly DepositFeeTier[] | null
 }
 
 export type FormattedDepositFees = {
@@ -16,9 +21,10 @@ export type FormattedDepositFees = {
 
 /**
  * Derives the displayed onchain deposit fees from `globals.feesInformation`.
- * `ratio` is in basis points; every field falls back to its default only when
- * the API value is not numeric — a zero ratio is a legitimate "no fee" and is
- * kept as 0.
+ * Fees are a flat amount per tier; the tier with no `maxAmount` is the
+ * unbounded one charged above the threshold. Every field falls back to its
+ * default only when the API value is not numeric — a zero amount is a
+ * legitimate "no fee" and is kept as 0.
  */
 export const formatDepositFees = (
   deposit: DepositFeesInformation,
@@ -31,11 +37,10 @@ export const formatDepositFees = (
   const threshold = new Intl.NumberFormat("en-US", { notation: "compact" }).format(
     Number.isFinite(parsedThreshold) ? parsedThreshold : DEFAULT_THRESHOLD,
   )
-  const computedOverFee = Math.round(
-    (Number(deposit.minBankFeeThreshold) * Number(deposit.ratio)) / 10000,
-  )
+  const unboundedTier = deposit.tiers?.find((tier) => !tier.maxAmount)
+  const parsedOverFee = Number(unboundedTier?.amount)
   const overFee = (
-    Number.isFinite(computedOverFee) ? computedOverFee : DEFAULT_OVER_FEE
+    Number.isFinite(parsedOverFee) ? parsedOverFee : DEFAULT_OVER_FEE
   ).toLocaleString("en-US")
   return { fee, threshold, overFee }
 }

--- a/app/utils/deposit-fees.ts
+++ b/app/utils/deposit-fees.ts
@@ -10,37 +10,77 @@ export type DepositFeeTier = {
 export type DepositFeesInformation = {
   minBankFee: string
   minBankFeeThreshold: string
-  tiers?: readonly DepositFeeTier[] | null
+  tiers: readonly DepositFeeTier[]
 }
 
-export type FormattedDepositFees = {
-  fee: string
-  threshold: string
-  overFee: string
+export type FormattedDepositFeeTier = {
+  /** Flat fee charged in this tier, e.g. "2,500". */
+  amount: string
+  /** Compact lower bound, e.g. "1M". Null on the first tier. */
+  minAmount: string | null
+  /** Compact upper bound, e.g. "1M". Null on the unbounded tier. */
+  maxAmount: string | null
+}
+
+type ParsedTier = {
+  amount: number
+  maxAmount: number | null
+}
+
+const toNumber = (value?: string | null): number | null => {
+  if (value === null || value === undefined || value.trim() === "") return null
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const compact = (value: number): string =>
+  new Intl.NumberFormat("en-US", { notation: "compact" }).format(value)
+
+/**
+ * The shape the API exposed before flat per-tier fees: `minBankFee` up to
+ * `minBankFeeThreshold`, a default above it. Only reached when `tiers` is
+ * empty or unusable, so the screens never render a bare "no fee".
+ */
+const fallbackTiers = (deposit: DepositFeesInformation): ParsedTier[] => [
+  {
+    amount: toNumber(deposit.minBankFee) ?? DEFAULT_MIN_BANK_FEE,
+    maxAmount: toNumber(deposit.minBankFeeThreshold) ?? DEFAULT_THRESHOLD,
+  },
+  { amount: DEFAULT_OVER_FEE, maxAmount: null },
+]
+
+const parseTiers = (deposit: DepositFeesInformation): ParsedTier[] => {
+  const parsed = deposit.tiers
+    .map((tier) => ({
+      amount: toNumber(tier.amount),
+      maxAmount: toNumber(tier.maxAmount),
+    }))
+    .filter((tier): tier is ParsedTier => tier.amount !== null)
+    // The API sorts ascending with the unbounded tier last; sorting here keeps
+    // the rendered bounds coherent even if that ever stops holding.
+    .sort((a, b) => (a.maxAmount ?? Infinity) - (b.maxAmount ?? Infinity))
+
+  return parsed.length > 0 ? parsed : fallbackTiers(deposit)
 }
 
 /**
  * Derives the displayed onchain deposit fees from `globals.feesInformation`.
  * Fees are a flat amount per tier; the tier with no `maxAmount` is the
- * unbounded one charged above the threshold. Every field falls back to its
- * default only when the API value is not numeric — a zero amount is a
- * legitimate "no fee" and is kept as 0.
+ * unbounded one. Both bounds of a tier come from the tier list itself, so a
+ * label can never disagree with the amount beside it, and a zero amount stays
+ * a legitimate "no fee" rather than being treated as missing.
  */
-export const formatDepositFees = (
+export const formatDepositFeeTiers = (
   deposit: DepositFeesInformation,
-): FormattedDepositFees => {
-  const parsedFee = Number(deposit.minBankFee)
-  const fee = (
-    Number.isFinite(parsedFee) ? parsedFee : DEFAULT_MIN_BANK_FEE
-  ).toLocaleString("en-US")
-  const parsedThreshold = Number(deposit.minBankFeeThreshold)
-  const threshold = new Intl.NumberFormat("en-US", { notation: "compact" }).format(
-    Number.isFinite(parsedThreshold) ? parsedThreshold : DEFAULT_THRESHOLD,
-  )
-  const unboundedTier = deposit.tiers?.find((tier) => !tier.maxAmount)
-  const parsedOverFee = Number(unboundedTier?.amount)
-  const overFee = (
-    Number.isFinite(parsedOverFee) ? parsedOverFee : DEFAULT_OVER_FEE
-  ).toLocaleString("en-US")
-  return { fee, threshold, overFee }
+): FormattedDepositFeeTier[] => {
+  const tiers = parseTiers(deposit)
+
+  return tiers.map((tier, index) => {
+    const previousMax = index > 0 ? tiers[index - 1].maxAmount : null
+    return {
+      amount: tier.amount.toLocaleString("en-US"),
+      minAmount: previousMax === null ? null : compact(previousMax),
+      maxAmount: tier.maxAmount === null ? null : compact(tier.maxAmount),
+    }
+  })
 }


### PR DESCRIPTION
Fixes blinkbitcoin/blink-wip#1013

## Problem

The receive screen and the Fee Rates settings page derived the above-threshold onchain deposit fee from `globals.feesInformation.deposit.ratio` — basis points applied to `minBankFeeThreshold`. Onchain receive fees moved to flat-per-tier pricing, so the server has hardcoded `ratio: "0"` ever since, and both surfaces rendered **0 sats** while deposits over 1M sats are actually charged **5,000 sats** (blink-deployments#8918, 2026-01-13).

## Fix

blinkbitcoin/blink#717 deprecated `ratio` and added `tiers` to `feesInformation.deposit`. Both queries now select `tiers` instead, and `formatDepositFees` takes the over-threshold fee from the unbounded tier (the one with no `maxAmount`) rather than doing the basis-point math. `minBankFee` / `minBankFeeThreshold` are unchanged and still drive the below-threshold amount and the "1M" threshold text, so no copy and no translations change.

The unbounded tier is found by predicate rather than by position, and the existing 5,000 default remains the fallback when it is missing or non-numeric.

## Verification

- `deposit-fees.spec.ts` rewritten: staging-shaped tiers now yield `overFee: "5,000"` (the regression), plus unbounded-tier-anywhere, zero amount, missing tiers, and non-numeric fallbacks.
- Affected suites pass: `deposit-fees`, `contextual-info`, `fee-rates-screen`, `receive`, `use-wallet-resolution`, `self-custodial/use-payment-request` — 125 tests.
- `yarn tsc:check`, `yarn eslint` on changed files, and `yarn graphql-check` all clean. The remaining "1 document with deprecated fields" notice is pre-existing on `main` and unrelated.

## ⚠️ Draft — blocked on a prod deploy

`tiers` is live on staging but **not yet on prod** (verified today):

    curl -s https://api.blink.sv/graphql -H 'Content-Type: application/json' \
      -d '{"query":"{ globals { feesInformation { deposit { tiers { maxAmount amount } } } } }"}'

Requesting an unknown field fails the entire `paymentRequest` query, and `use-wallet-resolution.ts` returns `null` in that case — the receive screen would render blank for everyone. CI cannot catch this, since codegen and `graphql-check` both run against staging. Re-run the curl above and confirm it returns tier data before marking this ready.