### PR TITLE
fix(home): Improve Account Switching functionality

### DIFF
--- a/__tests__/screens/home.spec.tsx
+++ b/__tests__/screens/home.spec.tsx
@@ -18,6 +18,7 @@ import {
 import { IsAuthedContextProvider } from "@app/graphql/is-authed-context"
 import { mockCurrencyList } from "@app/graphql/mocks"
 import { ConvertDirection } from "@app/types/payment"
+import { AccountStatus, AccountType, DefaultAccountId } from "@app/types/wallet"
 
 let currentMocks: MockedResponse[] = []
 
@@ -125,6 +126,68 @@ jest.mock("@app/hooks/use-transfer-blocked", () => ({
   useTransferBlocked: () => mockTransferBlockedOverride,
   useTransferBlockedSync: () => undefined,
 }))
+
+// eslint-disable-next-line prefer-const
+let mockAccountRegistryOverride: Record<string, unknown> | null = null
+
+/** Merged over the real registry (and always calling it) so the provider the screen
+ *  helper mounts keeps working and the hook order never changes between renders. */
+jest.mock("@app/hooks/use-account-registry", () => {
+  const actual = jest.requireActual<typeof import("@app/hooks/use-account-registry")>(
+    "@app/hooks/use-account-registry",
+  )
+  return {
+    ...actual,
+    useAccountRegistry: () => {
+      const real = actual.useAccountRegistry()
+      return mockAccountRegistryOverride
+        ? { ...real, ...mockAccountRegistryOverride }
+        : real
+    },
+  }
+})
+
+// eslint-disable-next-line prefer-const
+let mockUnseenTxOverride: {
+  hasUnseenBtcTx: boolean
+  hasUnseenUsdTx: boolean
+} | null = null
+
+jest.mock("@app/hooks/use-transaction-seen-state", () => {
+  const actual = jest.requireActual<
+    typeof import("@app/hooks/use-transaction-seen-state")
+  >("@app/hooks/use-transaction-seen-state")
+  return {
+    ...actual,
+    useTransactionSeenState: (
+      ...args: Parameters<typeof actual.useTransactionSeenState>
+    ) => {
+      const real = actual.useTransactionSeenState(...args)
+      return mockUnseenTxOverride ? { ...real, ...mockUnseenTxOverride } : real
+    },
+  }
+})
+
+const mockWalletOverviewProps = jest.fn<
+  void,
+  [{ showBtcNotification?: boolean; showUsdNotification?: boolean }]
+>()
+
+/** Passthrough spy: the real rows still render; the spy only records the per-account
+ *  notification props so the seen-state gating can be asserted. */
+jest.mock("@app/components/wallet-overview/wallet-overview", () => {
+  const ReactActual = jest.requireActual<typeof import("react")>("react")
+  const actual = jest.requireActual<
+    typeof import("@app/components/wallet-overview/wallet-overview")
+  >("@app/components/wallet-overview/wallet-overview")
+  return {
+    __esModule: true,
+    default: (props: React.ComponentProps<typeof actual.default>) => {
+      mockWalletOverviewProps(props)
+      return ReactActual.createElement(actual.default, props)
+    },
+  }
+})
 
 jest.mock("@app/hooks/use-dollar-balance-restricted", () => ({
   useDollarBalanceRestricted: () => mockDollarBalanceRestrictedOverride,
@@ -745,6 +808,8 @@ const runRestrictionInvariantCase = async ({
 const resetHomeScreenMocks = () => {
   currentMocks = []
   mockActiveWalletOverride = null
+  mockAccountRegistryOverride = null
+  mockUnseenTxOverride = null
   mockDollarBalanceRestrictedOverride = false
   mockMigratePromptVisible = false
   mockCanReopen = false
@@ -1930,6 +1995,221 @@ describe("HomeScreen layout under font scaling (blink-wip#931)", () => {
     expect(getByTestId("home-username").props.maxFontSizeMultiplier).toBeLessThanOrEqual(
       1.5,
     )
+  })
+})
+
+describe("HomeScreen account switching", () => {
+  const custodialAccount = {
+    id: DefaultAccountId.Custodial,
+    type: AccountType.Custodial,
+    label: "Blink",
+    selected: true,
+    status: AccountStatus.Available,
+  }
+
+  const selfCustodialAccount = {
+    id: "self-custodial-jurisdiction-b",
+    type: AccountType.SelfCustodial,
+    label: "satoshi@blink.sv",
+    selected: false,
+    status: AccountStatus.Available,
+  }
+
+  /** The switch has landed in the registry but Breez has not connected yet, so
+   *  `isSelfCustodial` is still false while the custodial session stays cached. This is
+   *  also the permanent state of an account whose mnemonic is missing from the keystore. */
+  const connectingSelfCustodialWallet = {
+    wallets: [],
+    status: "unavailable",
+    accountType: "self-custodial",
+    isReady: false,
+    isSelfCustodial: false,
+    needsBackendAuth: false,
+  }
+
+  const lastWalletOverviewProps = () => {
+    const calls = mockWalletOverviewProps.mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    return calls[calls.length - 1][0]
+  }
+
+  beforeEach(resetHomeScreenMocks)
+
+  it("keeps the previous account's balance off a self-custodial home while it connects", async () => {
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount, selfCustodialAccount],
+      activeAccount: selfCustodialAccount,
+    }
+    mockActiveWalletOverride = connectingSelfCustodialWallet
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 5000,
+    })
+
+    const { queryByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    // The custodial balance and identity belong to another account: show the
+    // skeleton until the self-custodial wallet reports its own.
+    expect(queryByTestId("balance-value")).toBeNull()
+    expect(queryByTestId("home-username")).toBeNull()
+  })
+
+  it("does not ask a connecting self-custodial account to create a Blink account", async () => {
+    mockActiveWalletOverride = connectingSelfCustodialWallet
+
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <IsAuthedContextProvider value={false}>
+          <HomeScreen />
+        </IsAuthedContextProvider>
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    fireEvent.press(getByTestId("receive"))
+
+    // A self-custodial account is unauthed by design — that is not a missing wallet.
+    expect(mockNavigate).toHaveBeenCalledWith("receiveBitcoin")
+  })
+
+  it("lets a trial custodial user reach the switcher when another account exists", async () => {
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount, selfCustodialAccount],
+      activeAccount: custodialAccount,
+    }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.Zero,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    await waitFor(() => expect(getByTestId("home-username")).toBeTruthy())
+    fireEvent.press(getByTestId("home-username"))
+
+    expect(mockNavigate).toHaveBeenCalledWith("profileScreen")
+  })
+
+  it("keeps the header inert when there is no other account to switch to", async () => {
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount],
+      activeAccount: custodialAccount,
+    }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.Zero,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    const { getByTestId } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    await waitFor(() => expect(getByTestId("home-username")).toBeTruthy())
+    fireEvent.press(getByTestId("home-username"))
+
+    expect(mockNavigate).not.toHaveBeenCalledWith("profileScreen")
+  })
+
+  it("closes a modal the previous account opened when the active account changes", async () => {
+    mockDollarBalanceRestrictedOverride = true
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount, selfCustodialAccount],
+      activeAccount: custodialAccount,
+    }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.Two,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    const { getByTestId, rerender } = render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    fireEvent.press(getByTestId("transfer"))
+    expect(mockDollarBalanceModalVisible).toBe(true)
+
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount, selfCustodialAccount],
+      activeAccount: selfCustodialAccount,
+    }
+    mockActiveWalletOverride = selfCustodialReadyWalletOverride(0)
+    rerender(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    // The screen survives the switch, so the restriction explanation opened for the
+    // custodial account must not carry over to the next one.
+    expect(mockDollarBalanceModalVisible).toBe(false)
+  })
+
+  it("keeps the custodial unseen-transaction dots off a self-custodial account", async () => {
+    /** The seen-state hook falls back to the custodial home cache whenever the
+     *  transaction list it is handed is empty — which it always is off the custodial
+     *  account — and keys "seen" on an empty account id shared by every self-custodial
+     *  account, so the home screen has to gate its result. */
+    mockUnseenTxOverride = { hasUnseenBtcTx: true, hasUnseenUsdTx: true }
+    mockAccountRegistryOverride = {
+      accounts: [custodialAccount, selfCustodialAccount],
+      activeAccount: selfCustodialAccount,
+    }
+    mockActiveWalletOverride = selfCustodialReadyWalletOverride(0)
+
+    render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(lastWalletOverviewProps().showBtcNotification).toBe(false)
+    expect(lastWalletOverviewProps().showUsdNotification).toBe(false)
+  })
+
+  it("still shows the unseen-transaction dots on the custodial account they belong to", async () => {
+    mockUnseenTxOverride = { hasUnseenBtcTx: true, hasUnseenUsdTx: true }
+    currentMocks = generateHomeMock({
+      level: AccountLevel.One,
+      network: Network.Mainnet,
+      btcBalance: 1000,
+      usdBalance: 0,
+    })
+
+    render(
+      <ContextForScreen>
+        <HomeScreen />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+
+    expect(lastWalletOverviewProps().showBtcNotification).toBe(true)
+    expect(lastWalletOverviewProps().showUsdNotification).toBe(true)
   })
 })
 

--- a/app/screens/home-screen/home-screen.tsx
+++ b/app/screens/home-screen/home-screen.tsx
@@ -213,14 +213,25 @@ export const HomeScreen: React.FC = () => {
 
   const isAuthed = useIsAuthed()
   const activeWallet = useActiveWallet()
-  const { isSelfCustodial } = activeWallet
+  /** Which account the home screen renders is decided by the registry descriptor, never
+   *  by the SDK connection: `activeWallet.isSelfCustodial` only turns true once Breez is
+   *  connected, so from the moment of a switch until the first successful connect — and
+   *  permanently for an account that cannot connect at all (mnemonic missing from the
+   *  keystore, stored network mismatch) — it still describes the *previous* account.
+   *  Gating on `accountType` is what the restriction and transfer-block policies already
+   *  do, and it keeps every account-scoped branch below agreeing with each other. */
+  const isCustodialAccount = activeWallet.accountType === AccountType.Custodial
+  const isSelfCustodialAccount = !isCustodialAccount
   useSelfCustodialNetworkMismatchToast()
   const {
     refreshWallets: refreshSelfCustodialWallets,
+    retry: retrySelfCustodialConnection,
+    sdk: selfCustodialSdk,
     isStableBalanceActive,
     lightningAddress: selfCustodialLightningAddress,
   } = useSelfCustodialWallet()
   const { accounts, activeAccount } = useAccountRegistry()
+  const activeAccountId = activeAccount?.id
   const hasMultipleAccounts = accounts.length > 1
   const { stableBalanceEnabled } = useFeatureFlags()
   const { mode: balanceMode, toggleMode: toggleBalanceMode } = useBalanceMode()
@@ -244,7 +255,7 @@ export const HomeScreen: React.FC = () => {
     error,
     refetch: refetchAuthed,
   } = useHomeAuthedQuery({
-    skip: !isAuthed || isSelfCustodial,
+    skip: !isAuthed || isSelfCustodialAccount,
     fetchPolicy: "network-only",
     errorPolicy: "all",
 
@@ -253,7 +264,7 @@ export const HomeScreen: React.FC = () => {
   })
 
   const { loading: loadingPrice, refetch: refetchRealtimePrice } = useRealtimePriceQuery({
-    skip: !isAuthed || isSelfCustodial,
+    skip: !isAuthed || isSelfCustodialAccount,
     fetchPolicy: "network-only",
 
     // this enables offline mode use-case
@@ -293,7 +304,7 @@ export const HomeScreen: React.FC = () => {
 
   // not loaded yet: no wallets while not ready (a loaded account keeps its balance
   // when a refresh goes offline, and a ready empty account shows zero, not a skeleton)
-  const queryLoading = isSelfCustodial
+  const queryLoading = isSelfCustodialAccount
     ? !activeWallet.isReady && activeWallet.wallets.length === 0
     : loadingAuthed || loadingPrice || loadingUnauthed || loadingSettings
 
@@ -303,17 +314,30 @@ export const HomeScreen: React.FC = () => {
   const selfCustodialUsername = extractLightningAddressUsername(
     selfCustodialLightningAddress,
   )
-  const usernameTitle = isSelfCustodial
+  const usernameTitle = isSelfCustodialAccount
     ? selfCustodialUsername ?? selfCustodialFallbackTitle
     : username || phone || LL.common.blinkUser()
-  const canSwitchAccount = isSelfCustodial ? hasMultipleAccounts : isAtLeastLevelOne
+  /** Anything the switcher can reach keeps the caret: gating the self-custodial side on
+   *  a live SDK used to hide it exactly when the user most needs it (an account that
+   *  fails to connect), stranding them on a screen with no way back to another account.
+   *  Level one still qualifies on its own — the custodial switcher also lists session
+   *  profiles, which the registry collapses into a single descriptor. */
+  const canSwitchAccount = hasMultipleAccounts || isAtLeastLevelOne
 
-  const wallets = isSelfCustodial
-    ? activeWallet.wallets.map((w) => ({
+  /** Memoized: an inline map would hand `useTotalBalance`, `WalletOverview` and the
+   *  wallet-count effect a new array on every render. */
+  const selfCustodialWallets = useMemo(
+    () =>
+      activeWallet.wallets.map((w) => ({
         id: w.id,
         balance: w.balance.amount,
         walletCurrency: w.walletCurrency,
-      }))
+      })),
+    [activeWallet.wallets],
+  )
+
+  const wallets = isSelfCustodialAccount
+    ? selfCustodialWallets
     : dataAuthed?.me?.defaultAccount?.wallets
 
   /**
@@ -323,7 +347,12 @@ export const HomeScreen: React.FC = () => {
    * Ref PR #3899.
    */
   const isCardBackendAvailable = galoyInstanceId === "Staging"
-  const { card: homeCard } = useCardData({ skip: !isCardBackendAvailable })
+  /** The card belongs to the custodial account, so it must not survive a switch: the
+   *  query is cache-first, and a self-custodial account would otherwise keep rendering
+   *  the previous account's card row under its own balances. */
+  const { card: homeCard } = useCardData({
+    skip: !isCardBackendAvailable || !isCustodialAccount,
+  })
   const hasCard = homeCard !== undefined && isCardUsable(homeCard.status)
   const cardLastFour = homeCard?.lastFour
 
@@ -336,7 +365,7 @@ export const HomeScreen: React.FC = () => {
   const loading = queryLoading || balanceConversionLoading
 
   const showStableBalanceToggle =
-    stableBalanceEnabled && isSelfCustodial && isStableBalanceActive
+    stableBalanceEnabled && isSelfCustodialAccount && isStableBalanceActive
 
   const { formatMoneyAmount } = useDisplayCurrency()
 
@@ -364,14 +393,23 @@ export const HomeScreen: React.FC = () => {
     return txs
   }, [pendingIncomingTransactions, transactionsEdges])
 
-  const { hasUnseenBtcTx, hasUnseenUsdTx, markTxSeen } = useTransactionSeenState(
-    accountId || "",
-    transactions,
-  )
+  const {
+    hasUnseenBtcTx: hasUnseenBtcTxForAccount,
+    hasUnseenUsdTx: hasUnseenUsdTxForAccount,
+    markTxSeen,
+  } = useTransactionSeenState(accountId || "", transactions)
+
+  /** Unseen-tx state is custodial-only: the hook falls back to the custodial home cache
+   *  whenever the transaction list it is handed is empty (which it always is off the
+   *  custodial account), and it would key the "seen" marker on an empty account id
+   *  shared by every self-custodial account. Left ungated, a self-custodial account
+   *  shows notification dots for the custodial account's transactions. */
+  const hasUnseenBtcTx = isCustodialAccount && hasUnseenBtcTxForAccount
+  const hasUnseenUsdTx = isCustodialAccount && hasUnseenUsdTxForAccount
 
   const { canShowUpgradeModal, markShownUpgradeModal } = useAutoShowUpgradeModal({
     cooldownDays: upgradeModalCooldownDays,
-    enabled: isAuthed && levelAccount === AccountLevel.Zero,
+    enabled: isAuthed && isCustodialAccount && levelAccount === AccountLevel.Zero,
   })
 
   const { latestUnseenTx, unseenAmountText, handleUnseenBadgePress, isOutgoing } =
@@ -405,6 +443,21 @@ export const HomeScreen: React.FC = () => {
   const [isStablesatModalVisible, setIsStablesatModalVisible] = React.useState(false)
   const [isUpgradeModalVisible, setIsUpgradeModalVisible] = React.useState(false)
   const [isRestrictionModalVisible, setIsRestrictionModalVisible] = React.useState(false)
+
+  /** The home screen outlives an account switch — the switcher only flips the active id —
+   *  so every modal it owns must close with the account that opened it, the same way the
+   *  forced-conversion latch resets. Otherwise the next account inherits a modal about
+   *  wallets, levels or restrictions that are not its own; the pending upgrade reopen is
+   *  cleared for the same reason, since it fires unconditionally on the next focus. */
+  React.useEffect(() => {
+    setModalVisible(false)
+    setIsStablesatModalVisible(false)
+    setIsUpgradeModalVisible(false)
+    setIsRestrictionModalVisible(false)
+    setSetDefaultAccountModalVisible(false)
+    reopenUpgradeModal.current = false
+  }, [activeAccountId])
+
   const isDollarBalanceRestricted = useDollarBalanceRestricted()
   useDollarBalanceRestrictionSync()
 
@@ -413,12 +466,11 @@ export const HomeScreen: React.FC = () => {
 
   const restrictedUsdWallet = getUsdWallet(dataAuthed?.me?.defaultAccount?.wallets)
   const restrictedBtcWallet = getBtcWallet(dataAuthed?.me?.defaultAccount?.wallets)
-  /** Balance and restriction policy must resolve for the SAME account type: right
-   *  after switching to self-custodial the SDK is still connecting (so
-   *  `isSelfCustodial` is false) while the restriction already applies the
-   *  self-custodial policy; reading the cached custodial balance in that window
-   *  would trigger the previous account's modal. */
-  const isCustodialAccount = activeWallet.accountType === AccountType.Custodial
+  /** Balance and restriction policy resolve for the SAME account type (see
+   *  `isCustodialAccount` above): right after switching to self-custodial the SDK is
+   *  still connecting while the restriction already applies the self-custodial policy,
+   *  and reading the cached custodial balance in that window would trigger the previous
+   *  account's modal. */
   const selfCustodialUsdWallet = activeWallet.wallets.find(
     (w) => w.walletCurrency === WalletCurrency.Usd,
   )
@@ -470,7 +522,8 @@ export const HomeScreen: React.FC = () => {
     isCustodialAccount && restrictedUsdWallet && restrictedBtcWallet
       ? { usdWalletId: restrictedUsdWallet.id, btcWalletId: restrictedBtcWallet.id }
       : null
-  const shouldShowStableTokenConvertModal = isSelfCustodial && isConvertModalVisible
+  const shouldShowStableTokenConvertModal =
+    isSelfCustodialAccount && isConvertModalVisible
 
   const { migrateNowPrompt, offboardBulletin, reminderBulletin, receiveBlocked } =
     useWindDownHomeNudges()
@@ -498,12 +551,14 @@ export const HomeScreen: React.FC = () => {
   }, [])
 
   const triggerUpgradeModal = React.useCallback(() => {
+    if (!isCustodialAccount) return
     if (!accountId || levelAccount !== AccountLevel.Zero) return
     if (!canShowUpgradeModal || satsBalance <= balanceLimitToTriggerUpgradeModal) return
 
     openUpgradeModal()
     markShownUpgradeModal()
   }, [
+    isCustodialAccount,
     accountId,
     levelAccount,
     canShowUpgradeModal,
@@ -514,8 +569,13 @@ export const HomeScreen: React.FC = () => {
   ])
 
   const refetch = React.useCallback(() => {
-    if (isSelfCustodial) {
-      refreshSelfCustodialWallets()
+    if (isSelfCustodialAccount) {
+      /** A refresh without a live SDK is a no-op, which would leave pull-to-refresh dead
+       *  on an account whose connect failed; reconnecting is the only recovery from
+       *  there. A connected-but-offline wallet still refreshes, so its retained balance
+       *  is never thrown away by a teardown. */
+      if (selfCustodialSdk) refreshSelfCustodialWallets()
+      else retrySelfCustodialConnection()
       return
     }
 
@@ -532,8 +592,10 @@ export const HomeScreen: React.FC = () => {
     })
   }, [
     isAuthed,
-    isSelfCustodial,
+    isSelfCustodialAccount,
+    selfCustodialSdk,
     refreshSelfCustodialWallets,
+    retrySelfCustodialConnection,
     refetchAuthed,
     refetchBulletins,
     refetchRealtimePrice,
@@ -544,13 +606,17 @@ export const HomeScreen: React.FC = () => {
   const numberOfTxs = transactions.length
 
   const onMenuClick = (target: Target) => {
-    if (!isSelfCustodial && !isAuthed) {
+    /** Only a custodial account can be missing a backend session. A self-custodial
+     *  account is unauthed by design (its Apollo token is empty), so keying this on the
+     *  SDK connection turned every home action into a "create an account" prompt while
+     *  the wallet was still connecting. */
+    if (isCustodialAccount && !isAuthed) {
       setModalVisible(true)
       return
     }
 
     if (
-      !isSelfCustodial &&
+      isCustodialAccount &&
       !isDollarBalanceRestricted &&
       target === "receiveBitcoin" &&
       !defaultAccountModalShown &&
@@ -572,17 +638,17 @@ export const HomeScreen: React.FC = () => {
   // debug code. verify that we have 2 wallets. mobile doesn't work well with only one wallet
   // TODO: add this code in a better place
   React.useEffect(() => {
-    if (isSelfCustodial) return
+    if (!isCustodialAccount) return
     if (wallets?.length !== undefined && wallets?.length !== 2) {
       Alert.alert(LL.HomeScreen.walletCountNotTwo())
     }
-  }, [wallets, LL, isSelfCustodial])
+  }, [wallets, LL, isCustodialAccount])
 
   // Trigger the upgrade trial account modal
   useFocusEffect(
     React.useCallback(() => {
       if (reopenUpgradeModal.current) {
-        openUpgradeModal()
+        if (isCustodialAccount) openUpgradeModal()
         reopenUpgradeModal.current = false
         return
       }
@@ -592,7 +658,7 @@ export const HomeScreen: React.FC = () => {
       }, UPGRADE_MODAL_INITIAL_DELAY_MS)
 
       return () => clearTimeout(id)
-    }, [openUpgradeModal, triggerUpgradeModal]),
+    }, [isCustodialAccount, openUpgradeModal, triggerUpgradeModal]),
   )
 
   type Target =
@@ -631,7 +697,7 @@ export const HomeScreen: React.FC = () => {
   ]
 
   const passesIosGate =
-    isSelfCustodial ||
+    isSelfCustodialAccount ||
     !isIos ||
     dataUnauthed?.globals?.network !== "mainnet" ||
     levelAccount === AccountLevel.Two ||
@@ -693,7 +759,7 @@ export const HomeScreen: React.FC = () => {
       <StableSatsModal
         isVisible={isStablesatModalVisible}
         setIsVisible={setIsStablesatModalVisible}
-        variant={isSelfCustodial ? "selfCustodial" : "custodial"}
+        variant={isSelfCustodialAccount ? "selfCustodial" : "custodial"}
       />
       <TrialAccountLimitsModal
         isVisible={isUpgradeModalVisible}
@@ -830,7 +896,7 @@ export const HomeScreen: React.FC = () => {
             </React.Fragment>
           ))}
         </View>
-        {isSelfCustodial && <UnclaimedDepositBanner />}
+        {isSelfCustodialAccount && <UnclaimedDepositBanner />}
         <NetworkStatusBanner />
         {shouldShowBanner && <BackupNudgeBanner onDismiss={dismissBanner} />}
         {offboardBulletin.isVisible && <OffboardOnlyBulletin />}

--- a/app/self-custodial/hooks/use-sdk-lifecycle.ts
+++ b/app/self-custodial/hooks/use-sdk-lifecycle.ts
@@ -179,12 +179,17 @@ export const useSdkLifecycle = (
       setStatus(ActiveWalletStatus.Unavailable)
       setWallets([])
       setAllTransactions([])
+      // Stable Balance is per-account user settings read from the connected SDK, so it
+      // is cleared alongside the wallets: keeping the previous account's value shows the
+      // home balance toggle on an account that never enabled it.
+      setSdkStableBalanceActive(undefined)
       return
     }
 
     setStatus(ActiveWalletStatus.Loading)
     setWallets([])
     setAllTransactions([])
+    setSdkStableBalanceActive(undefined)
 
     let mounted = true
     abortRef.current = false


### PR DESCRIPTION
`activeWallet.isSelfCustodial` means "the Breez SDK is connected", not "this account is self-custodial": it stays false from the moment a switch lands until the first successful connect, and permanently for an account that cannot connect at all (mnemonic missing from the keystore, stored-network mismatch). Every home branch keyed on it therefore rendered the *previous* account in that window. The restriction and transfer-block policies already gate on `accountType`; home now does the same everywhere, which fixes:

- the previous account's balance, wallets, username and transactions rendering under a self-custodial account (and a hard $0.00 once the Apollo token clears)
- home actions opening the "log in or create account" modal on a self-custodial account, which is unauthed by design
- the switcher caret disappearing for a level-zero custodial user who has other accounts, and for a self-custodial account that failed to connect
- unseen-tx dots derived from the custodial cache, marked seen under an empty account id shared by every self-custodial account
- modals (restriction, StableSats, upgrade, set-default) and the pending upgrade reopen surviving a switch into the next account
- the custodial card row and the trial-upgrade modal following the user across
- pull-to-refresh being a no-op after a failed switch: it now reconnects when no SDK is up, while a connected-but-offline wallet still refreshes

`sdkStableBalanceActive` was the only SDK state left uncleared on an account change, so the balance-mode toggle carried over until getUserSettings resolved.