### PR TITLE
fix(test): add crashlytics log to merchant-selection mock

### DIFF
--- a/__tests__/screens/merchant-selection.spec.tsx
+++ b/__tests__/screens/merchant-selection.spec.tsx
@@ -24,6 +24,7 @@ let mockSparkNetwork = "MAINNET"
 const mockFocusCleanups: Array<() => void> = []
 
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
+  log: jest.fn(),
   recordError: mockRecordError,
 }))
 


### PR DESCRIPTION
## What

Add the missing `log` function to the inline Crashlytics mock in `merchant-selection.spec.tsx`.

## Why

CI was failing on `MerchantSelectionScreen › renders merchant rows...` with:

```
TypeError: (0 , crashlytics_1.default)(...).log is not a function
  at recordAppError (app/utils/error-reporting.ts:74:17)
  at toReadFailed (app/self-custodial/storage/account-index.ts:53:17)
  at readIndex (app/self-custodial/storage/account-index.ts:82:12)
  at listSelfCustodialAccounts (app/self-custodial/storage/account-index.ts:90:80)
  at app/hooks/use-account-registry.tsx:93:51
```

PR #3971 (`4b03654cb`, *classify expected/transient states as breadcrumbs*) added a `crashlytics().log(...)` call to `recordAppError`. The shared manual mock (`__mocks__/@react-native-firebase/crashlytics.js`) and the module's own spec both expose `log` + `recordError`, but `merchant-selection.spec.tsx` overrides Crashlytics with an inline mock that only defined `recordError`.

The screen reaches `recordAppError` indirectly on render (`useAccountRegistry` → `listSelfCustodialAccounts` → `readIndex` → `toReadFailed`), so the missing `log` surfaced as a hard failure once #3971 landed.

## Change

```diff
 jest.mock("@react-native-firebase/crashlytics", () => () => ({
+  log: jest.fn(),
   recordError: mockRecordError,
 }))
```

This aligns the inline mock with the canonical shape used by the shared mock and `error-reporting.spec.ts`.

## Testing

- `merchant-selection.spec.tsx`: 9/9 passing, `TypeError` gone.