### PR TITLE
chore(i18n): rename "Earn" to "Learn" in the bottom navigation bar

### DIFF
--- a/__tests__/i18n/learn-tab-label.spec.ts
+++ b/__tests__/i18n/learn-tab-label.spec.ts
@@ -1,0 +1,18 @@
+import { i18nObject } from "@app/i18n/i18n-util"
+import { loadLocale } from "@app/i18n/i18n-util.sync"
+
+// The bottom navigation bar renders this key as its tab title, accessibility label
+// and test ID (app/navigation/root-navigator.tsx).
+describe("EarnScreen.title bottom bar label", () => {
+  it("reads 'Learn' in English", () => {
+    loadLocale("en")
+
+    expect(i18nObject("en").EarnScreen.title()).toBe("Learn")
+  })
+
+  it("reads 'Aprender' in Spanish", () => {
+    loadLocale("es")
+
+    expect(i18nObject("es").EarnScreen.title()).toBe("Aprender")
+  })
+})

--- a/app/i18n/en/index.ts
+++ b/app/i18n/en/index.ts
@@ -2038,7 +2038,7 @@ const en: BaseTranslation = {
     satAccumulated: "Sats accumulated",
     satsEarned: "{formattedNumber | sats} earned",
     sectionsCompleted: "You've completed",
-    title: "Earn",
+    title: "Learn",
     unlockQuestion: "To unlock, answer the question:",
     youEarned: "You Earned",
     registerTitle: "Need to upgrade your account",

--- a/app/i18n/i18n-types.ts
+++ b/app/i18n/i18n-types.ts
@@ -6305,7 +6305,7 @@ type RootTranslation = {
 		 */
 		sectionsCompleted: string
 		/**
-		 * E​a​r​n
+		 * L​e​a​r​n
 		 */
 		title: string
 		/**
@@ -19263,7 +19263,7 @@ export type TranslationFunctions = {
 		 */
 		sectionsCompleted: () => LocalizedString
 		/**
-		 * Earn
+		 * Learn
 		 */
 		title: () => LocalizedString
 		/**

--- a/app/i18n/raw-i18n/source/en.json
+++ b/app/i18n/raw-i18n/source/en.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulated",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "You've completed",
-        "title": "Earn",
+        "title": "Learn",
         "unlockQuestion": "To unlock, answer the question:",
         "youEarned": "You Earned",
         "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/af.json
+++ b/app/i18n/raw-i18n/translations/af.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats bymekaargemaak",
     "satsEarned": "{formattedNumber | sats} verdien",
     "sectionsCompleted": "Jy het dit voltooi",
-    "title": "Verdien",
+    "title": "Leer",
     "unlockQuestion": "Om te ontsluit moet jy die vraag beantwoord:",
     "youEarned": "Jy het verdien: ",
     "registerTitle": "Opgradeer jou rekening",

--- a/app/i18n/raw-i18n/translations/ar.json
+++ b/app/i18n/raw-i18n/translations/ar.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "ساتس تم تجميعها",
     "satsEarned": "{formattedNumber | sats}\nحصلت عليها",
     "sectionsCompleted": "لقد أتممت",
-    "title": "إكسب",
+    "title": "تعلّم",
     "unlockQuestion": "لتفتح القفل، قم بلإجابة عن السؤال:",
     "youEarned": "لقد كسبت",
     "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/ca.json
+++ b/app/i18n/raw-i18n/translations/ca.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats acumulats",
     "satsEarned": "{formattedNumber | sats} guanyats",
     "sectionsCompleted": "Has completat",
-    "title": "Guanya",
+    "title": "Aprèn",
     "unlockQuestion": "Per desbloquejar, respon la pregunta:",
     "youEarned": "Has guanyat",
     "registerTitle": "Necessites actualitzar el teu compte",

--- a/app/i18n/raw-i18n/translations/cs.json
+++ b/app/i18n/raw-i18n/translations/cs.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Nahromaděné saty",
     "satsEarned": "{formattedNumber | sats} získáno",
     "sectionsCompleted": "Dokončil jste",
-    "title": "Získej saty",
+    "title": "Uč se",
     "unlockQuestion": "Pro odemčení odpovězte na otázku:",
     "youEarned": "Získal jste",
     "registerTitle": "Musíme aktualizovat váš účet",

--- a/app/i18n/raw-i18n/translations/da.json
+++ b/app/i18n/raw-i18n/translations/da.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats akkumuleret",
     "satsEarned": "{formattedNumber | sats} optjent",
     "sectionsCompleted": "Du har fuldført",
-    "title": "Optjen",
+    "title": "Lær",
     "unlockQuestion": "For at låse op, besvar spørgsmålet:",
     "youEarned": "Du har tjent",
     "registerTitle": "Din konto skal opgraderes",

--- a/app/i18n/raw-i18n/translations/de.json
+++ b/app/i18n/raw-i18n/translations/de.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats gesammelt",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "Du bist fertig",
-        "title": "Verdienen",
+        "title": "Lernen",
         "unlockQuestion": "Beantworte folgende Frage zum Entsperren:",
         "youEarned": "Du hast",
         "registerTitle": "Account Upgrade benötigt",

--- a/app/i18n/raw-i18n/translations/el.json
+++ b/app/i18n/raw-i18n/translations/el.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Συσσωρευμένα sats ",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Ολοκληρώσατε",
-    "title": "Κερδίστε ",
+    "title": "Μάθετε",
     "unlockQuestion": "Για να ξεκλειδώσετε, απαντήστε στην ερώτηση:",
     "youEarned": "Έχετε κερδίσει",
     "registerTitle": "Χρειάζεται να αναβαθμίσετε τον λογαριασμό σας",

--- a/app/i18n/raw-i18n/translations/es.json
+++ b/app/i18n/raw-i18n/translations/es.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Satoshis acumulados",
         "satsEarned": "{formattedNumber | sats} ganados",
         "sectionsCompleted": "Has completado",
-        "title": "Ganar",
+        "title": "Aprender",
         "unlockQuestion": "Para desbloquear, responda la pregunta:",
         "youEarned": "Has Ganado",
         "registerTitle": "Necesitas actualizar tu cuenta",

--- a/app/i18n/raw-i18n/translations/fr.json
+++ b/app/i18n/raw-i18n/translations/fr.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulés",
         "satsEarned": "{formattedNumber | sats} gagnés",
         "sectionsCompleted": "Vous avez terminé",
-        "title": "Quiz",
+        "title": "Apprendre",
         "unlockQuestion": "Pour dévérouiller, répondez à la question :",
         "youEarned": "Vous avez gagné",
         "registerTitle": "Besoin de mettre à jour votre compte",

--- a/app/i18n/raw-i18n/translations/hr.json
+++ b/app/i18n/raw-i18n/translations/hr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sat akumulirani",
     "satsEarned": "{formattedNumber | sats} osvojeno",
     "sectionsCompleted": "Završili ste",
-    "title": "Zaradi",
+    "title": "Uči",
     "unlockQuestion": "Za otključavanje odgovorite na pitanje:",
     "youEarned": "Zaradio si",
     "registerTitle": "Morate nadograditi svoj račun",

--- a/app/i18n/raw-i18n/translations/hu.json
+++ b/app/i18n/raw-i18n/translations/hu.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Keresett satoshik",
     "satsEarned": "{formattedNumber | sats}-ot kaptál",
     "sectionsCompleted": "Befejezett szakaszok",
-    "title": "Kvíz",
+    "title": "Tanulj",
     "unlockQuestion": "Feloldáshoz, válaszolj a kérdésre:",
     "youEarned": "Kerestél",
     "registerTitle": "A magasabb szintű számlára kell váltanod",

--- a/app/i18n/raw-i18n/translations/hy.json
+++ b/app/i18n/raw-i18n/translations/hy.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Սատերը կուտակվել են",
     "satsEarned": "{formattedNumber | sats} վաստակել եք",
     "sectionsCompleted": "Դուք ավարտել եք",
-    "title": "Վաստակել",
+    "title": "Սովորել",
     "unlockQuestion": "Բացելու համար՝ պատասխանեք հարցին",
     "youEarned": "Դուք վաստակեցիք",
     "registerTitle": "Հարկավոր է թարմացնել Ձեր հաշիվը։ ",

--- a/app/i18n/raw-i18n/translations/id.json
+++ b/app/i18n/raw-i18n/translations/id.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats terkumpul",
     "satsEarned": "{formattedNumber | sats} diperoleh",
     "sectionsCompleted": "Anda telah menyelesaikan",
-    "title": "Dapatkan",
+    "title": "Belajar",
     "unlockQuestion": "Untuk membuka, jawab pertanyaannya:",
     "youEarned": "Anda Mendapatkan",
     "registerTitle": "Perlu memperbaharui akun Anda",

--- a/app/i18n/raw-i18n/translations/it.json
+++ b/app/i18n/raw-i18n/translations/it.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats accumulati",
         "satsEarned": "{formattedNumber | sats} guadagnati",
         "sectionsCompleted": "L'hai completato",
-        "title": "Guadagna",
+        "title": "Impara",
         "unlockQuestion": "Per sbloccarlo, rispondi alla domanda:",
         "youEarned": "Hai guadagnato",
         "registerTitle": "Devi aggiornare il tuo account",

--- a/app/i18n/raw-i18n/translations/ja.json
+++ b/app/i18n/raw-i18n/translations/ja.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "累計 sats",
         "satsEarned": "{formattedNumber | sats}を獲得しました",
         "sectionsCompleted": "完了しました",
-        "title": "獲得する",
+        "title": "学ぶ",
         "unlockQuestion": "アンロックするには、質問に答えてください：",
         "youEarned": "獲得額",
         "registerTitle": "ウォレットのアップグレードが必要です",

--- a/app/i18n/raw-i18n/translations/lg.json
+++ b/app/i18n/raw-i18n/translations/lg.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats ezikuŋŋaanyiziddwa",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Omaze",
-    "title": "Kolera Empeera",
+    "title": "Yiga",
     "unlockQuestion": "Okugulawo, ddamu ekibuuzo:",
     "youEarned": "Okolede Empeera",
     "registerTitle": "W'etaaga okwongera omutindo gwa akawunti yo",

--- a/app/i18n/raw-i18n/translations/ms.json
+++ b/app/i18n/raw-i18n/translations/ms.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "sats telah dikumpul",
     "satsEarned": "{format nombor dalam |sats: string} telah diperolehi",
     "sectionsCompleted": "Dah selesai",
-    "title": "Dapat",
+    "title": "Belajar",
     "unlockQuestion": "Untuk membuka kunci, sila jawab soalan:",
     "youEarned": "Anda telah memperolehi",
     "registerTitle": "Anda perlulah naik taraf akaun anda",

--- a/app/i18n/raw-i18n/translations/nl.json
+++ b/app/i18n/raw-i18n/translations/nl.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats verzameld",
     "satsEarned": "{formattedNumber | sats} verdiend",
     "sectionsCompleted": "Je hebt voltooid",
-    "title": "Verdien",
+    "title": "Leer",
     "unlockQuestion": "Beantwoord de vraag om te ontgrendelen:",
     "youEarned": "Jij hebt verdiend",
     "registerTitle": "U moet uw account upgraden",

--- a/app/i18n/raw-i18n/translations/pt.json
+++ b/app/i18n/raw-i18n/translations/pt.json
@@ -2003,7 +2003,7 @@
         "satAccumulated": "Sats acumulados",
         "satsEarned": "{formattedNumber | sats} earned",
         "sectionsCompleted": "Você concluiu",
-        "title": "Ganhar",
+        "title": "Aprender",
         "unlockQuestion": "Para desbloquear, responda a pergunta:",
         "youEarned": "Você ganhou",
         "registerTitle": "Precisa atualizar sua conta",

--- a/app/i18n/raw-i18n/translations/qu.json
+++ b/app/i18n/raw-i18n/translations/qu.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Kuskanchik sats",
     "satsEarned": "{formattedNumber | sats} kuskan.",
     "sectionsCompleted": "Ima sumaq kani",
-    "title": "Kuskan",
+    "title": "Yachay",
     "unlockQuestion": "Qhipaqaqmi, chaymantam yanapaqmi, chaymantam riyqanichu:",
     "youEarned": "Kuskan",
     "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/ro.json
+++ b/app/i18n/raw-i18n/translations/ro.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats acumulați",
     "satsEarned": "{formattedNumber | sats} câștigați",
     "sectionsCompleted": "Ați finalizat",
-    "title": "Câștigați",
+    "title": "Învățați",
     "unlockQuestion": "Pentru a debloca, răspundeți la întrebarea:",
     "youEarned": "Ați câștigat",
     "registerTitle": "Trebuie să faceți upgrade contului",

--- a/app/i18n/raw-i18n/translations/sk.json
+++ b/app/i18n/raw-i18n/translations/sk.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Nahromadené sats",
     "satsEarned": "{formattedNumber | sats} zarobené",
     "sectionsCompleted": "Dokončili ste",
-    "title": "Získajte saty",
+    "title": "Učte sa",
     "unlockQuestion": "Na odomknutie odpovedzte na otázku:",
     "youEarned": "Získali ste",
     "registerTitle": "Potrebujete upgradovať účet",

--- a/app/i18n/raw-i18n/translations/sr.json
+++ b/app/i18n/raw-i18n/translations/sr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Сати сакупљени",
     "satsEarned": "Зарадили сте {formattedNumber | sats}",
     "sectionsCompleted": "Завршили сте",
-    "title": "Заради",
+    "title": "Учи",
     "unlockQuestion": "Да откључате, одговорите на питање:",
     "youEarned": "Зарадили сте",
     "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/sw.json
+++ b/app/i18n/raw-i18n/translations/sw.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats kusanyiko",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Umekamilisha",
-    "title": "Pata",
+    "title": "Jifunze",
     "unlockQuestion": "Ili kufungua, jibu swali:",
     "youEarned": "Umechuma",
     "registerTitle": "Unahitaji kuboresha akaunti yako",

--- a/app/i18n/raw-i18n/translations/th.json
+++ b/app/i18n/raw-i18n/translations/th.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "การรวบรวม sats เสร็จสิ้น",
     "satsEarned": "ได้รับ {formattedNumber | sats}",
     "sectionsCompleted": "คุณทำแบบทดสอบเสร็จสิ้น",
-    "title": "รับเงิน",
+    "title": "เรียนรู้",
     "unlockQuestion": "ตอบคำถามเพื่อปลดล็อค:",
     "youEarned": "คุณได้รับ",
     "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/tr.json
+++ b/app/i18n/raw-i18n/translations/tr.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Biriktirilen satsler",
     "satsEarned": "{formattedNumber | sats} earned",
     "sectionsCompleted": "Tamamladınız",
-    "title": "Kazan",
+    "title": "Öğren",
     "unlockQuestion": "Kilidi açmak için soruya cevap ver:",
     "youEarned": "Kazandınız",
     "registerTitle": "Hesabınızı güncellemeniz gerekiyor",

--- a/app/i18n/raw-i18n/translations/vi.json
+++ b/app/i18n/raw-i18n/translations/vi.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "Sats đã tích lũy",
     "satsEarned": "{formattedNumber | sats} kiếm được",
     "sectionsCompleted": "Bạn vừa hoàn thành",
-    "title": "Kiếm được",
+    "title": "Học",
     "unlockQuestion": "Để mở khóa, hãy trả lời câu hỏi:",
     "youEarned": "Bạn đã kiếm được",
     "registerTitle": "Need to upgrade your account",

--- a/app/i18n/raw-i18n/translations/xh.json
+++ b/app/i18n/raw-i18n/translations/xh.json
@@ -2003,7 +2003,7 @@
     "satAccumulated": "IiSats ziqokelelene",
     "satsEarned": "{formattedNumber | sats} efunyenweyo",
     "sectionsCompleted": "Ugqibile",
-    "title": "Zuza",
+    "title": "Funda",
     "unlockQuestion": "Ukuvula, phendula umbuzo:",
     "youEarned": "Uzuzile",
     "registerTitle": "Need to upgrade your account",


### PR DESCRIPTION
Closes #4014

## Summary

Renames the "Earn" bottom navigation tab to "Learn" across every locale.

The bottom tab reads `LL.EarnScreen.title()` for its `title`, `tabBarAccessibilityLabel` and `tabBarButtonTestID` (`app/navigation/root-navigator.tsx:1159-1162`), so retitling that one key relabels the tab — no navigation code changes needed. The same key is also the header title of the Earn map screen, which is the intended behaviour: the tab and the screen it opens should read the same.

**Scope of the change**

- `app/i18n/raw-i18n/source/en.json` + `app/i18n/en/index.ts` — `EarnScreen.title`: "Earn" → "Learn"
- All 28 files in `app/i18n/raw-i18n/translations/` — each translated to the local word for *learn* (e.g. `es` "Ganar" → "Aprender", `de` "Verdienen" → "Lernen", `ja` "獲得する" → "学ぶ", `sw` "Pata" → "Jifunze"). `fr` and `hu` previously read "Quiz"/"Kvíz" rather than a translation of "Earn"; both now read the local word for *learn* ("Apprendre" / "Tanulj") for consistency with the rest of the locales.
- `app/i18n/i18n-types.ts` — regenerated via `yarn update-translations`, not hand-edited.

**Deliberately unchanged:** the `EarnScreen` translation key, the `Earn` route name, the `EarnMapScreen`/`EarnSection`/`EarnQuiz` components, and every other string under `EarnScreen` (`satsEarned`, `youEarned`, `satAccumulated`, …). Those describe the sats reward, which still exists — only the tab label changes. `e2e/utils/use-cases.ts:43` already derives its selector from `LL.EarnScreen.title()`, so it follows automatically.

## Acceptance requirements

- [x] The bottom navigation bar tab reads **Learn** instead of **Earn** in English.
- [x] Every non-English locale shows its own translation of *learn*, not the old *earn* wording — all 28 translation files updated, none left behind.
- [x] The tab's accessibility label and test ID follow the new title (they are the same key).
- [x] No navigation, routing, or screen-component behaviour changes; quiz and reward flows are untouched.
- [x] `app/i18n/i18n-types.ts` is codegen output — running `yarn update-translations` produces no further diff.

## Testing specs

New: `__tests__/i18n/learn-tab-label.spec.ts`, following the existing `anonymous-user-label.spec.ts` / `recovery-phrase-label.spec.ts` pattern.

| Case | Expectation |
|---|---|
| `EarnScreen.title` in `en` | `"Learn"` |
| `EarnScreen.title` in `es` | `"Aprender"` |

Revert check: reverting `app/i18n/en/index.ts` and `translations/es.json` to the old copy makes **both** cases fail (`Expected "Learn" / Received "Earn"`, `Expected "Aprender" / Received "Ganar"`). Verified locally.

Also run locally, all green:

- `yarn tsc:check`
- `yarn eslint:check` on the changed files
- `npx prettier --check` on the changed files
- `yarn check:translations`
- `yarn test` — 532 suites / 6006 tests passed (no stale copy assertions elsewhere referenced the old label)

## Notes on CI

`Check Code` fails at the `check:codegen` step on this PR. **This is pre-existing on `main` and unrelated to this diff** — the remote staging schema added `DepositFeeTier` / `DepositFeesInformation.tiers`, so `app/graphql/generated.ts` is stale for every branch. Baseline: #4027 fails identically at the same step. That regeneration belongs to #4024, not here, so `generated.ts` is deliberately not touched. The steps before it (`tsc:check`, `eslint:check`, `check:translations`) pass.

`Android` / `iOS` fail in ~20s on every PR in this repo (deprecated `actions/cache: v2`), also unrelated.

## Screenshots

