### PR TITLE
fix(bulletins): give notification card titles the themed bold preset

### DIFF
--- a/__tests__/components/notification-card-ui.spec.tsx
+++ b/__tests__/components/notification-card-ui.spec.tsx
@@ -62,6 +62,14 @@ describe("NotificationCardUI", () => {
     expect(getByText("Test Body")).toBeTruthy()
   })
 
+  it("styles the title with the themed bold preset so it outranks the body", () => {
+    const { getByText } = render(<NotificationCardUI {...defaultProps} />)
+
+    expect(getByText("Test Title").props).toMatchObject({ type: "p3", bold: true })
+    expect(getByText("Test Body").props).toMatchObject({ type: "p3" })
+    expect(getByText("Test Body").props.bold).toBeUndefined()
+  })
+
   it("renders icon when provided", () => {
     const { queryByTestId } = render(
       <NotificationCardUI {...defaultProps} icon="warning" />,

--- a/app/components/notifications/notification-card-ui.tsx
+++ b/app/components/notifications/notification-card-ui.tsx
@@ -116,7 +116,7 @@ const useStyles = makeStyles(({ colors }) => ({
   textColumn: {
     flex: 1,
     flexDirection: "column",
-    alignItems: "flex-start",
+    alignItems: "stretch",
     justifyContent: "center",
   },
   leftIconContainer: {

--- a/app/components/notifications/notification-card-ui.tsx
+++ b/app/components/notifications/notification-card-ui.tsx
@@ -50,8 +50,12 @@ export const NotificationCardUI: React.FC<NotificationCardUIProps> = ({
             </View>
           )}
           <View style={styles.textColumn}>
-            <Text style={styles.titleStyle}>{title}</Text>
-            <Text style={styles.bodyText}>{text}</Text>
+            <Text type="p3" bold>
+              {title}
+            </Text>
+            <Text type="p3" style={styles.bodyText}>
+              {text}
+            </Text>
           </View>
           {dismissAction && (
             <GaloyIconButton
@@ -115,12 +119,6 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "flex-start",
     justifyContent: "center",
   },
-  titleStyle: {
-    fontSize: 14,
-    lineHeight: 20,
-    fontWeight: "400",
-    color: colors.black,
-  },
   leftIconContainer: {
     justifyContent: "flex-start",
     flexDirection: "row",
@@ -135,9 +133,6 @@ const useStyles = makeStyles(({ colors }) => ({
     alignItems: "center",
   },
   bodyText: {
-    fontSize: 14,
-    lineHeight: 20,
-    fontWeight: "400",
     color: colors.grey2,
   },
   buttonActionContainer: {


### PR DESCRIPTION
Fixes #4012

## Problem

@designsats reported that the **"Your funds are at risk"** bulletin looks like it is missing the word *risk*.

The copy is intact — `BackupNudge.title` in `app/i18n/en/index.ts` reads `"Your funds are at risk"`, and all 28 locale files carry the full string. Nothing truncates the text either: `NotificationCardUI` sets no `numberOfLines` and no `ellipsizeMode`, so the title wraps rather than ellipsizing.

What it did have was this:

```ts
titleStyle: { fontSize: 14, lineHeight: 20, fontWeight: "400", color: colors.black },
bodyText:   { fontSize: 14, lineHeight: 20, fontWeight: "400", color: colors.grey2 },
```

The title and the body were styled **identically** — same size, same line height, same weight, differing only in colour. Every bulletin rendered its headline as if it were another paragraph, with nothing telling the eye where the title ended and the body began. When the title wraps (narrow device, or a longer locale — `ro` is 39 characters, `ja` and `el` longer still), the wrapped fragment reads as part of the body sentence.

It was also a convention violation: the app has a themed `Text` with size presets (`app/rne-theme/theme.ts`), used in 106 files. This card hardcoded `14/20`, which matches no preset — it had quietly drifted from the design system.

## Change

Adopt the themed presets on both texts:

```diff
-<Text style={styles.titleStyle}>{title}</Text>
-<Text style={styles.bodyText}>{text}</Text>
+<Text type="p3" bold>
+  {title}
+</Text>
+<Text type="p3" style={styles.bodyText}>
+  {text}
+</Text>
```

`titleStyle` disappears entirely — the theme already defaults to `colors.black`. `bodyText` survives only to carry `colors.grey2`, which is the card's own decision and not something a size preset owns.

Net visual delta: title `400 → 600` weight, both texts `lineHeight 20 → 18`. Size is unchanged at 14, so the title is no wider than before.

Scope is deliberately the one card, which covers every bulletin — `backup-nudge-banner`, `self-custodial-info-bulletin`, `migration-reminder-bulletin`, `offboard-only-bulletin` all render through it. `settings-screen/settings-card.tsx` shows the same string with its own hardcoded `14/700` title, but its title is already bold and so does not exhibit the symptom; left alone.

## Tests

Added one assertion in `notification-card-ui.spec.tsx` locking the convention in, so a future hardcode regresses loudly.

## Verification

- `notification-card-ui`, `backup-nudge-banner`, `backup-nudge-modal`, `self-custodial-info-bulletin` — 30/30 pass
- `bulletins`, `migration-reminder-bulletin`, `offboard-only-bulletin` — 26/26 pass
- `tsc --noEmit` clean, `eslint` clean on both changed files

Draft pending a visual check on a simulator with a non-backed-up self-custodial account over `backupNudgeBannerThreshold`.
