### PR TITLE
fix(config): add China and Myanmar to offboard-only countries

### DIFF
--- a/__tests__/config/feature-flags-default-blocks.spec.ts
+++ b/__tests__/config/feature-flags-default-blocks.spec.ts
@@ -99,7 +99,13 @@ describe("defaultRemoteConfig: compliance country lists", () => {
     assertCanonical(defaultRemoteConfig.offboardOnlyCountries)
   })
 
-  it("offboardOnlyCountries defaults to the UAE, Nepal and Algeria", () => {
-    expect(defaultRemoteConfig.offboardOnlyCountries).toEqual(["AE", "NP", "DZ"])
+  it("offboardOnlyCountries defaults to the UAE, Nepal, Algeria, China and Myanmar", () => {
+    expect(defaultRemoteConfig.offboardOnlyCountries).toEqual([
+      "AE",
+      "NP",
+      "DZ",
+      "CN",
+      "MM",
+    ])
   })
 })

--- a/app/config/feature-flags-context.tsx
+++ b/app/config/feature-flags-context.tsx
@@ -179,7 +179,7 @@ const creationBlockedDefault = [
  * migration nudges. Ops empties the remote list after the withdrawal deadline, which is
  * what retires the bulletin — the client never compares dates.
  */
-const offboardOnlyDefault = ["AE", "NP", "DZ"]
+const offboardOnlyDefault = ["AE", "NP", "DZ", "CN", "MM"]
 
 export const defaultRemoteConfig: RemoteConfig = {
   deviceAccountEnabledRestAuth: false,


### PR DESCRIPTION
## What

Adds `CN` (China) and `MM` (Myanmar) to the `offboardOnlyCountries` remote config default, which shipped in #3977 as `["AE", "NP", "DZ"]`.

The final offboard-only list for the custodial sunset is now confirmed: **UAE, Nepal, Algeria, China, Myanmar**.

## Why

#3977 landed with a provisional default while the country list was still TBD in #3974. With the list confirmed, the bundled default should match it so CN/MM-registered custodial accounts get the persistent "withdraw your funds" bulletin even before Remote Config is fetched (or if the fetch fails).

## Remote Config

The `offboardOnlyCountries` parameter is now live in Firebase Remote Config with the same five codes, so the confirmed list applies to already-shipped app versions too — this PR only aligns the bundled fallback.

![offboardOnlyCountries in the Firebase Remote Config console](https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/assets/pr-4026-screenshots/remote-config-offboard-only-countries.jpg)

The retirement mechanism is unchanged: ops empties the remote array (`[]`, not a blank value) after the withdrawal deadline. The client never compares dates.

## Test plan

- `__tests__/config/feature-flags-default-blocks.spec.ts` — default list assertion updated; canonical-form check (uppercase alpha-2, no duplicates) still passes.
- `__tests__/screens/account-migration/hooks/use-offboard-only-bulletin.spec.ts` — unchanged, passes.

Ref #3974
