### PR TITLE
fix(test): run the number-pad specs as several device locales

### DIFF
--- a/__tests__/components/number-pad-reducer.spec.ts
+++ b/__tests__/components/number-pad-reducer.spec.ts
@@ -1,5 +1,7 @@
-// The @wdio/mocha-framework types in tsconfig.jest.json shadow jest's, and
-// mocha's `describe` has no `.each` — same import the screen specs use.
+/**
+ * The @wdio/mocha-framework types in tsconfig.jest.json shadow jest's, and
+ * mocha's `describe` has no `.each`; same import the screen specs use.
+ */
 import { describe } from "@jest/globals"
 
 import { WalletCurrency } from "@app/graphql/generated"
@@ -144,10 +146,12 @@ describe("numberPadToString", () => {
 })
 
 describe("formatNumberPadNumber", () => {
-  // The literals below are how en-US groups digits. formatNumberPadNumber
-  // deliberately follows the device locale, so the locale has to be stated for
-  // them to mean anything — otherwise they assert whatever locale the machine
-  // running the suite is set to. The block after this one covers the others.
+  /**
+   * The literals below are how en-US groups digits. formatNumberPadNumber
+   * deliberately follows the device locale, so the locale has to be stated for
+   * them to mean anything; otherwise they assert whatever locale the machine
+   * running the suite is set to. The block after this one covers the others.
+   */
   withDeviceLocale("en-US")
 
   it("returns empty string for empty amounts with non-BTC currency", () => {
@@ -288,10 +292,12 @@ describe("formatNumberPadNumber follows the device locale", () => {
       currencyInfo,
     })
 
-  // Locales that group with a plain "," or "." — stable enough across CLDR
-  // releases to spell out, which keeps a real oracle in the suite rather than
-  // one derived from the same ICU data as the code. hi-IN groups in lakhs, so
-  // it also catches swapping the separator while keeping en-US's pattern.
+  /**
+   * Locales that group with a plain "," or "." are stable enough across CLDR
+   * releases to spell out, which keeps a real oracle in the suite rather than
+   * one derived from the same ICU data as the code. hi-IN groups in lakhs, so
+   * it also catches swapping the separator while keeping en-US's pattern.
+   */
   const STABLE_GROUPING = [
     { deviceLocale: "en-US", hundredThousand: "100,000", million: "1,000,000" },
     { deviceLocale: "de-DE", hundredThousand: "100.000", million: "1.000.000" },
@@ -309,20 +315,24 @@ describe("formatNumberPadNumber follows the device locale", () => {
       })
 
       it("leaves the decimal separator as the '.' the keypad types", () => {
-        // Only grouping is localised: the minor amount is appended verbatim
-        // after a literal ".", because "." is the key the number pad offers.
-        // In de-DE that reads as "100.000.5", the group and decimal separators
-        // being the same character.
+        /**
+         * Only grouping is localised: the minor amount is appended verbatim
+         * after a literal ".", because "." is the key the number pad offers.
+         * In de-DE that reads as "100.000.5", the group and decimal separators
+         * being the same character.
+         */
         expect(formatBtc("100000", "5")).toBe(`${hundredThousand}.5 SAT`)
       })
     },
   )
 
-  // Which space these group with is CLDR-version dependent — fr-FR moved from
-  // U+00A0 to U+202F in CLDR 34, and en-ZA is still on U+00A0 — so the
-  // separator is read from the same ICU data rather than hardcoded. The
-  // assertion is that the number pad followed the device, not which byte that
-  // locale uses this year; the en-US check below is what makes that bite.
+  /**
+   * Which space these group with is CLDR-version dependent (fr-FR moved from
+   * U+00A0 to U+202F in CLDR 34, and en-ZA is still on U+00A0), so the
+   * separator is read from the same ICU data rather than hardcoded. The
+   * assertion is that the number pad followed the device, not which byte that
+   * locale uses this year; the en-US check below is what makes that bite.
+   */
   describe.each(["fr-FR", "en-ZA"])("on a device set to %s", (deviceLocale) => {
     withDeviceLocale(deviceLocale)
 

--- a/__tests__/components/number-pad-reducer.spec.ts
+++ b/__tests__/components/number-pad-reducer.spec.ts
@@ -1,3 +1,7 @@
+// The @wdio/mocha-framework types in tsconfig.jest.json shadow jest's, and
+// mocha's `describe` has no `.each` — same import the screen specs use.
+import { describe } from "@jest/globals"
+
 import { WalletCurrency } from "@app/graphql/generated"
 import { CurrencyInfo } from "@app/hooks/use-display-currency"
 import { WalletOrDisplayCurrency } from "@app/types/amounts"
@@ -7,6 +11,7 @@ import {
   formatNumberPadNumber,
   NumberPadNumber,
 } from "@app/components/amount-input-screen/number-pad-reducer"
+import { groupedInLocale, withDeviceLocale } from "../helpers/device-locale"
 
 const currencyInfo: Record<WalletOrDisplayCurrency, CurrencyInfo> = {
   BTC: {
@@ -139,6 +144,12 @@ describe("numberPadToString", () => {
 })
 
 describe("formatNumberPadNumber", () => {
+  // The literals below are how en-US groups digits. formatNumberPadNumber
+  // deliberately follows the device locale, so the locale has to be stated for
+  // them to mean anything — otherwise they assert whatever locale the machine
+  // running the suite is set to. The block after this one covers the others.
+  withDeviceLocale("en-US")
+
   it("returns empty string for empty amounts with non-BTC currency", () => {
     expect(
       formatNumberPadNumber({
@@ -259,5 +270,68 @@ describe("formatNumberPadNumber", () => {
         currencyInfo,
       }),
     ).toBe("25.50")
+  })
+})
+
+/**
+ * The amount being typed is grouped the way the user's own device groups
+ * digits — that is what the bare `toLocaleString()` in formatNumberPadNumber is
+ * for. These run the same code as if the device were set to each locale in
+ * turn; converted amounts elsewhere in the app stay pinned to "en-US" (see
+ * formatCurrencyHelper in @app/hooks/use-display-currency).
+ */
+describe("formatNumberPadNumber follows the device locale", () => {
+  const formatBtc = (majorAmount: string, minorAmount = "") =>
+    formatNumberPadNumber({
+      numberPadNumber: { majorAmount, minorAmount, hasDecimal: Boolean(minorAmount) },
+      currency: WalletCurrency.Btc,
+      currencyInfo,
+    })
+
+  // Locales that group with a plain "," or "." — stable enough across CLDR
+  // releases to spell out, which keeps a real oracle in the suite rather than
+  // one derived from the same ICU data as the code. hi-IN groups in lakhs, so
+  // it also catches swapping the separator while keeping en-US's pattern.
+  const STABLE_GROUPING = [
+    { deviceLocale: "en-US", hundredThousand: "100,000", million: "1,000,000" },
+    { deviceLocale: "de-DE", hundredThousand: "100.000", million: "1.000.000" },
+    { deviceLocale: "hi-IN", hundredThousand: "1,00,000", million: "10,00,000" },
+  ]
+
+  describe.each(STABLE_GROUPING)(
+    "on a device set to $deviceLocale",
+    ({ deviceLocale, hundredThousand, million }) => {
+      withDeviceLocale(deviceLocale)
+
+      it("groups the major amount the way the device does", () => {
+        expect(formatBtc("100000")).toBe(`${hundredThousand} SAT`)
+        expect(formatBtc("1000000")).toBe(`${million} SAT`)
+      })
+
+      it("leaves the decimal separator as the '.' the keypad types", () => {
+        // Only grouping is localised: the minor amount is appended verbatim
+        // after a literal ".", because "." is the key the number pad offers.
+        // In de-DE that reads as "100.000.5", the group and decimal separators
+        // being the same character.
+        expect(formatBtc("100000", "5")).toBe(`${hundredThousand}.5 SAT`)
+      })
+    },
+  )
+
+  // Which space these group with is CLDR-version dependent — fr-FR moved from
+  // U+00A0 to U+202F in CLDR 34, and en-ZA is still on U+00A0 — so the
+  // separator is read from the same ICU data rather than hardcoded. The
+  // assertion is that the number pad followed the device, not which byte that
+  // locale uses this year; the en-US check below is what makes that bite.
+  describe.each(["fr-FR", "en-ZA"])("on a device set to %s", (deviceLocale) => {
+    withDeviceLocale(deviceLocale)
+
+    it("groups the major amount the way the device does", () => {
+      expect(formatBtc("100000")).toBe(`${groupedInLocale(100000, deviceLocale)} SAT`)
+    })
+
+    it("does not fall back to en-US grouping", () => {
+      expect(formatBtc("100000")).not.toBe("100,000 SAT")
+    })
   })
 })

--- a/__tests__/helpers/device-locale.ts
+++ b/__tests__/helpers/device-locale.ts
@@ -1,0 +1,96 @@
+/**
+ * Run a spec as if the device were set to a given locale.
+ *
+ * `formatNumberPadNumber` formats the number pad's major amount with a bare
+ * `Number#toLocaleString()` on purpose: the amount being typed is grouped the
+ * way the user's own device groups digits. Which locale that resolves to is
+ * decided by the runtime — `LANG`/`LC_ALL` under jest, the first locale data
+ * `app/i18n/mapping.ts` hands the formatjs polyfill on device — so a spec that
+ * hardcodes "1,500" is really asserting the locale of whichever machine happens
+ * to run it, and goes red for a developer whose shell is set to, say, en_ZA
+ * (which groups with a no-break space).
+ *
+ * `withDeviceLocale` substitutes that default, so a spec states the locale it
+ * means instead of inheriting one, and can run the same code under several:
+ *
+ *   describe("...", () => {
+ *     withDeviceLocale("de-DE")
+ *     it("groups the way the device does", () => { ... })
+ *   })
+ *
+ * Only the default is substituted. A call that names its locale is passed
+ * through untouched, which is what lets a spec tell the number pad's
+ * device-locale output apart from the "en-US" that `formatCurrencyHelper`
+ * (@app/hooks/use-display-currency) pins for every converted amount.
+ *
+ * Numbers only: dates still follow the runtime default. Add the matching
+ * `Date`/`Intl.DateTimeFormat` wrappers here if a date spec ever needs the
+ * same treatment.
+ */
+
+// Derived from whatever lib the TS config resolves rather than written out, so
+// this keeps compiling when the `Intl.LocalesArgument` typings move again.
+type LocalesArgument = Parameters<typeof Number.prototype.toLocaleString>[0]
+
+const installDeviceLocale = (locale: string): (() => void) => {
+  const originalToLocaleString = Number.prototype.toLocaleString
+  const OriginalNumberFormat = Intl.NumberFormat
+
+  const orDeviceLocale = (locales: LocalesArgument): LocalesArgument =>
+    locales === undefined ? locale : locales
+
+  // Proxies rather than wrapper functions: the receiver a number method is
+  // called on, and NumberFormat's prototype, statics (supportedLocalesOf) and
+  // `instanceof`, all keep working through them untouched.
+  const patchedToLocaleString = new Proxy(originalToLocaleString, {
+    apply: (target, value, [locales, options]) =>
+      Reflect.apply(target, value, [orDeviceLocale(locales), options]),
+  })
+
+  const PatchedNumberFormat = new Proxy(OriginalNumberFormat, {
+    construct: (target, [locales, options]) =>
+      new target(orDeviceLocale(locales), options),
+    apply: (target, _thisArg, [locales, options]) =>
+      target(orDeviceLocale(locales), options),
+  })
+
+  // eslint-disable-next-line no-extend-native
+  Number.prototype.toLocaleString = patchedToLocaleString
+  Intl.NumberFormat = PatchedNumberFormat
+
+  return () => {
+    // eslint-disable-next-line no-extend-native
+    Number.prototype.toLocaleString = originalToLocaleString
+    Intl.NumberFormat = OriginalNumberFormat
+  }
+}
+
+/**
+ * Pin the default locale for the enclosing `describe` (or the whole file, when
+ * called at module scope). Nests: an inner block's locale wraps the outer one
+ * and hands it back on the way out.
+ */
+export const withDeviceLocale = (locale: string): void => {
+  let restore: (() => void) | null = null
+
+  beforeAll(() => {
+    restore = installDeviceLocale(locale)
+  })
+
+  afterAll(() => {
+    restore?.()
+    restore = null
+  })
+}
+
+/**
+ * How `locale` groups `value`, read from the same ICU data as the code under
+ * test. Assert against this instead of a literal whenever the locale's group
+ * separator is one CLDR has moved: on this repo's node, fr-FR groups with
+ * U+202F (narrow no-break space) while en-ZA still uses U+00A0, and fr-FR used
+ * U+00A0 itself until CLDR 34. Locales whose separator is a plain "," or "."
+ * are stable enough to assert literally, and doing so keeps at least one real
+ * oracle in the suite.
+ */
+export const groupedInLocale = (value: number, locale: string): string =>
+  new Intl.NumberFormat(locale).format(value)

--- a/__tests__/helpers/device-locale.ts
+++ b/__tests__/helpers/device-locale.ts
@@ -28,8 +28,10 @@
  * same treatment.
  */
 
-// Derived from whatever lib the TS config resolves rather than written out, so
-// this keeps compiling when the `Intl.LocalesArgument` typings move again.
+/**
+ * Derived from whatever lib the TS config resolves rather than written out, so
+ * this keeps compiling when the `Intl.LocalesArgument` typings move again.
+ */
 type LocalesArgument = Parameters<typeof Number.prototype.toLocaleString>[0]
 
 const installDeviceLocale = (locale: string): (() => void) => {
@@ -39,17 +41,19 @@ const installDeviceLocale = (locale: string): (() => void) => {
   const orDeviceLocale = (locales: LocalesArgument): LocalesArgument =>
     locales === undefined ? locale : locales
 
-  // Proxies rather than wrapper functions: the receiver a number method is
-  // called on, and NumberFormat's prototype, statics (supportedLocalesOf) and
-  // `instanceof`, all keep working through them untouched.
+  /**
+   * Proxies rather than wrapper functions: the receiver a number method is
+   * called on, and NumberFormat's prototype, statics (supportedLocalesOf) and
+   * `instanceof`, all keep working through them untouched.
+   */
   const patchedToLocaleString = new Proxy(originalToLocaleString, {
     apply: (target, value, [locales, options]) =>
       Reflect.apply(target, value, [orDeviceLocale(locales), options]),
   })
 
   const PatchedNumberFormat = new Proxy(OriginalNumberFormat, {
-    construct: (target, [locales, options]) =>
-      new target(orDeviceLocale(locales), options),
+    construct: (target, [locales, options], newTarget) =>
+      Reflect.construct(target, [orDeviceLocale(locales), options], newTarget),
     apply: (target, _thisArg, [locales, options]) =>
       target(orDeviceLocale(locales), options),
   })

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -5,7 +5,7 @@ import {
   type StyleProp,
   type ViewStyle,
 } from "react-native"
-import { it } from "@jest/globals"
+import { describe, it } from "@jest/globals"
 import { fireEvent, render, waitFor, act } from "@testing-library/react-native"
 import { MockedProvider, MockedResponse } from "@apollo/client/testing"
 import { NavigationContainer } from "@react-navigation/native"
@@ -32,6 +32,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 import theme from "@app/rne-theme/theme"
 import { createCache } from "@app/graphql/cache"
 import { DisplayCurrency as DisplayCurrencyType } from "@app/types/amounts"
+import { withDeviceLocale } from "../helpers/device-locale"
 
 jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
@@ -154,6 +155,10 @@ const calculateExpectedSatsFromUsd = (usdCents: number): number => {
   return sats
 }
 
+// Converted amounts are formatted by formatCurrencyHelper
+// (@app/hooks/use-display-currency), which pins "en-US" whatever the device is
+// set to — so this stays "en-US" even in the device-locale suite at the bottom
+// of the file, which is the point of that suite.
 const formatNumber = (amount: number, fractionDigits: number) =>
   Intl.NumberFormat("en-US", {
     minimumFractionDigits: fractionDigits,
@@ -631,6 +636,12 @@ const defaultActiveWallet = {
 const defaultLimits = { limits: null, loading: false, error: null }
 
 loadLocale("en")
+
+// The amount being typed is grouped by the device's locale (the bare
+// toLocaleString() in formatNumberPadNumber), so every "100,000 SAT" below is
+// really an en-US expectation. State it, or the file asserts whatever locale
+// the machine running it is set to.
+withDeviceLocale("en-US")
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -2380,4 +2391,79 @@ describe("Self-custodial percentage chip happy-path", () => {
       }),
     )
   })
+})
+
+/**
+ * The screen formats its two kinds of value differently, and the split is only
+ * visible on a device that is not en-US:
+ *
+ *  - the field being typed in shows the number pad's own string
+ *    (formatNumberPadNumber -> bare toLocaleString), grouped the way the user's
+ *    device groups digits
+ *  - every other field shows the converted amount (formatMoneyAmount ->
+ *    formatCurrencyHelper), which pins "en-US"
+ *
+ * Running the same interaction under several device locales is what holds that
+ * split in place — on an en-US machine the two are indistinguishable.
+ */
+describe("Device locale", () => {
+  const deviceLocaleCases = [
+    { deviceLocale: "de-DE", typedSats: "100.000" },
+    { deviceLocale: "hi-IN", typedSats: "1,00,000" },
+  ]
+
+  describe.each(deviceLocaleCases)(
+    "on a device set to $deviceLocale",
+    ({ deviceLocale, typedSats }) => {
+      withDeviceLocale(deviceLocale)
+
+      beforeEach(() => {
+        jest.useFakeTimers()
+      })
+
+      afterEach(() => {
+        jest.useRealTimers()
+      })
+
+      it("groups the typed sats the device's way, leaving the conversion en-US", async () => {
+        const Wrapper = createTestWrapper(
+          createGraphQLMocks({ btcBalance: 100000, usdBalance: 50000 }),
+        )
+
+        const { getByTestId, getByPlaceholderText } = render(
+          <Wrapper>
+            <ConversionDetailsScreen />
+          </Wrapper>,
+        )
+
+        await waitFor(() => {
+          expect(getByTestId("Key 1")).toBeTruthy()
+        })
+
+        const btcInput = getByPlaceholderText("0 SAT")
+        const usdInput = getByPlaceholderText("$0")
+
+        act(() => {
+          fireEvent(btcInput, "focus")
+        })
+
+        await act(async () => {
+          pressKeys(getByTestId, ["1", "0", "0", "0", "0", "0"])
+        })
+
+        act(() => {
+          jest.advanceTimersByTime(1500)
+        })
+
+        const expectedUsdCents = calculateExpectedUsdFromSats(100000)
+
+        await waitFor(() => {
+          expect(btcInput.props.value).toBe(`${typedSats} SAT`)
+          expect(usdInput.props.value).toBe(
+            withApprox(formatUsdCents(expectedUsdCents), true),
+          )
+        })
+      })
+    },
+  )
 })

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -34,6 +34,15 @@ import { createCache } from "@app/graphql/cache"
 import { DisplayCurrency as DisplayCurrencyType } from "@app/types/amounts"
 import { withDeviceLocale } from "../helpers/device-locale"
 
+/**
+ * The amount being typed is grouped by the device's locale (the bare
+ * toLocaleString() in formatNumberPadNumber), so every "100,000 SAT" in this
+ * file is really an en-US expectation. State it, or the file asserts whatever
+ * locale the machine running it is set to. The device-locale suite at the
+ * bottom of the file nests its own locales on top of this one.
+ */
+withDeviceLocale("en-US")
+
 jest.mock("@app/store/persistent-state", () => ({
   ...jest.requireActual("@app/store/persistent-state"),
   usePersistentStateContext: () => ({
@@ -155,10 +164,12 @@ const calculateExpectedSatsFromUsd = (usdCents: number): number => {
   return sats
 }
 
-// Converted amounts are formatted by formatCurrencyHelper
-// (@app/hooks/use-display-currency), which pins "en-US" whatever the device is
-// set to — so this stays "en-US" even in the device-locale suite at the bottom
-// of the file, which is the point of that suite.
+/**
+ * Converted amounts are formatted by formatCurrencyHelper
+ * (@app/hooks/use-display-currency), which pins "en-US" whatever the device is
+ * set to, so this stays "en-US" even in the device-locale suite at the bottom
+ * of the file, which is the point of that suite.
+ */
 const formatNumber = (amount: number, fractionDigits: number) =>
   Intl.NumberFormat("en-US", {
     minimumFractionDigits: fractionDigits,
@@ -636,12 +647,6 @@ const defaultActiveWallet = {
 const defaultLimits = { limits: null, loading: false, error: null }
 
 loadLocale("en")
-
-// The amount being typed is grouped by the device's locale (the bare
-// toLocaleString() in formatNumberPadNumber), so every "100,000 SAT" below is
-// really an en-US expectation. State it, or the file asserts whatever locale
-// the machine running it is set to.
-withDeviceLocale("en-US")
 
 beforeEach(() => {
   jest.clearAllMocks()


### PR DESCRIPTION
formatNumberPadNumber formats the amount being typed with a bare Number#toLocaleString() on purpose: the number pad groups digits the way the user's own device does, while converted amounts pin "en-US" through formatCurrencyHelper. Which locale that bare call resolves to is decided by the runtime, so specs hardcoding "1,500" were really asserting the locale of whichever machine ran them, and went red on a shell set to en_ZA (which groups with a no-break space).

withDeviceLocale substitutes that default for a describe block, so a spec states the locale it means instead of inheriting one, and can run the same code as several devices. Calls that name a locale pass through untouched, which is what lets a spec tell the two formatters apart.

  - number-pad-reducer: en-US/de-DE/hi-IN assert literals, hi-IN grouping in lakhs so a swapped separator that kept en-US's pattern still fails; fr-FR and en-ZA read the separator from the same ICU data instead of hardcoding it, since CLDR moves those (fr-FR went U+00A0 -> U+202F, en-ZA is still on U+00A0)
  - conversion-details-screen: typing on a de-DE/hi-IN device pins down the split that is invisible on en-US — the focused field follows the device, the converted field stays "en-US"

Both suites pass under LC_ALL of en_ZA, de_DE, fr_FR and C. Pinning "en-US" in formatNumberPadNumber — the change this replaces — fails 8 reducer tests and both screen tests, so the new coverage bites.