### PR TITLE
fix(people): hide the circles card on self-custodial accounts

### DIFF
--- a/__tests__/screens/people.spec.tsx
+++ b/__tests__/screens/people.spec.tsx
@@ -25,9 +25,13 @@ jest.mock("react-native-safe-area-context", () => {
   }
 })
 
-jest.mock("@app/screens/people-screen/circles/circles-card-people-home", () => ({
-  CirclesCardPeopleHome: () => null,
-}))
+jest.mock("@app/screens/people-screen/circles/circles-card-people-home", () => {
+  const ReactActual = jest.requireActual<typeof React>("react")
+  return {
+    CirclesCardPeopleHome: () =>
+      ReactActual.createElement("CirclesCard", { testID: "circles-card" }),
+  }
+})
 jest.mock("@app/screens/people-screen/contacts/contacts-card", () => ({
   ContactsCard: () => null,
 }))
@@ -35,10 +39,37 @@ jest.mock("@app/screens/people-screen/circles/invite-friends-card", () => ({
   InviteFriendsCard: () => null,
 }))
 
+const mockUseIsSelfCustodialAccount = jest.fn()
+jest.mock("@app/hooks/use-is-self-custodial-account", () => ({
+  useIsSelfCustodialAccount: () => mockUseIsSelfCustodialAccount(),
+}))
+
 describe("PeopleScreen", () => {
+  beforeEach(() => {
+    mockUseIsSelfCustodialAccount.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("excludes the bottom safe-area edge the tab bar already reserves", () => {
     const { getByTestId } = render(<PeopleScreen />)
 
     expect(getByTestId("safe-area").props.edges).toEqual(["top", "left", "right"])
+  })
+
+  it("shows the circles card on a custodial account", () => {
+    const { queryByTestId } = render(<PeopleScreen />)
+
+    expect(queryByTestId("circles-card")).not.toBeNull()
+  })
+
+  it("hides the circles card on a self-custodial account", () => {
+    mockUseIsSelfCustodialAccount.mockReturnValue(true)
+
+    const { queryByTestId } = render(<PeopleScreen />)
+
+    expect(queryByTestId("circles-card")).toBeNull()
   })
 })

--- a/app/screens/people-screen/people.tsx
+++ b/app/screens/people-screen/people.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { useIsSelfCustodialAccount } from "@app/hooks/use-is-self-custodial-account"
 import { makeStyles } from "@rn-vui/themed"
 
 import { Screen } from "../../components/screen"
@@ -9,6 +10,7 @@ import { ContactsCard } from "./contacts/contacts-card"
 
 export const PeopleScreen: React.FC = () => {
   const styles = useStyles()
+  const isSelfCustodial = useIsSelfCustodialAccount()
 
   return (
     <Screen
@@ -17,7 +19,7 @@ export const PeopleScreen: React.FC = () => {
       headerShown={false}
       edges={["top", "left", "right"]}
     >
-      <CirclesCardPeopleHome />
+      {!isSelfCustodial && <CirclesCardPeopleHome />}
       <ContactsCard />
       <InviteFriendsCard />
     </Screen>


### PR DESCRIPTION
Circles is backed by the Blink account's welcome profile, so the card has nothing to show on a self-custodial account. Gate it on account type rather than useActiveWallet().isSelfCustodial, which reports false while the SDK is still loading and would make the card flash in and then disappear.