### PR TITLE
chore(graphql): regenerate generated.ts after the staging schema update

### DIFF
--- a/app/graphql/generated.ts
+++ b/app/graphql/generated.ts
@@ -885,13 +885,25 @@ export type CurrencyConversionEstimation = {
   readonly usdCentAmount: Scalars['CentAmount']['output'];
 };
 
+export type DepositFeeTier = {
+  readonly __typename: 'DepositFeeTier';
+  readonly amount: Scalars['String']['output'];
+  /** highest amount this tier applies to, null when unbounded */
+  readonly maxAmount?: Maybe<Scalars['String']['output']>;
+};
+
 export type DepositFeesInformation = {
   readonly __typename: 'DepositFeesInformation';
   readonly minBankFee: Scalars['String']['output'];
   /** below this amount minBankFee will be charged */
   readonly minBankFeeThreshold: Scalars['String']['output'];
-  /** ratio to charge as basis points above minBankFeeThreshold amount */
+  /**
+   * ratio to charge as basis points above minBankFeeThreshold amount
+   * @deprecated fees are a flat amount per tier, use tiers
+   */
   readonly ratio: Scalars['String']['output'];
+  /** amount charged per tier, in ascending order of maxAmount */
+  readonly tiers: ReadonlyArray<DepositFeeTier>;
 };
 
 export type DeviceNotificationTokenCreateInput = {
@@ -10076,6 +10088,7 @@ export type ResolversTypes = {
   Currency: ResolverTypeWrapper<Currency>;
   CurrencyConversionEstimation: ResolverTypeWrapper<CurrencyConversionEstimation>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
+  DepositFeeTier: ResolverTypeWrapper<DepositFeeTier>;
   DepositFeesInformation: ResolverTypeWrapper<DepositFeesInformation>;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: ResolverTypeWrapper<Scalars['DisplayCurrency']['output']>;
@@ -10379,6 +10392,7 @@ export type ResolversParentTypes = {
   Currency: Currency;
   CurrencyConversionEstimation: CurrencyConversionEstimation;
   DateTime: Scalars['DateTime']['output'];
+  DepositFeeTier: DepositFeeTier;
   DepositFeesInformation: DepositFeesInformation;
   DeviceNotificationTokenCreateInput: DeviceNotificationTokenCreateInput;
   DisplayCurrency: Scalars['DisplayCurrency']['output'];
@@ -11017,10 +11031,17 @@ export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversT
   name: 'DateTime';
 }
 
+export type DepositFeeTierResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeeTier'] = ResolversParentTypes['DepositFeeTier']> = {
+  amount?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  maxAmount?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type DepositFeesInformationResolvers<ContextType = any, ParentType extends ResolversParentTypes['DepositFeesInformation'] = ResolversParentTypes['DepositFeesInformation']> = {
   minBankFee?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   minBankFeeThreshold?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ratio?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  tiers?: Resolver<ReadonlyArray<ResolversTypes['DepositFeeTier']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -12073,6 +12094,7 @@ export type Resolvers<ContextType = any> = {
   Currency?: CurrencyResolvers<ContextType>;
   CurrencyConversionEstimation?: CurrencyConversionEstimationResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
+  DepositFeeTier?: DepositFeeTierResolvers<ContextType>;
   DepositFeesInformation?: DepositFeesInformationResolvers<ContextType>;
   DisplayCurrency?: GraphQLScalarType;
   Email?: EmailResolvers<ContextType>;


### PR DESCRIPTION
## Summary

`Check Code` is red on every open PR right now, including ones that touch no GraphQL at all (#4023 changes only translation JSON, #4025 only a settings row), with:

```
Error: app/graphql/generated.ts has changes, run `yarn dev:codegen` and re-commit
```

`codegen.yml` builds `generated.ts` from the live staging API schema, so the committed file goes stale the moment staging deploys a schema change — no PR has to touch a query for the check to fail. This is that regenerate-and-commit.

## What changed

`yarn dev:codegen` output only. Staging now exposes:

- a `DepositFeeTier` type (`amount`, nullable `maxAmount`),
- `DepositFeesInformation.tiers`,
- and marks `DepositFeesInformation.ratio` deprecated in favour of it.

Types only, no behaviour change — nothing in the app reads `tiers` yet. The consumer is #4024, which stays gated on `tiers` reaching production.

## Testing

- `graphql-codegen --config codegen.yml` against a clean `main`, then `git diff` is exactly this commit.
- `npx tsc --noEmit` — exit 0.
