### PR TITLE
feat(settings): open the terminal in the user's display currency

### DIFF
--- a/__tests__/screens/settings-screen/settings/pay-link-rows.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/pay-link-rows.spec.tsx
@@ -192,7 +192,9 @@ describe("ways to get paid rows", () => {
       expect(lastRowProps().loading).toBe(true)
     })
 
-    it("does not gate the rows that carry no currency", () => {
+    // A guard against the gate spreading: the printable QR link has no currency in it,
+    // so it has no reason to wait for one.
+    it("leaves the printable QR row tappable meanwhile", () => {
       mockUseEffectiveDisplayCurrency.mockReturnValue({
         displayCurrency: "USD",
         loading: true,

--- a/__tests__/screens/settings-screen/settings/pay-link-rows.spec.tsx
+++ b/__tests__/screens/settings-screen/settings/pay-link-rows.spec.tsx
@@ -34,6 +34,11 @@ jest.mock("@app/graphql/generated", () => ({
   useSettingsScreenQuery: () => mockSettingsScreenQuery(),
 }))
 
+const mockUseEffectiveDisplayCurrency = jest.fn()
+jest.mock("@app/hooks/use-effective-display-currency", () => ({
+  useEffectiveDisplayCurrency: () => mockUseEffectiveDisplayCurrency(),
+}))
+
 jest.mock("@rn-vui/themed", () => ({
   useTheme: () => ({ theme: { colors: { primary: "#fc5805", black: "#000" } } }),
 }))
@@ -90,6 +95,10 @@ describe("ways to get paid rows", () => {
     jest.spyOn(Linking, "openURL").mockResolvedValue(true)
     mockSettingsScreenQuery.mockReturnValue({ data: undefined, loading: false })
     mockUseSelfCustodialWallet.mockReturnValue({ lightningAddress: null })
+    mockUseEffectiveDisplayCurrency.mockReturnValue({
+      displayCurrency: "EUR",
+      loading: false,
+    })
   })
 
   // The POS and its printable QR are served by the terminal for custodial accounts
@@ -100,7 +109,9 @@ describe("ways to get paid rows", () => {
     it("POS", () => {
       render(<AccountPOS />)
       pressRow()
-      expect(Linking.openURL).toHaveBeenCalledWith("https://terminal.blinkbtc.com/bob")
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        "https://terminal.blinkbtc.com/bob?display=EUR",
+      )
     })
 
     it("printable QR", () => {
@@ -124,7 +135,9 @@ describe("ways to get paid rows", () => {
     it("POS", () => {
       render(<AccountPOS />)
       pressRow()
-      expect(Linking.openURL).toHaveBeenCalledWith("https://terminal.blinkbtc.com/alice")
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        "https://terminal.blinkbtc.com/alice?display=EUR",
+      )
     })
 
     it("printable QR", () => {
@@ -159,6 +172,35 @@ describe("ways to get paid rows", () => {
       )
 
       expect(mockSettingsRow).not.toHaveBeenCalled()
+    })
+  })
+
+  // The terminal defaults to USD, so the POS link carries the display currency the
+  // merchant already picked in the app. Until it is known the row stays in its
+  // loading state rather than opening a link built from the USD fallback.
+  describe("the POS link waits for the display currency", () => {
+    beforeEach(asCustodial)
+
+    it("keeps the row loading while the currency is resolving", () => {
+      mockUseEffectiveDisplayCurrency.mockReturnValue({
+        displayCurrency: "USD",
+        loading: true,
+      })
+
+      render(<AccountPOS />)
+
+      expect(lastRowProps().loading).toBe(true)
+    })
+
+    it("does not gate the rows that carry no currency", () => {
+      mockUseEffectiveDisplayCurrency.mockReturnValue({
+        displayCurrency: "USD",
+        loading: true,
+      })
+
+      render(<AccountStaticQR />)
+
+      expect(lastRowProps().loading).toBe(false)
     })
   })
 

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -18,7 +18,10 @@ jest.mock("@app/graphql/generated", () => ({
   useLanguageQuery: (opts: unknown) => mockUseLanguageQuery(opts),
   useUserUpdateLanguageMutation: () => [jest.fn(), { loading: false }],
   useExportCsvSettingLazyQuery: () => [jest.fn(), { loading: false }],
-  // AccountPOS reads the display currency to build its terminal link.
+  // AccountPOS reads the display currency to build its terminal link. That query is
+  // the one exception to the skip rule this suite guards: use-effective-display-currency
+  // keeps it unauthed-safe with fetchPolicy "cache-only" instead of skip, so it never
+  // reaches the network for a logged-out user either.
   useDisplayCurrencyQuery: () => ({ data: undefined, loading: false }),
   useAccountUpdateDisplayCurrencyMutation: () => [jest.fn(), { loading: false }],
 }))

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -18,6 +18,9 @@ jest.mock("@app/graphql/generated", () => ({
   useLanguageQuery: (opts: unknown) => mockUseLanguageQuery(opts),
   useUserUpdateLanguageMutation: () => [jest.fn(), { loading: false }],
   useExportCsvSettingLazyQuery: () => [jest.fn(), { loading: false }],
+  // AccountPOS reads the display currency to build its terminal link.
+  useDisplayCurrencyQuery: () => ({ data: undefined, loading: false }),
+  useAccountUpdateDisplayCurrencyMutation: () => [jest.fn(), { loading: false }],
 }))
 
 jest.mock("@react-navigation/native", () => ({

--- a/__tests__/utils/pay-links.spec.ts
+++ b/__tests__/utils/pay-links.spec.ts
@@ -10,6 +10,23 @@ describe("getPosUrl", () => {
   it("appends the address to the terminal host", () => {
     expect(getPosUrl("alice")).toBe("https://terminal.blinkbtc.com/alice")
   })
+
+  it("passes the display currency to the terminal", () => {
+    expect(getPosUrl("alice", "EUR")).toBe(
+      "https://terminal.blinkbtc.com/alice?display=EUR",
+    )
+  })
+
+  it("omits the query string when no currency is known", () => {
+    expect(getPosUrl("alice", "")).toBe("https://terminal.blinkbtc.com/alice")
+    expect(getPosUrl("alice", undefined)).toBe("https://terminal.blinkbtc.com/alice")
+  })
+
+  it("does not let a currency append another parameter", () => {
+    expect(getPosUrl("alice", "EU R&amount=1")).toBe(
+      "https://terminal.blinkbtc.com/alice?display=EU%20R%26amount%3D1",
+    )
+  })
 })
 
 describe("getPrintableQrCodeUrl", () => {

--- a/app/screens/settings-screen/settings/account-pos.tsx
+++ b/app/screens/settings-screen/settings/account-pos.tsx
@@ -16,8 +16,17 @@ export const AccountPOS: React.FC = () => {
   } = useTheme()
   const { LL } = useI18nContext()
   const { username, loading } = usePayLinks()
-  // Waiting on the currency keeps the row from opening a link built from the USD
-  // fallback the hook returns while the custodial query is still in flight.
+  /**
+   * Only the currency is read here; the setter the hook also returns belongs to the
+   * display currency screen. Its query is cache-only until the account is authed, so
+   * this row adds no request for a logged-out user even though it does not skip.
+   *
+   * Waiting on it keeps the row from opening a link built from the USD the hook
+   * answers with while the custodial query is still in flight. The cost is that a
+   * merchant whose cache is cold and whose network is hanging sees the row as a
+   * skeleton for as long as the query does not settle; opening someone's cash
+   * register in the wrong currency is the worse of the two.
+   */
   const { displayCurrency, loading: displayCurrencyLoading } =
     useEffectiveDisplayCurrency()
 

--- a/app/screens/settings-screen/settings/account-pos.tsx
+++ b/app/screens/settings-screen/settings/account-pos.tsx
@@ -3,6 +3,7 @@ import { Linking } from "react-native"
 import { useTheme } from "@rn-vui/themed"
 
 import { GaloyIcon } from "@app/components/atomic/galoy-icon"
+import { useEffectiveDisplayCurrency } from "@app/hooks/use-effective-display-currency"
 import { useI18nContext } from "@app/i18n/i18n-react"
 import { getPosUrl } from "@app/utils/pay-links"
 
@@ -15,14 +16,18 @@ export const AccountPOS: React.FC = () => {
   } = useTheme()
   const { LL } = useI18nContext()
   const { username, loading } = usePayLinks()
+  // Waiting on the currency keeps the row from opening a link built from the USD
+  // fallback the hook returns while the custodial query is still in flight.
+  const { displayCurrency, loading: displayCurrencyLoading } =
+    useEffectiveDisplayCurrency()
 
   if (!username) return null
 
-  const pos = getPosUrl(username)
+  const pos = getPosUrl(username, displayCurrency)
 
   return (
     <SettingsRow
-      loading={loading}
+      loading={loading || displayCurrencyLoading}
       title={LL.SettingsScreen.pos()}
       subtitleShorter={username.length > 22}
       leftGaloyIcon="calculator"

--- a/app/utils/pay-links.ts
+++ b/app/utils/pay-links.ts
@@ -15,8 +15,15 @@ const TERMINAL_URL = "https://terminal.blinkbtc.com"
  */
 const encodeUsername = (address: string): string => encodeURIComponent(address)
 
-export const getPosUrl = (address: string): string => {
-  return `${TERMINAL_URL}/${encodeUsername(address)}`
+/**
+ * `displayCurrency` becomes the terminal's `display` query param, which pre-selects the
+ * currency the point of sale prices in. The terminal falls back to USD for codes it does
+ * not know, so passing our own setting through stays safe if the two lists ever drift.
+ */
+export const getPosUrl = (address: string, displayCurrency?: string): string => {
+  const posUrl = `${TERMINAL_URL}/${encodeUsername(address)}`
+  if (!displayCurrency) return posUrl
+  return `${posUrl}?display=${encodeURIComponent(displayCurrency)}`
 }
 
 export const getPrintableQrCodeUrl = (address: string): string => {


### PR DESCRIPTION
## Summary

Blink Terminal defaults its point of sale to USD, so a merchant whose app is set to another currency had to change it by hand every time they opened their cash register from **Settings → Ways to get paid → Point of Sale**.

blinkbitcoin/blink-terminal#48 taught the public POS page to parse a `display` query param, so the link can carry the currency the merchant already picked:

```
https://terminal.blinkbtc.com/<username>?display=EUR
```

The terminal falls back to USD for codes it does not know, so passing our own setting through stays safe if the two currency lists ever drift.

## What changed

- **`app/utils/pay-links.ts`** — `getPosUrl` takes an optional display currency and appends `?display=<code>` only when one is given, so every existing caller keeps producing the exact same URL.
- **`app/screens/settings-screen/settings/account-pos.tsx`** — reads `useEffectiveDisplayCurrency()`, which already unifies both account types (custodial reads `me.defaultAccount.displayCurrency`, self-custodial reads persistent state). Its `loading` flag is folded into the row's existing `loading` prop: the hook answers `"USD"` while the custodial query is in flight, and opening the terminal on that fallback would be wrong for every non-USD merchant.

Two notes for reviewers:

- The row waits for the currency before it becomes tappable, because `useEffectiveDisplayCurrency` answers `"USD"` while the custodial query is in flight. The trade-off is that a cold cache behind a hanging network holds the row in its skeleton state; opening a merchant's cash register in the wrong currency is the worse outcome of the two.
- That query is the one settings query that does not pass `skip: !isAuthed`. The hook keeps it unauthed-safe with `fetchPolicy: "cache-only"` instead, so it still never reaches the network for a logged-out user — which is why `skip-queries-when-unauthed.spec.tsx` mocks it rather than asserting the skip flag.

Scope is the settings row only. The printable QR (`/print`) is left alone — blink-terminal parses the params on `/[blinkusername]` only, so a param there would be silently ignored. The older Galoy Address screen keeps its bare URL, which is the one that gets copied and shared.

## Testing

- `__tests__/utils/pay-links.spec.ts` — the param is appended, omitted when no currency is known, and encoded so a stray value cannot append another parameter.
- `__tests__/screens/settings-screen/settings/pay-link-rows.spec.tsx` — custodial and self-custodial POS rows both open the terminal with `?display=EUR`; the row stays in its loading state while the currency resolves, while the printable QR row (which carries no currency) does not.
- `npx jest --runTestsByPath` on the settings-screen suites, `npx tsc --noEmit` and `npx eslint` on the changed files all pass locally.

Fixes #4019

