### PR TITLE
fix(self-custodial): note/label field in receive and send flows

### DIFF
--- a/__tests__/helpers/self-custodial-payment-request.ts
+++ b/__tests__/helpers/self-custodial-payment-request.ts
@@ -1,0 +1,72 @@
+import { WalletCurrency } from "@app/graphql/generated"
+
+/**
+ * Fixtures and default mock behaviour shared by the self-custodial receive specs.
+ *
+ * The `jest.mock` factories themselves have to stay in each spec file (babel hoists
+ * them above imports), but everything they resolve to lives here so the two suites
+ * cannot drift apart.
+ */
+
+export const btcWallet = {
+  id: "btc-w1",
+  walletCurrency: WalletCurrency.Btc,
+  balance: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+  transactions: [],
+}
+
+export const usdWallet = {
+  id: "usd-w1",
+  walletCurrency: WalletCurrency.Usd,
+  balance: { amount: 500, currency: WalletCurrency.Usd, currencyCode: "USD" },
+  transactions: [],
+}
+
+export const mockSdk = { id: "mock-sdk" }
+
+export const btcAmount = (amount: number) => ({
+  amount,
+  currency: WalletCurrency.Btc,
+  currencyCode: "BTC",
+})
+
+export type PaymentRequestMocks = {
+  receiveLightning: jest.Mock
+  receiveOnchain: jest.Mock
+  selfCustodialWallet: jest.Mock
+  activeWallet: jest.Mock
+  convertMoneyAmount: jest.Mock
+  addPendingAutoConvert: jest.Mock
+  fetchAutoConvertMinSats: jest.Mock
+  useReceiveAssetMode: jest.Mock
+  formatMoneyAmount: jest.Mock
+}
+
+/** Puts every mock in the "self-custodial wallet is ready, BTC mode" baseline state. */
+export const applyPaymentRequestDefaults = (mocks: PaymentRequestMocks): void => {
+  mocks.selfCustodialWallet.mockReturnValue({
+    sdk: mockSdk,
+    lastReceivedPaymentId: null,
+  })
+  mocks.activeWallet.mockReturnValue({ wallets: [btcWallet, usdWallet], isReady: true })
+  mocks.receiveLightning.mockResolvedValue({ invoice: "lnbc1test..." })
+  mocks.receiveOnchain.mockResolvedValue({ address: "bc1qtest..." })
+  mocks.convertMoneyAmount.mockImplementation(
+    (amount: { amount: number }, currency: string) => ({
+      amount: amount.amount,
+      currency,
+      currencyCode: currency,
+    }),
+  )
+  mocks.formatMoneyAmount.mockImplementation(
+    ({ moneyAmount }: { moneyAmount: { amount: number } }) => `$${moneyAmount.amount}`,
+  )
+  mocks.addPendingAutoConvert.mockResolvedValue(undefined)
+  mocks.fetchAutoConvertMinSats.mockResolvedValue(undefined)
+  mocks.useReceiveAssetMode.mockReturnValue({
+    assetMode: "bitcoin",
+    setAssetMode: jest.fn(),
+    isToggleDisabled: false,
+    loading: false,
+  })
+}

--- a/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
@@ -6,6 +6,7 @@ import {
   btcAmount,
   mockSdk,
 } from "../../helpers/self-custodial-payment-request"
+import { Invoice } from "@app/screens/receive-bitcoin-screen/payment/index.types"
 import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
 
 const mockReceiveLightning = jest.fn()
@@ -140,6 +141,88 @@ describe("usePaymentRequest invoice regeneration", () => {
         "lnbc1second...",
       )
     })
+  })
+
+  // Same race as above, but on the path where the in-flight call rejects: the pending edit
+  // has to survive a failed attempt rather than only a successful one.
+  it("applies a memo edit made while a failing generation is in flight", async () => {
+    let rejectSecond: (err: Error) => void = () => {}
+    mockReceiveLightning
+      .mockImplementationOnce(() => Promise.reject(new Error("sdk down")))
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ invoice: string }>((_resolve, reject) => {
+            rejectSecond = reject
+          }),
+      )
+      .mockResolvedValue({ invoice: "lnbc1third..." })
+
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Error")
+    })
+
+    setMemoTo(result, "din")
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+
+    setMemoTo(result, "dinner")
+    await act(async () => {
+      rejectSecond(new Error("still down"))
+    })
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(3)
+    })
+    expect(mockReceiveLightning.mock.calls[2][0]).toEqual(
+      expect.objectContaining({ memo: "dinner" }),
+    )
+  })
+
+  it("regenerates the invoice when the asset mode is toggled", async () => {
+    const { result, rerender } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+    expect(mockAddPendingAutoConvert).not.toHaveBeenCalled()
+
+    mockUseReceiveAssetMode.mockReturnValue({
+      assetMode: "dollar",
+      setAssetMode: jest.fn(),
+      isToggleDisabled: false,
+      loading: false,
+    })
+    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1dollar..." })
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(mockAddPendingAutoConvert).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // The existing invoice is still the one the PayCode screen falls back to, so coming back
+  // to an unchanged Lightning tab must not burn a second invoice.
+  it("does not regenerate when the type leaves and returns to Lightning", async () => {
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+
+    act(() => {
+      result.current?.setType(Invoice.PayCode)
+    })
+    await flushEffects()
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current?.setType(Invoice.Lightning)
+    })
+    await flushEffects()
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
   })
 
   it("regenerates the invoice when the amount changes", async () => {

--- a/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
@@ -1,0 +1,250 @@
+import { renderHook, act, waitFor } from "@testing-library/react-native"
+import { WalletCurrency } from "@app/graphql/generated"
+
+import { flushEffects } from "../../helpers/flush-effects"
+import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
+
+const mockReceiveLightning = jest.fn()
+const mockReceiveOnchain = jest.fn()
+const mockSelfCustodialWallet = jest.fn()
+const mockActiveWallet = jest.fn()
+const mockConvertMoneyAmount = jest.fn()
+const mockRecordError = jest.fn()
+const mockAddPendingAutoConvert = jest.fn()
+const mockFetchAutoConvertMinSats = jest.fn()
+const mockUseReceiveAssetMode = jest.fn()
+const mockFormatMoneyAmount = jest.fn()
+
+jest.mock("@app/self-custodial/bridge", () => ({
+  createReceiveLightning: () => mockReceiveLightning,
+  createReceiveOnchain: () => mockReceiveOnchain,
+}))
+
+jest.mock("@react-native-firebase/crashlytics", () => ({
+  __esModule: true,
+  default: () => ({ recordError: mockRecordError, log: jest.fn() }),
+}))
+
+jest.mock("@app/self-custodial/auto-convert", () => ({
+  addPendingAutoConvert: (...args: unknown[]) => mockAddPendingAutoConvert(...args),
+  fetchAutoConvertMinSats: (...args: unknown[]) => mockFetchAutoConvertMinSats(...args),
+  ReceiveAssetMode: { Bitcoin: "bitcoin", Dollar: "dollar" },
+}))
+
+jest.mock("@app/self-custodial/hooks/use-receive-asset-mode", () => ({
+  useReceiveAssetMode: () => mockUseReceiveAssetMode(),
+}))
+
+jest.mock("@app/self-custodial/providers/wallet", () => ({
+  useSelfCustodialWallet: () => mockSelfCustodialWallet(),
+}))
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => mockActiveWallet(),
+}))
+
+jest.mock("@app/hooks/use-price-conversion", () => ({
+  usePriceConversion: () => ({ convertMoneyAmount: mockConvertMoneyAmount }),
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
+}))
+
+const btcWallet = {
+  id: "btc-w1",
+  walletCurrency: WalletCurrency.Btc,
+  balance: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
+  transactions: [],
+}
+
+const usdWallet = {
+  id: "usd-w1",
+  walletCurrency: WalletCurrency.Usd,
+  balance: { amount: 500, currency: WalletCurrency.Usd, currencyCode: "USD" },
+  transactions: [],
+}
+
+const mockSdk = { id: "mock-sdk" }
+
+const btcAmount = (amount: number) => ({
+  amount,
+  currency: WalletCurrency.Btc,
+  currencyCode: "BTC",
+})
+
+describe("usePaymentRequest invoice regeneration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSelfCustodialWallet.mockReturnValue({
+      sdk: mockSdk,
+      lastReceivedPaymentId: null,
+    })
+    mockActiveWallet.mockReturnValue({ wallets: [btcWallet, usdWallet], isReady: true })
+    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1test..." })
+    mockReceiveOnchain.mockResolvedValue({ address: "bc1qtest..." })
+    mockConvertMoneyAmount.mockImplementation(
+      (amount: { amount: number }, currency: string) => ({
+        amount: amount.amount,
+        currency,
+        currencyCode: currency,
+      }),
+    )
+    mockFormatMoneyAmount.mockImplementation(
+      ({ moneyAmount }: { moneyAmount: { amount: number } }) => `$${moneyAmount.amount}`,
+    )
+    mockAddPendingAutoConvert.mockResolvedValue(undefined)
+    mockFetchAutoConvertMinSats.mockResolvedValue(undefined)
+    mockUseReceiveAssetMode.mockReturnValue({
+      assetMode: "bitcoin",
+      setAssetMode: jest.fn(),
+      isToggleDisabled: false,
+      loading: false,
+    })
+  })
+
+  /** Mirrors the screen: type into the note field, then blur it. */
+  const setMemoTo = (
+    result: { current: ReturnType<typeof usePaymentRequest> },
+    memo: string,
+  ) => {
+    act(() => {
+      result.current?.setMemoChangeText(memo)
+    })
+    act(() => {
+      result.current?.setMemo()
+    })
+  }
+
+  it("regenerates the invoice with the new memo", async () => {
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1withmemo..." })
+
+    setMemoTo(result, "dinner")
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    expect(mockReceiveLightning.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ memo: "dinner" }),
+    )
+    await waitFor(() => {
+      expect(result.current?.pr?.info?.data?.getCopyableInvoiceFn()).toBe(
+        "lnbc1withmemo...",
+      )
+    })
+  })
+
+  it("applies a memo edit made while a generation is in flight", async () => {
+    let resolveFirst: (value: { invoice: string }) => void = () => {}
+    mockReceiveLightning
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ invoice: string }>((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockResolvedValue({ invoice: "lnbc1second..." })
+
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Loading")
+    })
+
+    setMemoTo(result, "dinner")
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFirst({ invoice: "lnbc1first..." })
+    })
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    expect(mockReceiveLightning.mock.calls[1][0]).toEqual(
+      expect.objectContaining({ memo: "dinner" }),
+    )
+    await waitFor(() => {
+      expect(result.current?.pr?.info?.data?.getCopyableInvoiceFn()).toBe(
+        "lnbc1second...",
+      )
+    })
+  })
+
+  it("regenerates the invoice when the amount changes", async () => {
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+
+    act(() => {
+      result.current?.setAmount(btcAmount(5000))
+    })
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    expect(mockReceiveLightning.mock.calls[1][0]?.amount?.amount).toBe(5000)
+  })
+
+  it("does not regenerate when nothing changed", async () => {
+    const { result, rerender } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+
+    rerender({})
+    await flushEffects()
+
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not regenerate once the invoice is paid", async () => {
+    const { result, rerender } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+    mockSelfCustodialWallet.mockReturnValue({
+      sdk: mockSdk,
+      lastReceivedPaymentId: "payment-abc-123",
+    })
+    rerender({})
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Paid")
+    })
+
+    setMemoTo(result, "too late")
+    await flushEffects()
+
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+    expect(result.current?.state).toBe("Paid")
+  })
+
+  it("does not retry in a loop when generation fails", async () => {
+    mockReceiveLightning.mockRejectedValue(new Error("sdk down"))
+
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Error")
+    })
+    await flushEffects()
+
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+  })
+
+  it("regenerateInvoice re-runs generation even when nothing changed", async () => {
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+
+    await act(async () => {
+      await result.current?.regenerateInvoice()
+    })
+
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+  })
+})

--- a/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts
@@ -1,7 +1,11 @@
 import { renderHook, act, waitFor } from "@testing-library/react-native"
-import { WalletCurrency } from "@app/graphql/generated"
 
 import { flushEffects } from "../../helpers/flush-effects"
+import {
+  applyPaymentRequestDefaults,
+  btcAmount,
+  mockSdk,
+} from "../../helpers/self-custodial-payment-request"
 import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
 
 const mockReceiveLightning = jest.fn()
@@ -51,55 +55,19 @@ jest.mock("@app/hooks/use-display-currency", () => ({
   useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
 }))
 
-const btcWallet = {
-  id: "btc-w1",
-  walletCurrency: WalletCurrency.Btc,
-  balance: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-  transactions: [],
-}
-
-const usdWallet = {
-  id: "usd-w1",
-  walletCurrency: WalletCurrency.Usd,
-  balance: { amount: 500, currency: WalletCurrency.Usd, currencyCode: "USD" },
-  transactions: [],
-}
-
-const mockSdk = { id: "mock-sdk" }
-
-const btcAmount = (amount: number) => ({
-  amount,
-  currency: WalletCurrency.Btc,
-  currencyCode: "BTC",
-})
-
 describe("usePaymentRequest invoice regeneration", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockSelfCustodialWallet.mockReturnValue({
-      sdk: mockSdk,
-      lastReceivedPaymentId: null,
-    })
-    mockActiveWallet.mockReturnValue({ wallets: [btcWallet, usdWallet], isReady: true })
-    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1test..." })
-    mockReceiveOnchain.mockResolvedValue({ address: "bc1qtest..." })
-    mockConvertMoneyAmount.mockImplementation(
-      (amount: { amount: number }, currency: string) => ({
-        amount: amount.amount,
-        currency,
-        currencyCode: currency,
-      }),
-    )
-    mockFormatMoneyAmount.mockImplementation(
-      ({ moneyAmount }: { moneyAmount: { amount: number } }) => `$${moneyAmount.amount}`,
-    )
-    mockAddPendingAutoConvert.mockResolvedValue(undefined)
-    mockFetchAutoConvertMinSats.mockResolvedValue(undefined)
-    mockUseReceiveAssetMode.mockReturnValue({
-      assetMode: "bitcoin",
-      setAssetMode: jest.fn(),
-      isToggleDisabled: false,
-      loading: false,
+    applyPaymentRequestDefaults({
+      receiveLightning: mockReceiveLightning,
+      receiveOnchain: mockReceiveOnchain,
+      selfCustodialWallet: mockSelfCustodialWallet,
+      activeWallet: mockActiveWallet,
+      convertMoneyAmount: mockConvertMoneyAmount,
+      addPendingAutoConvert: mockAddPendingAutoConvert,
+      fetchAutoConvertMinSats: mockFetchAutoConvertMinSats,
+      useReceiveAssetMode: mockUseReceiveAssetMode,
+      formatMoneyAmount: mockFormatMoneyAmount,
     })
   })
 
@@ -188,6 +156,88 @@ describe("usePaymentRequest invoice regeneration", () => {
       expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
     })
     expect(mockReceiveLightning.mock.calls[1][0]?.amount?.amount).toBe(5000)
+  })
+
+  it("applies an amount edit made while a generation is in flight", async () => {
+    let resolveFirst: (value: { invoice: string }) => void = () => {}
+    mockReceiveLightning
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ invoice: string }>((resolve) => {
+            resolveFirst = resolve
+          }),
+      )
+      .mockResolvedValue({ invoice: "lnbc1withamount..." })
+
+    const { result } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Loading")
+    })
+
+    act(() => {
+      result.current?.setAmount(btcAmount(5000))
+    })
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFirst({ invoice: "lnbc1first..." })
+    })
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    expect(mockReceiveLightning.mock.calls[1][0]?.amount?.amount).toBe(5000)
+  })
+
+  it("regenerates when the sdk instance is replaced", async () => {
+    const { result, rerender } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+
+    mockSelfCustodialWallet.mockReturnValue({
+      sdk: { id: "reconnected-sdk" },
+      lastReceivedPaymentId: null,
+    })
+    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1newsession..." })
+    rerender({})
+
+    await waitFor(() => {
+      expect(mockReceiveLightning).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(result.current?.pr?.info?.data?.getCopyableInvoiceFn()).toBe(
+        "lnbc1newsession...",
+      )
+    })
+  })
+
+  it("does not regenerate while an auto-convert is settling", async () => {
+    mockUseReceiveAssetMode.mockReturnValue({
+      assetMode: "dollar",
+      setAssetMode: jest.fn(),
+      isToggleDisabled: false,
+      loading: false,
+    })
+
+    const { result, rerender } = renderHook(() => usePaymentRequest())
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Created")
+    })
+    mockSelfCustodialWallet.mockReturnValue({
+      sdk: mockSdk,
+      lastReceivedPaymentId: "payment-abc-123",
+    })
+    rerender({})
+    await waitFor(() => {
+      expect(result.current?.state).toBe("Converting")
+    })
+
+    setMemoTo(result, "too late")
+    await flushEffects()
+
+    expect(mockReceiveLightning).toHaveBeenCalledTimes(1)
+    expect(result.current?.state).toBe("Converting")
   })
 
   it("does not regenerate when nothing changed", async () => {

--- a/__tests__/self-custodial/hooks/use-payment-request.spec.ts
+++ b/__tests__/self-custodial/hooks/use-payment-request.spec.ts
@@ -2,6 +2,13 @@ import { renderHook, act, waitFor } from "@testing-library/react-native"
 import { WalletCurrency } from "@app/graphql/generated"
 
 import { flushEffects } from "../../helpers/flush-effects"
+import {
+  applyPaymentRequestDefaults,
+  btcAmount,
+  btcWallet,
+  mockSdk,
+  usdWallet,
+} from "../../helpers/self-custodial-payment-request"
 import { usePaymentRequest } from "@app/self-custodial/hooks/use-payment-request"
 
 const mockReceiveLightning = jest.fn()
@@ -51,55 +58,19 @@ jest.mock("@app/hooks/use-display-currency", () => ({
   useDisplayCurrency: () => ({ formatMoneyAmount: mockFormatMoneyAmount }),
 }))
 
-const btcWallet = {
-  id: "btc-w1",
-  walletCurrency: WalletCurrency.Btc,
-  balance: { amount: 1000, currency: WalletCurrency.Btc, currencyCode: "BTC" },
-  transactions: [],
-}
-
-const usdWallet = {
-  id: "usd-w1",
-  walletCurrency: WalletCurrency.Usd,
-  balance: { amount: 500, currency: WalletCurrency.Usd, currencyCode: "USD" },
-  transactions: [],
-}
-
-const mockSdk = { id: "mock-sdk" }
-
-const btcAmount = (amount: number) => ({
-  amount,
-  currency: WalletCurrency.Btc,
-  currencyCode: "BTC",
-})
-
 describe("usePaymentRequest", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    mockSelfCustodialWallet.mockReturnValue({
-      sdk: mockSdk,
-      lastReceivedPaymentId: null,
-    })
-    mockActiveWallet.mockReturnValue({ wallets: [btcWallet, usdWallet], isReady: true })
-    mockReceiveLightning.mockResolvedValue({ invoice: "lnbc1test..." })
-    mockReceiveOnchain.mockResolvedValue({ address: "bc1qtest..." })
-    mockConvertMoneyAmount.mockImplementation(
-      (amount: { amount: number }, currency: string) => ({
-        amount: amount.amount,
-        currency,
-        currencyCode: currency,
-      }),
-    )
-    mockFormatMoneyAmount.mockImplementation(
-      ({ moneyAmount }: { moneyAmount: { amount: number } }) => `$${moneyAmount.amount}`,
-    )
-    mockAddPendingAutoConvert.mockResolvedValue(undefined)
-    mockFetchAutoConvertMinSats.mockResolvedValue(undefined)
-    mockUseReceiveAssetMode.mockReturnValue({
-      assetMode: "bitcoin",
-      setAssetMode: jest.fn(),
-      isToggleDisabled: false,
-      loading: false,
+    applyPaymentRequestDefaults({
+      receiveLightning: mockReceiveLightning,
+      receiveOnchain: mockReceiveOnchain,
+      selfCustodialWallet: mockSelfCustodialWallet,
+      activeWallet: mockActiveWallet,
+      convertMoneyAmount: mockConvertMoneyAmount,
+      addPendingAutoConvert: mockAddPendingAutoConvert,
+      fetchAutoConvertMinSats: mockFetchAutoConvertMinSats,
+      useReceiveAssetMode: mockUseReceiveAssetMode,
+      formatMoneyAmount: mockFormatMoneyAmount,
     })
   })
 

--- a/__tests__/self-custodial/mappers/transaction.spec.ts
+++ b/__tests__/self-custodial/mappers/transaction.spec.ts
@@ -135,6 +135,38 @@ describe("mapSelfCustodialTransaction", () => {
     expect(result.sourceAccountType).toBe(AccountType.SelfCustodial)
   })
 
+  it("prefers the LNURL comment over the invoice description for the memo", () => {
+    const result = mapSelfCustodialTransaction(
+      createPayment({
+        details: {
+          tag: "Lightning",
+          inner: {
+            description: "Payment to esaudeveloper",
+            lnurlPayInfo: { comment: "Dinner with Andrej" },
+          },
+        },
+      }),
+    )
+
+    expect(result.memo).toBe("Dinner with Andrej")
+  })
+
+  it("falls back to the invoice description when there is no LNURL comment", () => {
+    const result = mapSelfCustodialTransaction(
+      createPayment({
+        details: {
+          tag: "Lightning",
+          inner: {
+            description: "Payment to esaudeveloper",
+            lnurlPayInfo: { comment: undefined },
+          },
+        },
+      }),
+    )
+
+    expect(result.memo).toBe("Payment to esaudeveloper")
+  })
+
   it("scales token payment fees from base units to USD cents and tags them as USD", () => {
     const result = mapSelfCustodialTransaction(
       createPayment({

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -247,6 +247,23 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
         expect.objectContaining({ comment: "dinner" }),
       )
     })
+
+    it("truncates the comment to the length the destination allows", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ lnurlParams: baseLnurlParams({ commentAllowed: 10 }) }),
+      )
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+      const updated = detail.setMemo("a note far longer than the destination accepts")
+      if (!updated.canGetFee) throw new Error("expected canGetFee")
+
+      await updated.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ comment: "a note far" }),
+      )
+    })
   })
 
   describe("prepareLnurl options (currency-aware shape)", () => {

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -198,6 +198,55 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       const updated = detail.setMemo("new memo")
       expect(updated.memo).toBe("new memo")
     })
+
+    it("setMemo overrides a destination-specified memo", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ destinationSpecifiedMemo: "Payment to user@example.com" }),
+      )
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+
+      expect(detail.setMemo("dinner").memo).toBe("dinner")
+    })
+
+    it("keeps the typed memo across successive edits", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ destinationSpecifiedMemo: "Payment to user@example.com" }),
+      )
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+      const once = detail.setMemo("din")
+      if (!once.canSetMemo) throw new Error("expected canSetMemo")
+
+      expect(once.setMemo("dinner").memo).toBe("dinner")
+    })
+
+    it("clearing the memo does not fall back to the destination memo", () => {
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({ destinationSpecifiedMemo: "Payment to user@example.com" }),
+      )
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+
+      expect(detail.setMemo("").memo).toBe("")
+    })
+
+    it("sends the typed memo as the comment instead of the destination description", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      const detail = createSelfCustodialLnurlPaymentDetails(
+        createParams({
+          lnurlParams: baseLnurlParams({ commentAllowed: 200 }),
+          destinationSpecifiedMemo: "Payment to user@example.com",
+        }),
+      )
+      if (!detail.canSetMemo) throw new Error("expected canSetMemo")
+      const updated = detail.setMemo("dinner")
+      if (!updated.canGetFee) throw new Error("expected canGetFee")
+
+      await updated.getFee({} as never)
+
+      expect(mockPrepareLnurl).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ comment: "dinner" }),
+      )
+    })
   })
 
   describe("prepareLnurl options (currency-aware shape)", () => {

--- a/app/self-custodial/hooks/use-payment-request.ts
+++ b/app/self-custodial/hooks/use-payment-request.ts
@@ -98,17 +98,28 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     [amount, convertMoneyAmount],
   )
 
-  const generateRequest = useCallback(async () => {
-    if (!sdk || !isReady || isAssetModeLoading || !typeInitialized) return
-    if (type === Invoice.OnChain || type === Invoice.PayCode) return
-    if (
-      requestStateRef.current === PaymentRequestState.Loading ||
-      requestStateRef.current === PaymentRequestState.Converting ||
-      requestStateRef.current === PaymentRequestState.Paid
-    ) {
-      return
-    }
-    setRequestState(PaymentRequestState.Loading)
+  // The inputs a Lightning invoice is derived from. When they change, the invoice on
+  // screen is stale and has to be replaced. Tracking the key of the last attempt lets a
+  // change made while a generation is in flight be redone once it settles, instead of
+  // being silently dropped by a "busy" guard.
+  const generationKey = useMemo(
+    () =>
+      JSON.stringify({
+        type,
+        memo,
+        amount: amount ? `${amount.amount}-${amount.currencyCode}` : null,
+        assetMode,
+      }),
+    [type, memo, amount, assetMode],
+  )
+  const generationKeyRef = useRef(generationKey)
+  generationKeyRef.current = generationKey
+  const attemptedKeyRef = useRef<string | null>(null)
+  const isGeneratingRef = useRef(false)
+
+  /** Performs the SDK call itself; guards and bookkeeping live in generateRequest. */
+  const runGeneration = useCallback(async () => {
+    if (!sdk) return
 
     try {
       const convertMoneyAmount = convertMoneyAmountRef.current
@@ -157,7 +168,28 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
       )
       setRequestState(PaymentRequestState.Error)
     }
-  }, [sdk, isReady, isAssetModeLoading, typeInitialized, type, memo, amount, assetMode])
+  }, [sdk, memo, amount, assetMode])
+
+  const generateRequest = useCallback(async () => {
+    if (!sdk || !isReady || isAssetModeLoading || !typeInitialized) return
+    if (type === Invoice.OnChain || type === Invoice.PayCode) return
+    if (isGeneratingRef.current) return
+    if (
+      requestStateRef.current === PaymentRequestState.Converting ||
+      requestStateRef.current === PaymentRequestState.Paid
+    ) {
+      return
+    }
+    // Recorded before awaiting so a failed attempt is not retried in a loop, and so a
+    // change landing mid-flight leaves the key mismatched and triggers a new generation.
+    attemptedKeyRef.current = generationKeyRef.current
+    isGeneratingRef.current = true
+    setRequestState(PaymentRequestState.Loading)
+
+    return runGeneration().finally(() => {
+      isGeneratingRef.current = false
+    })
+  }, [sdk, isReady, isAssetModeLoading, typeInitialized, type, runGeneration])
 
   const setMemo = useCallback(() => {
     setMemoState(memoChangeText || "")
@@ -196,9 +228,12 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     setTypeInitialized(true)
   }, [typeInitialized, canUsePaycode, assetMode, amount, memoChangeText, memo])
 
+  // Re-runs on requestState as well as on the inputs: when a generation settles, this
+  // picks up any change (memo, amount, wallet) the user made while it was in flight.
   useEffect(() => {
+    if (attemptedKeyRef.current === generationKey) return
     generateRequest()
-  }, [generateRequest])
+  }, [generationKey, requestState, generateRequest])
 
   useEffect(() => {
     if (!sdk) return

--- a/app/self-custodial/hooks/use-payment-request.ts
+++ b/app/self-custodial/hooks/use-payment-request.ts
@@ -38,21 +38,33 @@ import { useSelfCustodialWallet } from "../providers/wallet"
 import { useReceiveAssetMode } from "./use-receive-asset-mode"
 import type { InvoiceData, SelfCustodialPaymentRequestState } from "./types"
 
+/**
+ * The identity of a generation: the sdk instance plus a key covering everything else the
+ * invoice is derived from. Two generations are the same when both halves match, so adding
+ * a new input means extending `key` — there is no field-by-field comparison to forget.
+ */
 type GenerationInputs = {
   sdk: BreezSdkInterface | null
-  type: InvoiceType
-  memo: string
-  amount: string | null
-  assetMode: ReceiveAssetMode
+  key: string
 }
 
+const buildGenerationKey = (parts: {
+  type: InvoiceType
+  memo: string
+  amount: MoneyAmount<WalletOrDisplayCurrency> | undefined
+  assetMode: ReceiveAssetMode
+}): string =>
+  // Serialised rather than joined so a memo containing the separator cannot make two
+  // different generations look alike.
+  JSON.stringify([
+    parts.type,
+    parts.memo,
+    parts.amount ? `${parts.amount.amount}-${parts.amount.currencyCode}` : null,
+    parts.assetMode,
+  ])
+
 const isSameGeneration = (a: GenerationInputs | null, b: GenerationInputs): boolean =>
-  a !== null &&
-  a.sdk === b.sdk &&
-  a.type === b.type &&
-  a.memo === b.memo &&
-  a.amount === b.amount &&
-  a.assetMode === b.assetMode
+  a !== null && a.sdk === b.sdk && a.key === b.key
 
 export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => {
   const { sdk, lastReceivedPaymentId, lightningAddress } = useSelfCustodialWallet()
@@ -120,13 +132,7 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
   // on screen is stale and has to be replaced. The sdk is part of it because a reconnect
   // or account switch hands back a new instance whose invoices belong to a new session.
   const generation: GenerationInputs = useMemo(
-    () => ({
-      sdk,
-      type,
-      memo,
-      amount: amount ? `${amount.amount}-${amount.currencyCode}` : null,
-      assetMode,
-    }),
+    () => ({ sdk, key: buildGenerationKey({ type, memo, amount, assetMode }) }),
     [sdk, type, memo, amount, assetMode],
   )
   const generationRef = useRef(generation)
@@ -137,6 +143,10 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
   // mid-flight leaves this mismatched and is picked up once the in-flight call settles.
   const attemptedRef = useRef<GenerationInputs | null>(null)
   const isGeneratingRef = useRef(false)
+
+  // Lets the settle handler below re-enter the newest generateRequest, whose runGeneration
+  // closure carries the current memo and amount, instead of the one it was created with.
+  const generateRequestRef = useRef<(attempt: GenerationInputs) => void>(() => {})
 
   /** Performs the SDK call itself; guards and bookkeeping live in generateRequest. */
   const runGeneration = useCallback(async () => {
@@ -192,28 +202,48 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
   }, [sdk, memo, amount, assetMode])
 
   /**
-   * Guards and bookkeeping around runGeneration. The busy flag is cleared from a
-   * `.finally` rather than a `try/finally` inside one async function because assigning a
-   * ref after an await trips eslint's require-atomic-updates — keep the two split.
+   * Guards and bookkeeping around runGeneration. `attempt` is the generation the caller
+   * observed, so the key recorded and the memo/amount the closure actually sends come from
+   * the same render rather than being paired implicitly through the ref.
+   *
+   * The busy flag is cleared from a `.finally` rather than a `try/finally` inside one async
+   * function because assigning a ref after an await trips eslint's require-atomic-updates —
+   * keep the two split.
    */
-  const generateRequest = useCallback(async () => {
-    if (!sdk || !isReady || isAssetModeLoading || !typeInitialized) return
-    if (type === Invoice.OnChain || type === Invoice.PayCode) return
-    if (isGeneratingRef.current) return
-    if (
-      requestStateRef.current === PaymentRequestState.Converting ||
-      requestStateRef.current === PaymentRequestState.Paid
-    ) {
-      return
-    }
-    attemptedRef.current = generationRef.current
-    isGeneratingRef.current = true
-    setRequestState(PaymentRequestState.Loading)
+  const generateRequest = useCallback(
+    async (attempt: GenerationInputs) => {
+      if (!sdk || !isReady || isAssetModeLoading || !typeInitialized) return
+      if (type === Invoice.OnChain || type === Invoice.PayCode) return
+      if (isGeneratingRef.current) return
+      if (
+        requestStateRef.current === PaymentRequestState.Converting ||
+        requestStateRef.current === PaymentRequestState.Paid
+      ) {
+        return
+      }
+      attemptedRef.current = attempt
+      isGeneratingRef.current = true
+      setRequestState(PaymentRequestState.Loading)
 
-    return runGeneration().finally(() => {
-      isGeneratingRef.current = false
-    })
-  }, [sdk, isReady, isAssetModeLoading, typeInitialized, type, runGeneration])
+      return runGeneration().finally(() => {
+        isGeneratingRef.current = false
+        // Anything the user changed while this call was in flight is picked up here rather
+        // than by the effect below, so the retry does not depend on React happening to
+        // re-run that effect after this flag is cleared rather than before.
+        if (!isSameGeneration(attemptedRef.current, generationRef.current)) {
+          generateRequestRef.current(generationRef.current)
+        }
+      })
+    },
+    [sdk, isReady, isAssetModeLoading, typeInitialized, type, runGeneration],
+  )
+
+  generateRequestRef.current = generateRequest
+
+  /** Forces a fresh invoice regardless of whether anything changed (retry button). */
+  const regenerateInvoice = useCallback(() => {
+    generateRequestRef.current(generationRef.current)
+  }, [])
 
   const setMemo = useCallback(() => {
     setMemoState(memoChangeText || "")
@@ -252,12 +282,10 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     setTypeInitialized(true)
   }, [typeInitialized, canUsePaycode, assetMode, amount, memoChangeText, memo])
 
-  // Re-runs on requestState as well as on the inputs: when a generation settles, this
-  // picks up any change (memo, amount, wallet) the user made while it was in flight.
   useEffect(() => {
     if (isSameGeneration(attemptedRef.current, generation)) return
-    generateRequest()
-  }, [generation, requestState, generateRequest])
+    generateRequest(generation)
+  }, [generation, generateRequest])
 
   useEffect(() => {
     if (!sdk) return
@@ -401,7 +429,7 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     setAmount,
     switchReceivingWallet,
     setExpirationTime: () => {},
-    regenerateInvoice: generateRequest,
+    regenerateInvoice,
     expiresInSeconds: null,
     expirationTime: 0,
     canSetExpirationTime: false,

--- a/app/self-custodial/hooks/use-payment-request.ts
+++ b/app/self-custodial/hooks/use-payment-request.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
+import { type BreezSdkInterface } from "@breeztech/breez-sdk-spark-react-native"
+
 import crashlytics from "@react-native-firebase/crashlytics"
 
 import { recordAppError } from "@app/utils/error-reporting"
@@ -35,6 +37,22 @@ import { useSelfCustodialWallet } from "../providers/wallet"
 
 import { useReceiveAssetMode } from "./use-receive-asset-mode"
 import type { InvoiceData, SelfCustodialPaymentRequestState } from "./types"
+
+type GenerationInputs = {
+  sdk: BreezSdkInterface | null
+  type: InvoiceType
+  memo: string
+  amount: string | null
+  assetMode: ReceiveAssetMode
+}
+
+const isSameGeneration = (a: GenerationInputs | null, b: GenerationInputs): boolean =>
+  a !== null &&
+  a.sdk === b.sdk &&
+  a.type === b.type &&
+  a.memo === b.memo &&
+  a.amount === b.amount &&
+  a.assetMode === b.assetMode
 
 export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => {
   const { sdk, lastReceivedPaymentId, lightningAddress } = useSelfCustodialWallet()
@@ -98,23 +116,26 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     [amount, convertMoneyAmount],
   )
 
-  // The inputs a Lightning invoice is derived from. When they change, the invoice on
-  // screen is stale and has to be replaced. Tracking the key of the last attempt lets a
-  // change made while a generation is in flight be redone once it settles, instead of
-  // being silently dropped by a "busy" guard.
-  const generationKey = useMemo(
-    () =>
-      JSON.stringify({
-        type,
-        memo,
-        amount: amount ? `${amount.amount}-${amount.currencyCode}` : null,
-        assetMode,
-      }),
-    [type, memo, amount, assetMode],
+  // The inputs a Lightning invoice is derived from. When any of them change, the invoice
+  // on screen is stale and has to be replaced. The sdk is part of it because a reconnect
+  // or account switch hands back a new instance whose invoices belong to a new session.
+  const generation: GenerationInputs = useMemo(
+    () => ({
+      sdk,
+      type,
+      memo,
+      amount: amount ? `${amount.amount}-${amount.currencyCode}` : null,
+      assetMode,
+    }),
+    [sdk, type, memo, amount, assetMode],
   )
-  const generationKeyRef = useRef(generationKey)
-  generationKeyRef.current = generationKey
-  const attemptedKeyRef = useRef<string | null>(null)
+  const generationRef = useRef(generation)
+  generationRef.current = generation
+
+  // Holds what was last *attempted*, not what succeeded: recording the attempt is what
+  // keeps a failed generation from being retried in a loop, while a change that lands
+  // mid-flight leaves this mismatched and is picked up once the in-flight call settles.
+  const attemptedRef = useRef<GenerationInputs | null>(null)
   const isGeneratingRef = useRef(false)
 
   /** Performs the SDK call itself; guards and bookkeeping live in generateRequest. */
@@ -170,6 +191,11 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     }
   }, [sdk, memo, amount, assetMode])
 
+  /**
+   * Guards and bookkeeping around runGeneration. The busy flag is cleared from a
+   * `.finally` rather than a `try/finally` inside one async function because assigning a
+   * ref after an await trips eslint's require-atomic-updates — keep the two split.
+   */
   const generateRequest = useCallback(async () => {
     if (!sdk || !isReady || isAssetModeLoading || !typeInitialized) return
     if (type === Invoice.OnChain || type === Invoice.PayCode) return
@@ -180,9 +206,7 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
     ) {
       return
     }
-    // Recorded before awaiting so a failed attempt is not retried in a loop, and so a
-    // change landing mid-flight leaves the key mismatched and triggers a new generation.
-    attemptedKeyRef.current = generationKeyRef.current
+    attemptedRef.current = generationRef.current
     isGeneratingRef.current = true
     setRequestState(PaymentRequestState.Loading)
 
@@ -231,9 +255,9 @@ export const usePaymentRequest = (): SelfCustodialPaymentRequestState | null => 
   // Re-runs on requestState as well as on the inputs: when a generation settles, this
   // picks up any change (memo, amount, wallet) the user made while it was in flight.
   useEffect(() => {
-    if (attemptedKeyRef.current === generationKey) return
+    if (isSameGeneration(attemptedRef.current, generation)) return
     generateRequest()
-  }, [generationKey, requestState, generateRequest])
+  }, [generation, requestState, generateRequest])
 
   useEffect(() => {
     if (!sdk) return

--- a/app/self-custodial/mappers/transaction.ts
+++ b/app/self-custodial/mappers/transaction.ts
@@ -111,7 +111,14 @@ const extractMemo = (payment: Payment): string | undefined => {
   if (!payment.details) return undefined
 
   if (PaymentDetails.Lightning.instanceOf(payment.details)) {
-    return payment.details.inner.description ?? undefined
+    /**
+     * For an LNURL/Lightning-address send the invoice description carries the destination's
+     * own advertised text, while the sender's note travels as the LUD-12 comment and is what
+     * the SDK stores in lnurlPayInfo.comment. The comment is the user's own note, so it wins
+     * over the destination description for history display, matching custodial behaviour.
+     */
+    const { lnurlPayInfo, description } = payment.details.inner
+    return lnurlPayInfo?.comment ?? description ?? undefined
   }
 
   if (PaymentDetails.Spark.instanceOf(payment.details)) {

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -229,6 +229,9 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
   // otherwise keeps winning the `memo` resolution above, leaving the note field frozen on
   // the destination's own text and sending it as the comment. Mirrors the custodial LNURL
   // details in app/screens/send-bitcoin-screen/payment-details/lightning.ts.
+  // Consequence, also intentional and shared with custodial: once the user edits the note
+  // the destination description is gone, so clearing the field sends no comment at all
+  // rather than falling back to it.
   const setMemo: PaymentDetailSetMemo<T> = {
     canSetMemo: true,
     setMemo: (newMemo) =>

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -225,12 +225,17 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
       }
     : { canSendPayment: false, canGetFee: false }
 
+  // Both memos are overwritten because the LNURL description supplied by the destination
+  // otherwise keeps winning the `memo` resolution above, leaving the note field frozen on
+  // the destination's own text and sending it as the comment. Mirrors the custodial LNURL
+  // details in app/screens/send-bitcoin-screen/payment-details/lightning.ts.
   const setMemo: PaymentDetailSetMemo<T> = {
     canSetMemo: true,
     setMemo: (newMemo) =>
       createSelfCustodialLnurlPaymentDetails({
         ...paramsWithKey,
         senderSpecifiedMemo: newMemo,
+        destinationSpecifiedMemo: newMemo,
       }),
   }
 

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -170,10 +170,18 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
   const isUsdSend = sendingWalletDescriptor.currency === WalletCurrency.Usd
   const payRequest = lnurlParamsToPayRequest(lnurlParams, lnurl)
 
+  // `commentAllowed` is a maximum length, not a flag. The note field accepts more
+  // characters than a destination typically allows, and since the note is now what fills
+  // the comment an over-long one would have the pay request rejected outright.
+  const comment =
+    lnurlParams.commentAllowed && memo
+      ? memo.slice(0, lnurlParams.commentAllowed)
+      : undefined
+
   const prepareOptions = {
     amount: toSdkSendAmount(settlementAmount.amount, sendingWalletDescriptor.currency),
     payRequest,
-    comment: lnurlParams.commentAllowed && memo ? memo : undefined,
+    comment,
     tokenIdentifier: resolveSendTokenIdentifier(sendingWalletDescriptor.currency),
     conversionOptions: isUsdSend
       ? {

--- a/app/self-custodial/payment-details/wrap-destination.ts
+++ b/app/self-custodial/payment-details/wrap-destination.ts
@@ -80,8 +80,8 @@ const buildLnurlDetail = <T extends WalletCurrency>({
     lnurlParams: destination.lnurlParams,
     unitOfAccountAmount: toBtcMoneyAmount(destination.lnurlParams.min || 0),
     isMerchant: destination.isMerchant,
-    destinationSpecifiedMemo: destination.lnurlParams.description,
     ...params,
+    destinationSpecifiedMemo: destination.lnurlParams.description,
   })
 
 const buildSparkDetail = <T extends WalletCurrency>({


### PR DESCRIPTION
Fixes blinkbitcoin/blink-wip#949

## Problem

In non-custodial mode the note/label field was broken on both sides:

- **Send:** typing in the note field did nothing — it read as a disabled field.
- **Receive:** editing the note sometimes never regenerated the invoice; the edit was silently dropped.

Both work in custodial mode. The non-custodial flows are separate implementations that reproduce the shape of the custodial ones but not two mechanisms that make them correct.

## Receive — the edit was dropped while a generation was in flight

`usePaymentRequest` regenerated only when the `generateRequest` callback identity changed, and returned early whenever the request state was `Loading`. Spark invoice creation takes a second or two, so an edit made during that window hit the guard, was dropped, and nothing ever re-triggered it — the in-flight call finished with the old memo.

Generation is now identified by the sdk instance plus a key over the inputs the invoice is derived from (`type`, `memo`, `amount`, asset mode). The sdk is part of the identity because a reconnect or account switch hands back a new instance whose invoices belong to a new session. The key of the attempt is recorded before awaiting, so a failed attempt is not retried in a loop, and a change landing mid-flight leaves the key mismatched.

Picking that change back up is done by the settle handler that clears the busy flag, not by waiting for the state transition to re-run the effect — so the retry does not depend on React re-running that effect after the flag is cleared rather than before. `generateRequest` takes the generation its caller observed, so the key recorded and the memo the closure actually sends come from the same render.

Side effect: this fixes the same race for amount edits and BTC/USDB toggles, not just the memo.

## Send — the destination description kept winning

`NoteInput` on the details screen is controlled by `paymentDetail.memo`, which resolves as `destinationSpecifiedMemo || senderSpecifiedMemo`. The non-custodial LNURL details recreated themselves with only `senderSpecifiedMemo`, and a Lightning address always resolves with a non-empty `lnurlParams.description` — so the value fed back into the input never changed and typing appeared to do nothing. The LUD-12 comment carried the destination's description rather than the user's note for the same reason.

`setMemo` now overrides both memos, exactly as the custodial LNURL details do (`app/screens/send-bitcoin-screen/payment-details/lightning.ts`). Also aligned the spread order in `buildLnurlDetail` with `buildLightningDetail` so an explicit override can't be clobbered by `...params`.

One consequence, shared with custodial: once the note is edited the destination description is gone, so clearing the field sends no comment rather than falling back to it.

## Send — the comment is bounded by what the destination allows

`lnurlParams.commentAllowed` is a maximum length, not a flag, and the note field accepts 500 characters. While the comment carried the destination's own description an over-long value could never reach it; now that the user's note is what fills it, a note longer than the destination allows would have the pay request rejected outright. The comment is sliced to `commentAllowed`.

The custodial path has the same unsliced shape (`app/screens/send-bitcoin-screen/send-bitcoin-details-screen.tsx`) and is left alone here as out of scope.

## Out of scope

BOLT11, Spark-address and on-chain non-custodial sends are unchanged. `PrepareSendPaymentRequest` in the Breez Spark SDK has no memo/description field, so a sender note cannot be transmitted for those types — it stays a local value. BOLT11 invoices that carry their own description keep the note field disabled, same as custodial.

## Screenshots

The user types "Dinner with Andrej" into the note field while paying the Lightning address `andrej@blink.sv`.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4034-assets/send-note-before.png" width="320"> | <img src="https://raw.githubusercontent.com/blinkbitcoin/blink-mobile/pr-4034-assets/send-note-after.png" width="320"> |

Before, every keystroke is discarded and both the field and the LUD-12 comment stay pinned to the destination's own description. After, the typed note is what the field shows and what is sent as the comment.

Captured on an isolated simulator against a harness that renders the real `NoteInput` and the real `createSelfCustodialLnurlPaymentDetails` with a stubbed LNURL destination — self-custodial needs a provisioned Spark account, which is not reachable without a `BREEZ_API_KEY`. The readout lines under the field print `paymentDetail.memo` and the comment the LNURL send would carry. Only the fix itself differs between the two captures. The note is well under any advertised `commentAllowed`, so the slice added later does not change what these frames show.

The receive-side fix is a timing race — an edit landing while the SDK call is in flight — which a still screenshot cannot show. It is covered by the deterministic regression tests instead, three of which fail against the unpatched source.

## Tests

- `__tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts` (new): regeneration on memo and amount change, the mid-flight edit race for memo and amount and on the path where the in-flight call rejects, regeneration on a BTC→USDB toggle and when the sdk instance is replaced, no regeneration when nothing changed, once paid, while an auto-convert is settling, or on a PayCode round trip, no retry loop on failure, manual `regenerateInvoice` still forces a new invoice.
- `__tests__/self-custodial/payment-details/lnurl.spec.ts`: `setMemo` overrides a destination-specified memo, survives successive edits and clearing, the typed memo is what reaches `prepareLnurl` as the comment, and a note longer than `commentAllowed` is truncated to it.

Each new test was confirmed to fail against the source it covers. 209 tests across the touched modules and their consumer screens pass; `eslint` and `tsc --noEmit` are clean.

## Verification

Targeted run (the full suite is left to CI):

```
yarn jest --runTestsByPath \
  __tests__/self-custodial/hooks/use-payment-request.spec.ts \
  __tests__/self-custodial/hooks/use-payment-request-regeneration.spec.ts \
  __tests__/self-custodial/payment-details/lnurl.spec.ts \
  __tests__/self-custodial/payment-details/wrap-destination.spec.ts \
  __tests__/screens/receive-bitcoin-screen/receive-screen.spec.tsx \
  __tests__/screens/receive-self-custodial.spec.tsx \
  __tests__/screens/receive.spec.tsx \
  __tests__/receive-bitcoin/hooks/use-receive-flow.spec.ts \
  __tests__/screens/send-details.spec.tsx \
  __tests__/screens/send-confirmation.spec.tsx
```

The receive flow needs a provisioned Spark account to exercise on device, which is not reachable locally without a `BREEZ_API_KEY` — worth a pass from someone who has one.
