### PR TITLE
fix(notifications): wrap notification history text inside screen bounds

### DIFF
--- a/__tests__/screens/notification-history-screen/helpers.ts
+++ b/__tests__/screens/notification-history-screen/helpers.ts
@@ -1,0 +1,10 @@
+import { Icon } from "@app/graphql/generated"
+
+/**
+ * An icon the backend can send but the app ships no asset for.
+ *
+ * Declared once so the guard in `utils.spec.ts`, which asserts it really is unmapped,
+ * keeps every spec that renders it honest. Two copies could drift, and the day a rocket
+ * asset lands only the copy next to the guard would notice.
+ */
+export const UNMAPPED_ICON = "ROCKET" as Icon

--- a/__tests__/screens/notification-history-screen/notification.spec.tsx
+++ b/__tests__/screens/notification-history-screen/notification.spec.tsx
@@ -12,6 +12,8 @@ import { Notification } from "@app/screens/notification-history-screen/notificat
 
 import { findPressableParent } from "../helper"
 
+import { UNMAPPED_ICON } from "./helpers"
+
 /**
  * `timeAgo` reads the wall clock, so the relative-time assertion only stays
  * stable if both the clock and the notification timestamp are pinned.
@@ -19,9 +21,6 @@ import { findPressableParent } from "../helper"
 const FIXED_NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0)
 const THIRTY_SECONDS_AGO = Math.floor(FIXED_NOW_MS / 1000) - 30
 const ACKNOWLEDGED_AT = Math.floor(FIXED_NOW_MS / 1000) - 60
-
-/** An icon the backend can send but the app ships no asset for. */
-const UNMAPPED_ICON = "ROCKET" as Icon
 
 const makeNotification = (
   overrides: Partial<StatefulNotification> = {},
@@ -100,7 +99,7 @@ describe("Notification", () => {
     )
 
     expect(getByTestId("notification-default-icon")).toBeTruthy()
-    expect(queryByTestId("icon-rocket")).toBeNull()
+    expect(queryByTestId(`icon-${UNMAPPED_ICON.toLowerCase()}`)).toBeNull()
   })
 
   it("renders unacknowledged text and icon in the primary color", () => {

--- a/__tests__/screens/notification-history-screen/notification.spec.tsx
+++ b/__tests__/screens/notification-history-screen/notification.spec.tsx
@@ -68,6 +68,14 @@ describe("Notification", () => {
     expect(getByTestId("galoy-icon-bell")).toBeTruthy()
   })
 
+  it("maps every underscore of the icon enum to the dashed icon name", () => {
+    const { getByTestId } = renderNotification(
+      makeNotification({ icon: Icon.WarningWithBackground }),
+    )
+
+    expect(getByTestId("galoy-icon-warning-with-background")).toBeTruthy()
+  })
+
   it("falls back to the default ionicon when the notification has no icon", () => {
     const { queryAllByTestId } = renderNotification(makeNotification())
 

--- a/__tests__/screens/notification-history-screen/notification.spec.tsx
+++ b/__tests__/screens/notification-history-screen/notification.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Linking, StyleSheet, View } from "react-native"
+import { Linking, StyleSheet } from "react-native"
 import { fireEvent, render } from "@testing-library/react-native"
 
 import { ThemeProvider } from "@rn-vui/themed"
@@ -12,9 +12,16 @@ import { Notification } from "@app/screens/notification-history-screen/notificat
 
 import { findPressableParent } from "../helper"
 
-jest.mock("@app/components/atomic/galoy-icon", () => ({
-  GaloyIcon: ({ name }: { name: string }) => <View testID={`galoy-icon-${name}`} />,
-}))
+/**
+ * `timeAgo` reads the wall clock, so the relative-time assertion only stays
+ * stable if both the clock and the notification timestamp are pinned.
+ */
+const FIXED_NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0)
+const THIRTY_SECONDS_AGO = Math.floor(FIXED_NOW_MS / 1000) - 30
+const ACKNOWLEDGED_AT = Math.floor(FIXED_NOW_MS / 1000) - 60
+
+/** An icon the backend can send but the app ships no asset for. */
+const UNMAPPED_ICON = "ROCKET" as Icon
 
 const makeNotification = (
   overrides: Partial<StatefulNotification> = {},
@@ -23,7 +30,7 @@ const makeNotification = (
   id: "notification-1",
   title: "Self-custodial accounts have arrived",
   body: "Move your funds to a wallet where only you hold the keys.",
-  createdAt: Math.floor(Date.now() / 1000) - 30,
+  createdAt: THIRTY_SECONDS_AGO,
   acknowledgedAt: null,
   bulletinEnabled: false,
   icon: null,
@@ -41,7 +48,12 @@ const renderNotification = (notification: StatefulNotification) =>
 describe("Notification", () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers({ now: FIXED_NOW_MS })
     jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it("renders title, body and relative time", () => {
@@ -65,32 +77,42 @@ describe("Notification", () => {
   it("renders the mapped galoy icon when the notification has one", () => {
     const { getByTestId } = renderNotification(makeNotification({ icon: Icon.Bell }))
 
-    expect(getByTestId("galoy-icon-bell")).toBeTruthy()
+    expect(getByTestId("icon-bell")).toBeTruthy()
   })
 
-  it("maps every underscore of the icon enum to the dashed icon name", () => {
+  it("maps every underscore of the icon enum to an icon that has an asset", () => {
     const { getByTestId } = renderNotification(
       makeNotification({ icon: Icon.WarningWithBackground }),
     )
 
-    expect(getByTestId("galoy-icon-warning-with-background")).toBeTruthy()
+    expect(getByTestId("icon-warning-with-background")).toBeTruthy()
   })
 
   it("falls back to the default ionicon when the notification has no icon", () => {
-    const { queryAllByTestId } = renderNotification(makeNotification())
+    const { getByTestId } = renderNotification(makeNotification())
 
-    expect(queryAllByTestId(/^galoy-icon-/)).toHaveLength(0)
+    expect(getByTestId("notification-default-icon")).toBeTruthy()
   })
 
-  it("renders unacknowledged text in the primary color", () => {
-    const notification = makeNotification()
-    const { getByText } = renderNotification(notification)
+  it("falls back to the default ionicon when the icon has no asset", () => {
+    const { getByTestId, queryByTestId } = renderNotification(
+      makeNotification({ icon: UNMAPPED_ICON }),
+    )
+
+    expect(getByTestId("notification-default-icon")).toBeTruthy()
+    expect(queryByTestId("icon-rocket")).toBeNull()
+  })
+
+  it("renders unacknowledged text and icon in the primary color", () => {
+    const notification = makeNotification({ icon: Icon.Bell })
+    const { getByText, getByTestId } = renderNotification(notification)
 
     expect(getByText(notification.body)).toHaveStyle({ color: light.black })
+    expect(getByTestId("icon-bell").props.color).toBe(light.black)
   })
 
   it("renders acknowledged text greyed out", () => {
-    const notification = makeNotification({ acknowledgedAt: 1700000000 })
+    const notification = makeNotification({ acknowledgedAt: ACKNOWLEDGED_AT })
     const { getByText } = renderNotification(notification)
 
     expect(getByText(notification.body)).toHaveStyle({ color: light.grey2 })
@@ -99,11 +121,11 @@ describe("Notification", () => {
   it("greys out the icon variant once acknowledged", () => {
     const notification = makeNotification({
       icon: Icon.Bell,
-      acknowledgedAt: 1700000000,
+      acknowledgedAt: ACKNOWLEDGED_AT,
     })
-    const { getByText } = renderNotification(notification)
+    const { getByTestId } = renderNotification(notification)
 
-    expect(getByText(notification.body)).toHaveStyle({ color: light.grey2 })
+    expect(getByTestId("icon-bell").props.color).toBe(light.grey2)
   })
 
   it("greys out the text when acknowledgedAt arrives after mount", () => {
@@ -114,7 +136,7 @@ describe("Notification", () => {
 
     rerender(
       <ThemeProvider theme={theme}>
-        <Notification {...notification} acknowledgedAt={1700000000} />
+        <Notification {...notification} acknowledgedAt={ACKNOWLEDGED_AT} />
       </ThemeProvider>,
     )
 

--- a/__tests__/screens/notification-history-screen/notification.spec.tsx
+++ b/__tests__/screens/notification-history-screen/notification.spec.tsx
@@ -1,0 +1,154 @@
+import * as React from "react"
+import { Linking, StyleSheet, View } from "react-native"
+import { fireEvent, render } from "@testing-library/react-native"
+
+import { ThemeProvider } from "@rn-vui/themed"
+
+import { BLINK_DEEP_LINK_PREFIX } from "@app/config"
+import { Icon, StatefulNotification } from "@app/graphql/generated"
+import { light } from "@app/rne-theme/colors"
+import theme from "@app/rne-theme/theme"
+import { Notification } from "@app/screens/notification-history-screen/notification"
+
+import { findPressableParent } from "../helper"
+
+jest.mock("@app/components/atomic/galoy-icon", () => ({
+  GaloyIcon: ({ name }: { name: string }) => <View testID={`galoy-icon-${name}`} />,
+}))
+
+const makeNotification = (
+  overrides: Partial<StatefulNotification> = {},
+): StatefulNotification => ({
+  __typename: "StatefulNotification",
+  id: "notification-1",
+  title: "Self-custodial accounts have arrived",
+  body: "Move your funds to a wallet where only you hold the keys.",
+  createdAt: Math.floor(Date.now() / 1000) - 30,
+  acknowledgedAt: null,
+  bulletinEnabled: false,
+  icon: null,
+  action: null,
+  ...overrides,
+})
+
+const renderNotification = (notification: StatefulNotification) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <Notification {...notification} />
+    </ThemeProvider>,
+  )
+
+describe("Notification", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(Linking, "openURL").mockResolvedValue(undefined)
+  })
+
+  it("renders title, body and relative time", () => {
+    const notification = makeNotification()
+    const { getByText } = renderNotification(notification)
+
+    expect(getByText(notification.title)).toBeTruthy()
+    expect(getByText(notification.body)).toBeTruthy()
+    expect(getByText("a few seconds ago")).toBeTruthy()
+  })
+
+  it("constrains the text column to the row width so long text wraps", () => {
+    const { getByTestId } = renderNotification(makeNotification())
+
+    const contentStyle = StyleSheet.flatten(
+      getByTestId("notification-content").props.style,
+    )
+    expect(contentStyle).toMatchObject({ flex: 1 })
+  })
+
+  it("renders the mapped galoy icon when the notification has one", () => {
+    const { getByTestId } = renderNotification(makeNotification({ icon: Icon.Bell }))
+
+    expect(getByTestId("galoy-icon-bell")).toBeTruthy()
+  })
+
+  it("falls back to the default ionicon when the notification has no icon", () => {
+    const { queryAllByTestId } = renderNotification(makeNotification())
+
+    expect(queryAllByTestId(/^galoy-icon-/)).toHaveLength(0)
+  })
+
+  it("renders unacknowledged text in the primary color", () => {
+    const notification = makeNotification()
+    const { getByText } = renderNotification(notification)
+
+    expect(getByText(notification.body)).toHaveStyle({ color: light.black })
+  })
+
+  it("renders acknowledged text greyed out", () => {
+    const notification = makeNotification({ acknowledgedAt: 1700000000 })
+    const { getByText } = renderNotification(notification)
+
+    expect(getByText(notification.body)).toHaveStyle({ color: light.grey2 })
+  })
+
+  it("greys out the icon variant once acknowledged", () => {
+    const notification = makeNotification({
+      icon: Icon.Bell,
+      acknowledgedAt: 1700000000,
+    })
+    const { getByText } = renderNotification(notification)
+
+    expect(getByText(notification.body)).toHaveStyle({ color: light.grey2 })
+  })
+
+  it("greys out the text when acknowledgedAt arrives after mount", () => {
+    const notification = makeNotification()
+    const { getByText, rerender } = renderNotification(notification)
+
+    expect(getByText(notification.body)).toHaveStyle({ color: light.black })
+
+    rerender(
+      <ThemeProvider theme={theme}>
+        <Notification {...notification} acknowledgedAt={1700000000} />
+      </ThemeProvider>,
+    )
+
+    expect(getByText(notification.body)).toHaveStyle({ color: light.grey2 })
+  })
+
+  it("opens the blink deep link when pressed with a deep link action", () => {
+    const notification = makeNotification({
+      action: {
+        __typename: "OpenDeepLinkAction",
+        deepLink: "/settings",
+        label: "Open settings",
+      },
+    })
+    const { getByText } = renderNotification(notification)
+
+    fireEvent.press(findPressableParent(getByText(notification.title)))
+
+    expect(Linking.openURL).toHaveBeenCalledWith(`${BLINK_DEEP_LINK_PREFIX}/settings`)
+  })
+
+  it("opens the external url when pressed with an external link action", () => {
+    const notification = makeNotification({
+      action: {
+        __typename: "OpenExternalLinkAction",
+        url: "https://www.blink.sv",
+        label: "Learn more",
+      },
+    })
+    const { getByText } = renderNotification(notification)
+
+    fireEvent.press(findPressableParent(getByText(notification.title)))
+
+    expect(Linking.openURL).toHaveBeenCalledWith("https://www.blink.sv")
+  })
+
+  it("does not open anything when pressed without an action", () => {
+    const notification = makeNotification()
+    const { getByText } = renderNotification(notification)
+
+    fireEvent.press(findPressableParent(getByText(notification.title)))
+
+    expect(Linking.openURL).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/screens/notification-history-screen/utils.spec.ts
+++ b/__tests__/screens/notification-history-screen/utils.spec.ts
@@ -1,0 +1,73 @@
+import { icons } from "@app/components/atomic/galoy-icon"
+import { Icon } from "@app/graphql/generated"
+import { timeAgo, toGaloyIconName } from "@app/screens/notification-history-screen/utils"
+
+/** An icon the backend can send but the app ships no asset for. */
+const UNMAPPED_ICON = "ROCKET" as Icon
+
+/** `timeAgo` reads the wall clock, so both ends of the diff have to be pinned. */
+const FIXED_NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0)
+const FIXED_NOW_SECONDS = Math.floor(FIXED_NOW_MS / 1000)
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
+const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
+
+describe("toGaloyIconName", () => {
+  it("resolves every backend icon to an asset the app ships", () => {
+    const unresolved = Object.values(Icon).filter((icon) => !toGaloyIconName(icon))
+
+    expect(unresolved).toEqual([])
+  })
+
+  it("replaces every underscore of the enum value", () => {
+    expect(toGaloyIconName(Icon.WarningWithBackground)).toBe("warning-with-background")
+    expect(toGaloyIconName(Icon.CloseCrossWithBackground)).toBe(
+      "close-cross-with-background",
+    )
+  })
+
+  it("returns the mapped name for a single word enum value", () => {
+    expect(toGaloyIconName(Icon.Bell)).toBe("bell")
+  })
+
+  it("returns undefined for an icon the app has no asset for", () => {
+    expect(UNMAPPED_ICON.toLowerCase() in icons).toBe(false)
+    expect(toGaloyIconName(UNMAPPED_ICON)).toBeUndefined()
+  })
+
+  it("returns undefined when the notification carries no icon", () => {
+    expect(toGaloyIconName(null)).toBeUndefined()
+    expect(toGaloyIconName(undefined)).toBeUndefined()
+  })
+})
+
+describe("timeAgo", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: FIXED_NOW_MS })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const secondsAgo = (seconds: number) => FIXED_NOW_SECONDS - seconds
+
+  it("reports a sub minute difference without a unit", () => {
+    expect(timeAgo(secondsAgo(30))).toBe("a few seconds ago")
+  })
+
+  it("singularizes and pluralizes minutes", () => {
+    expect(timeAgo(secondsAgo(SECONDS_PER_MINUTE))).toBe("1 minute ago")
+    expect(timeAgo(secondsAgo(5 * SECONDS_PER_MINUTE))).toBe("5 minutes ago")
+  })
+
+  it("singularizes and pluralizes hours", () => {
+    expect(timeAgo(secondsAgo(SECONDS_PER_HOUR))).toBe("1 hour ago")
+    expect(timeAgo(secondsAgo(3 * SECONDS_PER_HOUR))).toBe("3 hours ago")
+  })
+
+  it("singularizes and pluralizes days", () => {
+    expect(timeAgo(secondsAgo(SECONDS_PER_DAY))).toBe("1 day ago")
+    expect(timeAgo(secondsAgo(4 * SECONDS_PER_DAY))).toBe("4 days ago")
+  })
+})

--- a/__tests__/screens/notification-history-screen/utils.spec.ts
+++ b/__tests__/screens/notification-history-screen/utils.spec.ts
@@ -2,8 +2,7 @@ import { icons } from "@app/components/atomic/galoy-icon"
 import { Icon } from "@app/graphql/generated"
 import { timeAgo, toGaloyIconName } from "@app/screens/notification-history-screen/utils"
 
-/** An icon the backend can send but the app ships no asset for. */
-const UNMAPPED_ICON = "ROCKET" as Icon
+import { UNMAPPED_ICON } from "./helpers"
 
 /** `timeAgo` reads the wall clock, so both ends of the diff have to be pinned. */
 const FIXED_NOW_MS = Date.UTC(2026, 0, 15, 12, 0, 0)
@@ -13,12 +12,6 @@ const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
 
 describe("toGaloyIconName", () => {
-  it("resolves every backend icon to an asset the app ships", () => {
-    const unresolved = Object.values(Icon).filter((icon) => !toGaloyIconName(icon))
-
-    expect(unresolved).toEqual([])
-  })
-
   it("replaces every underscore of the enum value", () => {
     expect(toGaloyIconName(Icon.WarningWithBackground)).toBe("warning-with-background")
     expect(toGaloyIconName(Icon.CloseCrossWithBackground)).toBe(

--- a/app/screens/notification-history-screen/notification.tsx
+++ b/app/screens/notification-history-screen/notification.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from "react"
 import { StatefulNotification } from "@app/graphql/generated"
 import { Icon, Text, makeStyles, useTheme } from "@rn-vui/themed"
 import { View, Linking } from "react-native"
-import { timeAgo } from "./utils"
+import { timeAgo, toGaloyIconName } from "./utils"
 import { TouchableWithoutFeedback } from "react-native-gesture-handler"
 import { BLINK_DEEP_LINK_PREFIX } from "@app/config"
-import { GaloyIcon, IconNamesType } from "@app/components/atomic/galoy-icon"
+import { GaloyIcon } from "@app/components/atomic/galoy-icon"
 
 export const Notification: React.FC<StatefulNotification> = ({
   title,
@@ -27,6 +27,9 @@ export const Notification: React.FC<StatefulNotification> = ({
     }
   }, [acknowledgedAt, isAcknowledged])
 
+  const iconName = toGaloyIconName(icon)
+  const iconColor = isAcknowledged ? colors.grey2 : colors.black
+
   return (
     <TouchableWithoutFeedback
       onPress={() => {
@@ -37,18 +40,15 @@ export const Notification: React.FC<StatefulNotification> = ({
       }}
     >
       <View style={styles.container}>
-        {icon ? (
-          <GaloyIcon
-            name={icon.toLowerCase().replace(/_/g, "-") as IconNamesType}
-            color={isAcknowledged ? colors.grey2 : colors.black}
-            size={26}
-          />
+        {iconName ? (
+          <GaloyIcon name={iconName} color={iconColor} size={26} />
         ) : (
           <Icon
             type="ionicon"
             name="notifications-outline"
-            color={isAcknowledged ? colors.grey2 : colors.black}
+            color={iconColor}
             size={26}
+            testID="notification-default-icon"
           />
         )}
         <View style={styles.content} testID="notification-content">

--- a/app/screens/notification-history-screen/notification.tsx
+++ b/app/screens/notification-history-screen/notification.tsx
@@ -39,7 +39,7 @@ export const Notification: React.FC<StatefulNotification> = ({
       <View style={styles.container}>
         {icon ? (
           <GaloyIcon
-            name={icon?.toLowerCase().replace("_", "-") as IconNamesType}
+            name={icon.toLowerCase().replace("_", "-") as IconNamesType}
             color={isAcknowledged ? colors.grey2 : colors.black}
             size={26}
           />
@@ -51,7 +51,7 @@ export const Notification: React.FC<StatefulNotification> = ({
             size={26}
           />
         )}
-        <View>
+        <View style={styles.content} testID="notification-content">
           <Text type="p2" style={styles.text}>
             {title}
           </Text>
@@ -77,6 +77,13 @@ const useStyles = makeStyles(
       flexDirection: "row",
       columnGap: 12,
       alignItems: "center",
+    },
+    /**
+     * Without flex: 1 the text column sizes to its content inside the row,
+     * pushing long titles and bodies past the screen edge instead of wrapping.
+     */
+    content: {
+      flex: 1,
     },
     text: {
       color: isAcknowledged ? colors.grey2 : colors.black,

--- a/app/screens/notification-history-screen/notification.tsx
+++ b/app/screens/notification-history-screen/notification.tsx
@@ -39,7 +39,7 @@ export const Notification: React.FC<StatefulNotification> = ({
       <View style={styles.container}>
         {icon ? (
           <GaloyIcon
-            name={icon.toLowerCase().replace("_", "-") as IconNamesType}
+            name={icon.toLowerCase().replace(/_/g, "-") as IconNamesType}
             color={isAcknowledged ? colors.grey2 : colors.black}
             size={26}
           />

--- a/app/screens/notification-history-screen/utils.ts
+++ b/app/screens/notification-history-screen/utils.ts
@@ -1,3 +1,23 @@
+import { IconNamesType, icons } from "@app/components/atomic/galoy-icon"
+import { Icon } from "@app/graphql/generated"
+
+const isMappedIconName = (name: string): name is IconNamesType => name in icons
+
+/**
+ * The backend icon enum and the app icon map are maintained separately, so a
+ * value the app ships no asset for would reach `GaloyIcon`, miss both of its
+ * maps and render an empty slot. Returning undefined for unmapped names keeps
+ * the default ionicon as the single fallback for unknown icons.
+ */
+export const toGaloyIconName = (icon?: Icon | null): IconNamesType | undefined => {
+  if (!icon) {
+    return undefined
+  }
+
+  const derivedName = icon.toLowerCase().replace(/_/g, "-")
+  return isMappedIconName(derivedName) ? derivedName : undefined
+}
+
 export const timeAgo = (pastDate: number): string => {
   const now = new Date()
   const past = new Date(pastDate * 1000)


### PR DESCRIPTION
## Summary

Notification history items render an icon and a text column inside a `flexDirection: "row"` container, but the text column had no width constraint. Long titles and bodies (like the "Time to move to non-custodial" and "Self-custodial accounts have arrived" bulletins) sized to their content and ran past the right edge of the screen, getting clipped instead of wrapping.

This constrains the text column with `flex: 1` so it takes the remaining row width and long text wraps within screen bounds.

Closes blinkbitcoin/blink-wip#946

## Changes

- `app/screens/notification-history-screen/notification.tsx`: add `flex: 1` to the text column, plus a `testID` used by the regression test, and drop an optional chain on `icon` that is unreachable inside the icon-present branch.
- `app/screens/notification-history-screen/notification.tsx`: map icon enum values with `replace(/_/g, "-")` instead of single-occurrence `replace("_", "-")` — multi-underscore values (`CLOSE_CROSS_WITH_BACKGROUND`, `WARNING_WITH_BACKGROUND`) previously produced names missing from the GaloyIcon map and rendered no icon.
- `__tests__/screens/notification-history-screen/notification.spec.tsx`: new spec with 100% statement/branch/function/line coverage of the component — wrap regression, galoy-icon and ionicon fallback branches, acknowledged styling (initial and transition after mount), and deep link / external link / no-action press behavior.

## Test plan

- `yarn jest __tests__/screens/notification-history-screen/notification.spec.tsx --coverage`: 12 passed, 100% coverage on `notification.tsx`, no console noise
- `yarn tsc --noEmit` and `eslint` on the changed files: clean

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="250" alt="Screenshot from 2026-07-31 15-32-42" src="https://github.com/user-attachments/assets/0a9ea1ae-1b1a-48de-9397-180200fedc66" /> | <img width="250" alt="Screenshot from 2026-07-31 15-34-11" src="https://github.com/user-attachments/assets/146fa343-2277-4bf4-9c99-6d0d965acab3" /> |

