### PR TITLE
refactor(schema-version): Introduce CURRENT_SCHEMA_VERSION instead of MAGIC Number.

### DIFF
--- a/__tests__/hooks/use-default-account-modal-shown.spec.ts
+++ b/__tests__/hooks/use-default-account-modal-shown.spec.ts
@@ -1,7 +1,10 @@
 import { act, renderHook } from "@testing-library/react-native"
 
 import { useDefaultAccountModalShown } from "@app/hooks/use-default-account-modal-shown"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const mockUpdateState = jest.fn()
 let mockPersistentState: PersistentState
@@ -14,7 +17,7 @@ jest.mock("@app/store/persistent-state", () => ({
 }))
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/hooks/use-dollar-balance-restricted.spec.ts
+++ b/__tests__/hooks/use-dollar-balance-restricted.spec.ts
@@ -2,7 +2,10 @@ import { renderHook } from "@testing-library/react-native"
 
 import { getStableTokenRestricted } from "@app/store/persistent-state/stable-token-restriction"
 import { getStablesatsRestricted } from "@app/store/persistent-state/stablesats-restriction"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
 const mockUseDeviceLocation = jest.fn()
@@ -48,7 +51,7 @@ import {
 } from "@app/hooks/use-dollar-balance-restricted"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/hooks/use-effective-display-currency.spec.ts
+++ b/__tests__/hooks/use-effective-display-currency.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react-native"
 
+import { CURRENT_SCHEMA_VERSION } from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
 const mockUseIsAuthed = jest.fn()
@@ -14,7 +15,7 @@ const mockUseAccountUpdateDisplayCurrencyMutation = jest.fn(
 )
 const mockUpdateState = jest.fn()
 let mockPersistentState = {
-  schemaVersion: 12,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: undefined as string | undefined,
@@ -51,7 +52,7 @@ describe("useEffectiveDisplayCurrency", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPersistentState = {
-      schemaVersion: 12,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
       activeAccountId: undefined,

--- a/__tests__/hooks/use-effective-language.spec.ts
+++ b/__tests__/hooks/use-effective-language.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from "@testing-library/react-native"
 
+import { CURRENT_SCHEMA_VERSION } from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
 const mockUseIsAuthed = jest.fn()
@@ -14,7 +15,7 @@ const mockUseUserUpdateLanguageMutation = jest.fn(
 )
 const mockUpdateState = jest.fn()
 let mockPersistentState = {
-  schemaVersion: 12,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
   activeAccountId: undefined as string | undefined,
@@ -47,7 +48,7 @@ describe("useEffectiveLanguage", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockPersistentState = {
-      schemaVersion: 12,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "",
       activeAccountId: undefined,

--- a/__tests__/hooks/use-show-warning-secure-account.spec.tsx
+++ b/__tests__/hooks/use-show-warning-secure-account.spec.tsx
@@ -13,18 +13,24 @@ import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { useShowWarningSecureAccount } from "@app/screens/settings-screen/account/show-warning-secure-account-hook"
 import { renderHook } from "@testing-library/react-hooks"
 
-jest.mock("@app/store/persistent-state", () => ({
-  ...jest.requireActual("@app/store/persistent-state"),
-  usePersistentStateContext: () => ({
-    persistentState: {
-      schemaVersion: 12,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
-    },
-    updateState: jest.fn(),
-    resetState: jest.fn(),
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    ...jest.requireActual("@app/store/persistent-state"),
+    usePersistentStateContext: () => ({
+      persistentState: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      },
+      updateState: jest.fn(),
+      resetState: jest.fn(),
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-account-registry", () => ({
   useAccountRegistry: () => ({

--- a/__tests__/hooks/use-transfer-blocked.spec.ts
+++ b/__tests__/hooks/use-transfer-blocked.spec.ts
@@ -1,6 +1,9 @@
 import { renderHook } from "@testing-library/react-native"
 
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { AccountType } from "@app/types/wallet"
 
 const mockUseDeviceLocation = jest.fn()
@@ -39,7 +42,7 @@ import {
 } from "@app/hooks/use-transfer-blocked"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/persistent-storage.spec.ts
+++ b/__tests__/persistent-storage.spec.ts
@@ -1,4 +1,5 @@
 import {
+  CURRENT_SCHEMA_VERSION,
   migratePersistentState,
   MigrationStatus,
 } from "../app/store/persistent-state/state-migrations"
@@ -33,7 +34,7 @@ it("migration from 5 to current returns ok with the migrated state", async () =>
   expect(result).toEqual({
     status: MigrationStatus.Ok,
     state: {
-      schemaVersion: 14,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "myToken",
     },

--- a/__tests__/screens/conversion-details-screen.spec.tsx
+++ b/__tests__/screens/conversion-details-screen.spec.tsx
@@ -33,18 +33,24 @@ import theme from "@app/rne-theme/theme"
 import { createCache } from "@app/graphql/cache"
 import { DisplayCurrency as DisplayCurrencyType } from "@app/types/amounts"
 
-jest.mock("@app/store/persistent-state", () => ({
-  ...jest.requireActual("@app/store/persistent-state"),
-  usePersistentStateContext: () => ({
-    persistentState: {
-      schemaVersion: 12,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
-    },
-    updateState: jest.fn(),
-    resetState: jest.fn(),
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    ...jest.requireActual("@app/store/persistent-state"),
+    usePersistentStateContext: () => ({
+      persistentState: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      },
+      updateState: jest.fn(),
+      resetState: jest.fn(),
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-account-registry", () => ({
   useAccountRegistry: () => ({

--- a/__tests__/screens/helper.tsx
+++ b/__tests__/screens/helper.tsx
@@ -14,12 +14,13 @@ import { createCache } from "../../app/graphql/cache"
 import { IsAuthedContextProvider } from "../../app/graphql/is-authed-context"
 import { AccountRegistryProvider } from "../../app/hooks/use-account-registry"
 import { PersistentStateContext } from "../../app/store/persistent-state"
+import { CURRENT_SCHEMA_VERSION } from "../../app/store/persistent-state/state-migrations"
 
 const PersistentStateWrapper: React.FC<PropsWithChildren> = ({ children }) => (
   <PersistentStateContext.Provider
     value={{
       persistentState: {
-        schemaVersion: 14,
+        schemaVersion: CURRENT_SCHEMA_VERSION,
         galoyInstance: {
           id: "Main",
         },

--- a/__tests__/screens/receive-self-custodial.spec.tsx
+++ b/__tests__/screens/receive-self-custodial.spec.tsx
@@ -25,6 +25,7 @@ import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 import { WalletCurrency } from "@app/graphql/generated"
 import ReceiveScreen from "@app/screens/receive-bitcoin-screen/receive-screen"
+import { CURRENT_SCHEMA_VERSION } from "@app/store/persistent-state/state-migrations"
 import {
   AccountType,
   ActiveWalletStatus,
@@ -307,7 +308,7 @@ const baseSelfCustodialWallet = {
 }
 
 const basePersistentState = {
-  schemaVersion: 8,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" as const },
   galoyAuthToken: "",
 }

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -30,18 +30,24 @@ const LightningLnURL = ({
   route: RouteProp<RootStackParamList, "sendBitcoinConfirmation">
 }) => <SendBitcoinConfirmationScreen route={route} />
 
-jest.mock("@app/store/persistent-state", () => ({
-  ...jest.requireActual("@app/store/persistent-state"),
-  usePersistentStateContext: () => ({
-    persistentState: {
-      schemaVersion: 12,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
-    },
-    updateState: jest.fn(),
-    resetState: jest.fn(),
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    ...jest.requireActual("@app/store/persistent-state"),
+    usePersistentStateContext: () => ({
+      persistentState: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      },
+      updateState: jest.fn(),
+      resetState: jest.fn(),
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-account-registry", () => ({
   AccountRegistryProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/__tests__/screens/send-details.spec.tsx
+++ b/__tests__/screens/send-details.spec.tsx
@@ -38,18 +38,24 @@ jest.mock("@react-navigation/native", () => ({
   }),
 }))
 
-jest.mock("@app/store/persistent-state", () => ({
-  ...jest.requireActual("@app/store/persistent-state"),
-  usePersistentStateContext: () => ({
-    persistentState: {
-      schemaVersion: 12,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
-    },
-    updateState: jest.fn(),
-    resetState: jest.fn(),
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    ...jest.requireActual("@app/store/persistent-state"),
+    usePersistentStateContext: () => ({
+      persistentState: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      },
+      updateState: jest.fn(),
+      resetState: jest.fn(),
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-account-registry", () => ({
   AccountRegistryProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
+++ b/__tests__/screens/settings-screen/skip-queries-when-unauthed.spec.tsx
@@ -83,18 +83,24 @@ jest.mock("@app/hooks/use-account-registry", () => ({
   }),
 }))
 
-jest.mock("@app/store/persistent-state", () => ({
-  ...jest.requireActual("@app/store/persistent-state"),
-  usePersistentStateContext: () => ({
-    persistentState: {
-      schemaVersion: 12,
-      galoyInstance: { id: "Main" },
-      galoyAuthToken: "",
-    },
-    updateState: jest.fn(),
-    resetState: jest.fn(),
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    ...jest.requireActual("@app/store/persistent-state"),
+    usePersistentStateContext: () => ({
+      persistentState: {
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        galoyInstance: { id: "Main" },
+        galoyAuthToken: "",
+      },
+      updateState: jest.fn(),
+      resetState: jest.fn(),
+    }),
+  }
+})
 
 jest.mock("@rn-vui/themed", () => ({
   ...jest.requireActual("@rn-vui/themed"),

--- a/__tests__/self-custodial/providers/wallet.spec.tsx
+++ b/__tests__/self-custodial/providers/wallet.spec.tsx
@@ -137,17 +137,23 @@ const mockUpdateState = jest.fn()
 const mockSaveToken = jest.fn()
 const mockState = { activeAccountId: undefined as string | undefined }
 
-jest.mock("@app/store/persistent-state", () => ({
-  usePersistentStateContext: () => ({
-    persistentState: {
-      activeAccountId: mockState.activeAccountId,
-      galoyAuthToken: "",
-      galoyInstance: { id: "Main" },
-      schemaVersion: 9,
-    },
-    updateState: mockUpdateState,
-  }),
-}))
+jest.mock("@app/store/persistent-state", () => {
+  const { CURRENT_SCHEMA_VERSION } = jest.requireActual<
+    typeof import("@app/store/persistent-state/state-migrations")
+  >("@app/store/persistent-state/state-migrations")
+
+  return {
+    usePersistentStateContext: () => ({
+      persistentState: {
+        activeAccountId: mockState.activeAccountId,
+        galoyAuthToken: "",
+        galoyInstance: { id: "Main" },
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      },
+      updateState: mockUpdateState,
+    }),
+  }
+})
 
 jest.mock("@app/hooks/use-app-config", () => ({
   useAppConfig: () => ({

--- a/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
+++ b/__tests__/store/persistent-state/default-account-modal-shown.spec.ts
@@ -2,11 +2,14 @@ import {
   getDefaultAccountModalShown,
   withDefaultAccountModalShown,
 } from "@app/store/persistent-state/default-account-modal-shown"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/index.spec.tsx
+++ b/__tests__/store/persistent-state/index.spec.tsx
@@ -6,7 +6,10 @@ import {
   PersistentStateProvider,
   PersistentStateContext,
 } from "@app/store/persistent-state"
-import { defaultPersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  defaultPersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const mockLoadJson = jest.fn()
 const mockSaveJson = jest.fn()
@@ -85,7 +88,7 @@ describe("PersistentStateProvider", () => {
     })
 
     expect(screen.getByTestId("token").props.children).toBe("saved-token")
-    expect(screen.getByTestId("schema").props.children).toBe(14)
+    expect(screen.getByTestId("schema").props.children).toBe(CURRENT_SCHEMA_VERSION)
   })
 
   it("falls back to default state when no persisted data exists", async () => {

--- a/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-default-currency.spec.ts
@@ -2,11 +2,14 @@ import {
   getSelfCustodialDefaultCurrency,
   withSelfCustodialDefaultCurrency,
 } from "@app/store/persistent-state/self-custodial-default-currency"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-display-currency.spec.ts
@@ -2,11 +2,14 @@ import {
   getSelfCustodialDisplayCurrency,
   withSelfCustodialDisplayCurrency,
 } from "@app/store/persistent-state/self-custodial-display-currency"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/self-custodial-language.spec.ts
+++ b/__tests__/store/persistent-state/self-custodial-language.spec.ts
@@ -2,11 +2,14 @@ import {
   getSelfCustodialLanguage,
   withSelfCustodialLanguage,
 } from "@app/store/persistent-state/self-custodial-language"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/stable-token-restriction.spec.ts
+++ b/__tests__/store/persistent-state/stable-token-restriction.spec.ts
@@ -2,10 +2,13 @@ import {
   getStableTokenRestricted,
   withStableTokenRestricted,
 } from "@app/store/persistent-state/stable-token-restriction"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/stable-token-transfer-block.spec.ts
+++ b/__tests__/store/persistent-state/stable-token-transfer-block.spec.ts
@@ -2,10 +2,13 @@ import {
   getStableTokenTransferBlocked,
   withStableTokenTransferBlocked,
 } from "@app/store/persistent-state/stable-token-transfer-block"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/stablesats-restriction.spec.ts
+++ b/__tests__/store/persistent-state/stablesats-restriction.spec.ts
@@ -2,10 +2,13 @@ import {
   getStablesatsRestricted,
   withStablesatsRestricted,
 } from "@app/store/persistent-state/stablesats-restriction"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/stablesats-transfer-block.spec.ts
+++ b/__tests__/store/persistent-state/stablesats-transfer-block.spec.ts
@@ -2,10 +2,13 @@ import {
   getStablesatsTransferBlocked,
   withStablesatsTransferBlocked,
 } from "@app/store/persistent-state/stablesats-transfer-block"
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -289,6 +289,28 @@ describe("state-migrations schema 10", () => {
     ).toBeUndefined()
   })
 
+  // Half of a version bump is invisible to the compiler: adding the type and
+  // moving the alias typechecks even if the new version is never registered in
+  // `stateMigrations`. The app would then write a version it cannot read back,
+  // and every launch would silently reset persisted state — auth token included.
+  it("reads back the state it writes: the current version has a registered migration", async () => {
+    const result = await migratePersistentState(defaultPersistentState)
+
+    expect(result.status).toBe(MigrationStatus.Ok)
+    if (result.status === MigrationStatus.Ok) {
+      expect(result.state).toEqual(defaultPersistentState)
+    }
+  })
+
+  it("registers nothing above the current version", async () => {
+    const result = await migratePersistentState({
+      ...defaultPersistentState,
+      schemaVersion: CURRENT_SCHEMA_VERSION + 1,
+    })
+
+    expect(result).toEqual({ status: MigrationStatus.NoData })
+  })
+
   it("attributes legacy 'USD' from schema 8 to the active self-custodial slot and clears the legacy field", async () => {
     const state8 = {
       schemaVersion: 8,

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -1,4 +1,5 @@
 import {
+  CURRENT_SCHEMA_VERSION,
   defaultPersistentState,
   migratePersistentState,
   MigrationStatus,
@@ -23,7 +24,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state6)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.galoyAuthToken).toBe("test-token")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -39,7 +40,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state7)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.activeAccountId).toBe("custodial-default")
   })
 
@@ -52,7 +53,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state5)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.galoyAuthToken).toBe("old-token")
     expect(result.activeAccountId).toBeUndefined()
   })
@@ -68,7 +69,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -89,7 +90,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "USD",
       "self-custodial-id-2": "BTC",
@@ -105,7 +106,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toBeUndefined()
     expect(result.selfCustodialLanguageByAccountId).toBeUndefined()
   })
@@ -128,7 +129,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state12)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDisplayCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "EUR",
       "self-custodial-id-2": "JPY",
@@ -153,7 +154,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state12)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.themeByAccountId).toEqual({
       "self-custodial-id-1": "dark",
       "self-custodial-id-2": "light",
@@ -174,24 +175,24 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state13)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.defaultAccountModalShownByAccountId).toEqual({
       "self-custodial-id-1": true,
       "self-custodial-id-2": false,
     })
   })
 
-  it("v14 identity migration preserves stablesatsRestrictedCustodial untouched", async () => {
-    const state14 = {
-      schemaVersion: 14,
+  it("identity migration at the current version preserves stablesatsRestrictedCustodial untouched", async () => {
+    const currentState = {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
       galoyInstance: { id: "Main" },
       galoyAuthToken: "token",
       stablesatsRestrictedCustodial: true,
     }
 
-    const result = await migrateAndGetPersistentState(state14)
+    const result = await migrateAndGetPersistentState(currentState)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.stablesatsRestrictedCustodial).toBe(true)
   })
 
@@ -204,7 +205,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state13)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.stablesatsRestrictedCustodial).toBeUndefined()
   })
 
@@ -244,7 +245,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state4)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.galoyAuthToken).toBe("token-v4")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
@@ -274,14 +275,14 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state3)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.galoyAuthToken).toBe("token-v3")
     expect(result.galoyInstance).toEqual({ id: "Main" })
     expect(result.activeAccountId).toBeUndefined()
   })
 
   it("default state has the current schema version", () => {
-    expect(defaultPersistentState.schemaVersion).toBe(14)
+    expect(defaultPersistentState.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(defaultPersistentState.activeAccountId).toBeUndefined()
     expect(
       defaultPersistentState.selfCustodialDefaultWalletCurrencyByAccountId,
@@ -299,7 +300,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "USD",
@@ -318,7 +319,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id": "BTC",
@@ -334,7 +335,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state8)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -349,7 +350,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state9)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -365,7 +366,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toBeUndefined()
   })
@@ -385,7 +386,7 @@ describe("state-migrations schema 10", () => {
 
     const result = await migrateAndGetPersistentState(state10)
 
-    expect(result.schemaVersion).toBe(14)
+    expect(result.schemaVersion).toBe(CURRENT_SCHEMA_VERSION)
     expect(result.selfCustodialDefaultWalletCurrency).toBeUndefined()
     expect(result.selfCustodialDefaultWalletCurrencyByAccountId).toEqual({
       "self-custodial-id-1": "BTC",

--- a/__tests__/store/persistent-state/state-migrations.spec.ts
+++ b/__tests__/store/persistent-state/state-migrations.spec.ts
@@ -1,6 +1,7 @@
 import {
   CURRENT_SCHEMA_VERSION,
   defaultPersistentState,
+  LATEST_REGISTERED_SCHEMA_VERSION,
   migratePersistentState,
   MigrationStatus,
   type PersistentState,
@@ -287,6 +288,23 @@ describe("state-migrations schema 10", () => {
     expect(
       defaultPersistentState.selfCustodialDefaultWalletCurrencyByAccountId,
     ).toBeUndefined()
+  })
+
+  // Half of a version bump is invisible to the compiler: adding the type and
+  // moving the alias typechecks even if the new version is never registered in
+  // `stateMigrations`. The app would then write a version it cannot read back,
+  // and every launch would silently reset persisted state — auth token included.
+  it("reads back the state it writes: the current version has a registered migration", async () => {
+    const result = await migratePersistentState(defaultPersistentState)
+
+    expect(result.status).toBe(MigrationStatus.Ok)
+    if (result.status === MigrationStatus.Ok) {
+      expect(result.state).toEqual(defaultPersistentState)
+    }
+  })
+
+  it("registers no migration newer than the current version", () => {
+    expect(LATEST_REGISTERED_SCHEMA_VERSION).toBe(CURRENT_SCHEMA_VERSION)
   })
 
   it("attributes legacy 'USD' from schema 8 to the active self-custodial slot and clears the legacy field", async () => {

--- a/__tests__/store/persistent-state/theme-preference.spec.ts
+++ b/__tests__/store/persistent-state/theme-preference.spec.ts
@@ -1,4 +1,7 @@
-import { PersistentState } from "@app/store/persistent-state/state-migrations"
+import {
+  CURRENT_SCHEMA_VERSION,
+  PersistentState,
+} from "@app/store/persistent-state/state-migrations"
 import {
   getThemePreference,
   withThemePreference,
@@ -6,7 +9,7 @@ import {
 import { DefaultAccountId } from "@app/types/wallet"
 
 const baseState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -261,9 +261,10 @@ const stateMigrations: StateMigrations = {
 export type PersistentState = PersistentState_14
 
 /**
- * The one place the current schema version is written down. Bumping
- * `PersistentState` above without bumping this fails to compile, and nothing
- * else — app code or tests — should spell the number out.
+ * The current schema version, written down once. Bumping `PersistentState`
+ * above without bumping this fails to compile. Outside the migration chain —
+ * where each step deliberately targets one specific version — nothing should
+ * spell the number out, tests included.
  */
 export const CURRENT_SCHEMA_VERSION: PersistentState["schemaVersion"] = 14
 

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -265,8 +265,21 @@ export type PersistentState = PersistentState_14
  * above without bumping this fails to compile. Outside the migration chain —
  * where each step deliberately targets one specific version — nothing should
  * spell the number out, tests included.
+ *
+ * The compiler cannot see the other half of a bump: registering the new
+ * version in `stateMigrations`. `state-migrations.spec.ts` pins that, since
+ * skipping it leaves the app writing a version it can no longer read back.
  */
 export const CURRENT_SCHEMA_VERSION: PersistentState["schemaVersion"] = 14
+
+/**
+ * Newest version `stateMigrations` can actually handle, derived from the map so
+ * it cannot drift on its own. Exported for the invariant in
+ * `state-migrations.spec.ts`: it must equal `CURRENT_SCHEMA_VERSION`.
+ */
+export const LATEST_REGISTERED_SCHEMA_VERSION = Math.max(
+  ...Object.keys(stateMigrations).map(Number),
+)
 
 export const defaultPersistentState: PersistentState = {
   schemaVersion: CURRENT_SCHEMA_VERSION,

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -265,6 +265,10 @@ export type PersistentState = PersistentState_14
  * above without bumping this fails to compile. Outside the migration chain —
  * where each step deliberately targets one specific version — nothing should
  * spell the number out, tests included.
+ *
+ * The compiler cannot see the other half of a bump: registering the new
+ * version in `stateMigrations`. `state-migrations.spec.ts` pins that, since
+ * skipping it leaves the app writing a version it can no longer read back.
  */
 export const CURRENT_SCHEMA_VERSION: PersistentState["schemaVersion"] = 14
 

--- a/app/store/persistent-state/state-migrations.ts
+++ b/app/store/persistent-state/state-migrations.ts
@@ -260,8 +260,15 @@ const stateMigrations: StateMigrations = {
 
 export type PersistentState = PersistentState_14
 
+/**
+ * The one place the current schema version is written down. Bumping
+ * `PersistentState` above without bumping this fails to compile, and nothing
+ * else — app code or tests — should spell the number out.
+ */
+export const CURRENT_SCHEMA_VERSION: PersistentState["schemaVersion"] = 14
+
 export const defaultPersistentState: PersistentState = {
-  schemaVersion: 14,
+  schemaVersion: CURRENT_SCHEMA_VERSION,
   galoyInstance: { id: "Main" },
   galoyAuthToken: "",
 }
@@ -288,8 +295,7 @@ export const migratePersistentState = async (
   if (!data || !(data.schemaVersion in stateMigrations)) {
     return { status: MigrationStatus.NoData }
   }
-  const schemaVersion: 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 =
-    data.schemaVersion
+  const schemaVersion: keyof StateMigrations = data.schemaVersion
   try {
     const migration = stateMigrations[schemaVersion]
     const state = await migration(data)


### PR DESCRIPTION
The current schema version was spelled out as a literal in 25 test files, so every bump meant editing all of them. Nothing forced them to keep up, and several had already drifted: mocked persistent states were still claiming schema 8, 9, and 12 while the real one was 14.

Export the version once, typed as PersistentState["schemaVersion"], so moving the PersistentState alias without bumping the constant is a compile error. Tests keep their own literal fixtures and take only the number from it. The jest.mock factories reach it via requireActual, since a hoisted factory cannot safely close over a module-scope import.

Also replaces the hand-written 3 | 4 | ... | 14 union in migratePersistentState with keyof StateMigrations, leaving the migrations map as the only list to maintain.

Historical inputs in the migration specs stay literal — those versions are the thing under test.