### PR TITLE
fix: mock Crashlytics breadcrumbs in merchant selection test

### DIFF
--- a/__tests__/screens/merchant-selection.spec.tsx
+++ b/__tests__/screens/merchant-selection.spec.tsx
@@ -24,6 +24,7 @@ let mockSparkNetwork = "MAINNET"
 const mockFocusCleanups: Array<() => void> = []
 
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
+  log: jest.fn(),
   recordError: mockRecordError,
 }))
 


### PR DESCRIPTION
Adds the missing Crashlytics breadcrumb mock so the merchant selection screen test passes.