### PR TITLE
fix(transaction-detail): stop the amount heading dropping its last word

### DIFF
--- a/__tests__/helpers/transaction-detail-mocks.tsx
+++ b/__tests__/helpers/transaction-detail-mocks.tsx
@@ -1,0 +1,128 @@
+import * as React from "react"
+
+/**
+ * Shared mocks for the transaction-detail-screen specs.
+ *
+ * The screen pulls in the whole themed/hook stack, so every spec that renders
+ * it needs the same stubs. Keeping them here means a change to the screen's
+ * hooks is a one-line change instead of the same edit in three files.
+ *
+ * Pull each one in from inside the factory, the way card-flow-mocks is used:
+ *
+ *   jest.mock("@rn-vui/themed", () =>
+ *     jest.requireActual("../helpers/transaction-detail-mocks").mockThemedText(),
+ *   )
+ *
+ * Importing these at the top of a spec instead looks tidier but breaks. A
+ * factory fires the first time its module is required, which happens midway
+ * through importing the screen under test — so any binding the spec declares
+ * after that import is still in its TDZ. That is also why mockAppHooks takes
+ * a thunk rather than a spy.
+ */
+
+export const TEST_GALOY_INSTANCE = {
+  name: "Blink",
+  blockExplorer: "https://mempool.space/tx/",
+  sparkExplorer: "https://sparkscan.io/tx/",
+}
+
+const colors: Record<string, string> = {
+  grey5: "#f5f5f5",
+  primary: "#fc5805",
+  black: "#000",
+  white: "#fff",
+}
+
+/**
+ * `@rn-vui/themed` reduced to the pieces the screen uses. Text renders as a
+ * host "Text" element keeping its props, so specs can assert on `type`,
+ * `numberOfLines` and children.
+ */
+export const mockThemedText = () => ({
+  makeStyles:
+    (
+      fn: (
+        theme: { colors: Record<string, string> },
+        params: Record<string, unknown>,
+      ) => Record<string, object>,
+    ) =>
+    (params: Record<string, unknown> = {}) =>
+      fn({ colors }, params),
+  Text: ({ children, ...props }: { children: React.ReactNode }) =>
+    React.createElement("Text", props, children),
+  useTheme: () => ({ theme: { colors, mode: "light" } }),
+})
+
+export const mockSafeAreaInsets = () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+})
+
+export const mockScreen = () => ({
+  Screen: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("View", { testID: "screen" }, children),
+})
+
+/**
+ * IconAction renders a GaloyIconButton; reduce it to a plain Pressable so the
+ * explorer / copy icons can be pressed by testID without the themed internals.
+ */
+export const mockGaloyIconButton = () => {
+  const { Pressable } = jest.requireActual("react-native")
+  return {
+    GaloyIconButton: ({ name, onPress }: { name: string; onPress: () => void }) =>
+      React.createElement(Pressable, { testID: name, onPress }),
+  }
+}
+
+export const mockGaloyPrimaryButton = () => {
+  const { Pressable, Text } = jest.requireActual("react-native")
+  return {
+    GaloyPrimaryButton: ({ title, onPress }: { title: string; onPress: () => void }) =>
+      React.createElement(
+        Pressable,
+        { testID: "primary-button", onPress },
+        React.createElement(Text, null, title),
+      ),
+  }
+}
+
+export const mockGeneratedGraphql = () => ({
+  TransactionFragmentDoc: {},
+  WalletCurrency: { Btc: "BTC", Usd: "USD" },
+  useTransactionListForDefaultAccountLazyQuery: () => [jest.fn()],
+  useHomeAuthedQuery: () => ({ data: undefined }),
+})
+
+/**
+ * `getCopyToClipboard` is a thunk, not the spy itself: the factory runs while
+ * the screen is still being imported, so a spy passed by value would be read
+ * before its `const` initializes. Resolving it inside useClipboard defers the
+ * read to render time.
+ */
+export const mockAppHooks = ({
+  getCopyToClipboard,
+}: { getCopyToClipboard?: () => jest.Mock } = {}) => {
+  const unobservedCopy = jest.fn()
+  return {
+    useAppConfig: () => ({ appConfig: { galoyInstance: TEST_GALOY_INSTANCE } }),
+    useClipboard: () => ({
+      copyToClipboard: getCopyToClipboard ? getCopyToClipboard() : unobservedCopy,
+    }),
+    useTransactionSeenState: () => ({
+      latestBtcTxId: undefined,
+      latestUsdTxId: undefined,
+      markTxSeen: jest.fn(),
+    }),
+  }
+}
+
+export const mockDisplayCurrency = () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: () => "1,000 sats",
+    formatCurrency: () => "$1.00",
+  }),
+})
+
+export const mockNavigation = () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+})

--- a/__tests__/screens/transaction-detail-fallback.spec.tsx
+++ b/__tests__/screens/transaction-detail-fallback.spec.tsx
@@ -5,37 +5,15 @@ import { fireEvent, render } from "@testing-library/react-native"
 import type { ResolveTransactionAccountStatus } from "@app/hooks/use-resolve-transaction-account"
 import { TransactionDetailScreen } from "@app/screens/transaction-detail-screen/transaction-detail-screen"
 
-jest.mock("@rn-vui/themed", () => {
-  const colors: Record<string, string> = {
-    grey5: "#f5f5f5",
-    primary: "#fc5805",
-    black: "#000",
-    white: "#fff",
-  }
-  return {
-    makeStyles:
-      (
-        fn: (
-          theme: { colors: Record<string, string> },
-          params: Record<string, unknown>,
-        ) => Record<string, object>,
-      ) =>
-      (params: Record<string, unknown> = {}) =>
-        fn({ colors }, params),
-    Text: ({ children, ...props }: { children: React.ReactNode }) =>
-      React.createElement("Text", props, children),
-    useTheme: () => ({ theme: { colors, mode: "light" } }),
-  }
-})
-
-jest.mock("react-native-safe-area-context", () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}))
-
-jest.mock("@app/components/screen", () => ({
-  Screen: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("View", { testID: "screen" }, children),
-}))
+jest.mock("@rn-vui/themed", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockThemedText(),
+)
+jest.mock("react-native-safe-area-context", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockSafeAreaInsets(),
+)
+jest.mock("@app/components/screen", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockScreen(),
+)
 
 jest.mock("@app/components/icon-transactions", () => ({
   IconTransaction: () => null,
@@ -53,27 +31,12 @@ jest.mock("@app/components/atomic/galoy-info", () => ({
   GaloyInfo: () => null,
 }))
 
-jest.mock("@app/components/atomic/galoy-icon-button", () => {
-  const ReactActual = jest.requireActual<typeof React>("react")
-  const { Pressable: RNPressable } = jest.requireActual("react-native")
-  return {
-    GaloyIconButton: ({ name, onPress }: { name: string; onPress: () => void }) =>
-      ReactActual.createElement(RNPressable, { testID: name, onPress }),
-  }
-})
-
-jest.mock("@app/components/atomic/galoy-primary-button", () => {
-  const ReactActual = jest.requireActual<typeof React>("react")
-  const { Pressable: RNPressable, Text: RNText } = jest.requireActual("react-native")
-  return {
-    GaloyPrimaryButton: ({ title, onPress }: { title: string; onPress: () => void }) =>
-      ReactActual.createElement(
-        RNPressable,
-        { testID: "primary-button", onPress },
-        ReactActual.createElement(RNText, null, title),
-      ),
-  }
-})
+jest.mock("@app/components/atomic/galoy-icon-button", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGaloyIconButton(),
+)
+jest.mock("@app/components/atomic/galoy-primary-button", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGaloyPrimaryButton(),
+)
 
 jest.mock("@app/components/transaction-item", () => ({
   useDescriptionDisplay: () => "some description",
@@ -85,35 +48,15 @@ jest.mock("@apollo/client", () => ({
   useFragment: () => mockUseFragment(),
 }))
 
-jest.mock("@app/graphql/generated", () => ({
-  TransactionFragmentDoc: {},
-  WalletCurrency: { Btc: "BTC", Usd: "USD" },
-  useTransactionListForDefaultAccountLazyQuery: () => [jest.fn()],
-  useHomeAuthedQuery: () => ({ data: undefined }),
-}))
-
-const galoyInstance = {
-  name: "Blink",
-  blockExplorer: "https://mempool.space/tx/",
-  sparkExplorer: "https://sparkscan.io/tx/",
-}
-
-jest.mock("@app/hooks", () => ({
-  useAppConfig: () => ({ appConfig: { galoyInstance } }),
-  useClipboard: () => ({ copyToClipboard: jest.fn() }),
-  useTransactionSeenState: () => ({
-    latestBtcTxId: undefined,
-    latestUsdTxId: undefined,
-    markTxSeen: jest.fn(),
-  }),
-}))
-
-jest.mock("@app/hooks/use-display-currency", () => ({
-  useDisplayCurrency: () => ({
-    formatMoneyAmount: () => "1,000 sats",
-    formatCurrency: () => "$1.00",
-  }),
-}))
+jest.mock("@app/graphql/generated", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGeneratedGraphql(),
+)
+jest.mock("@app/hooks", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockAppHooks(),
+)
+jest.mock("@app/hooks/use-display-currency", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockDisplayCurrency(),
+)
 
 let mockActiveWallet: { isSelfCustodial: boolean; wallets: unknown[] } = {
   isSelfCustodial: false,
@@ -123,9 +66,9 @@ jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => mockActiveWallet,
 }))
 
-jest.mock("@react-navigation/native", () => ({
-  useNavigation: () => ({ goBack: jest.fn() }),
-}))
+jest.mock("@react-navigation/native", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockNavigation(),
+)
 
 const LLText = () => ""
 jest.mock("@app/i18n/i18n-react", () => ({

--- a/__tests__/screens/transaction-detail-heading.spec.tsx
+++ b/__tests__/screens/transaction-detail-heading.spec.tsx
@@ -4,100 +4,52 @@ import { render } from "@testing-library/react-native"
 
 import { TransactionDetailScreen } from "@app/screens/transaction-detail-screen/transaction-detail-screen"
 
-jest.mock("@rn-vui/themed", () => {
-  const colors: Record<string, string> = {
-    grey5: "#f5f5f5",
-    primary: "#fc5805",
-    black: "#000",
-    white: "#fff",
-  }
-  return {
-    makeStyles:
-      (
-        fn: (
-          theme: { colors: Record<string, string> },
-          params: Record<string, unknown>,
-        ) => Record<string, object>,
-      ) =>
-      (params: Record<string, unknown> = {}) =>
-        fn({ colors }, params),
-    Text: ({ children, ...props }: { children: React.ReactNode }) =>
-      React.createElement("Text", props, children),
-    useTheme: () => ({ theme: { colors, mode: "light" } }),
-  }
-})
-
-jest.mock("react-native-safe-area-context", () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}))
-
-jest.mock("@app/components/screen", () => ({
-  Screen: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("View", { testID: "screen" }, children),
-}))
+jest.mock("@rn-vui/themed", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockThemedText(),
+)
+jest.mock("react-native-safe-area-context", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockSafeAreaInsets(),
+)
+jest.mock("@app/components/screen", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockScreen(),
+)
+jest.mock("@app/components/atomic/galoy-icon-button", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGaloyIconButton(),
+)
+jest.mock("@app/components/atomic/galoy-primary-button", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGaloyPrimaryButton(),
+)
+jest.mock("@app/graphql/generated", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGeneratedGraphql(),
+)
+jest.mock("@app/hooks", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockAppHooks(),
+)
+jest.mock("@app/hooks/use-display-currency", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockDisplayCurrency(),
+)
+jest.mock("@react-navigation/native", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockNavigation(),
+)
 
 jest.mock("@app/components/icon-transactions", () => ({ IconTransaction: () => null }))
 jest.mock("@app/components/wallet-summary", () => ({ WalletSummary: () => null }))
 jest.mock("@app/components/transaction-date", () => ({ TransactionDate: () => null }))
 jest.mock("@app/components/atomic/galoy-info", () => ({ GaloyInfo: () => null }))
-jest.mock("@app/components/atomic/galoy-primary-button", () => ({
-  GaloyPrimaryButton: () => null,
-}))
-jest.mock("@app/components/atomic/galoy-icon-button", () => ({
-  GaloyIconButton: () => null,
-}))
 jest.mock("@app/components/transaction-item", () => ({
   useDescriptionDisplay: () => "some description",
+}))
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => ({ isSelfCustodial: false, wallets: [] }),
+}))
+jest.mock("@app/hooks/use-resolve-transaction-account", () => ({
+  useResolveTransactionAccount: () => ({ status: "resolved", retry: jest.fn() }),
 }))
 
 const mockUseFragment = jest.fn()
 jest.mock("@apollo/client", () => ({
   ...jest.requireActual("@apollo/client"),
   useFragment: () => mockUseFragment(),
-}))
-
-jest.mock("@app/graphql/generated", () => ({
-  TransactionFragmentDoc: {},
-  WalletCurrency: { Btc: "BTC", Usd: "USD" },
-  useTransactionListForDefaultAccountLazyQuery: () => [jest.fn()],
-  useHomeAuthedQuery: () => ({ data: undefined }),
-}))
-
-jest.mock("@app/hooks", () => ({
-  useAppConfig: () => ({
-    appConfig: {
-      galoyInstance: {
-        name: "Blink",
-        blockExplorer: "https://mempool.space/tx/",
-        sparkExplorer: "https://sparkscan.io/tx/",
-      },
-    },
-  }),
-  useClipboard: () => ({ copyToClipboard: jest.fn() }),
-  useTransactionSeenState: () => ({
-    latestBtcTxId: undefined,
-    latestUsdTxId: undefined,
-    markTxSeen: jest.fn(),
-  }),
-}))
-
-jest.mock("@app/hooks/use-display-currency", () => ({
-  useDisplayCurrency: () => ({
-    formatMoneyAmount: () => "1,000 sats",
-    formatCurrency: () => "$0.01",
-  }),
-}))
-
-jest.mock("@app/hooks/use-active-wallet", () => ({
-  useActiveWallet: () => ({ isSelfCustodial: false, wallets: [] }),
-}))
-
-jest.mock("@react-navigation/native", () => ({
-  useNavigation: () => ({ goBack: jest.fn() }),
-}))
-
-jest.mock("@app/hooks/use-resolve-transaction-account", () => ({
-  useResolveTransactionAccount: () => ({ status: "resolved", retry: jest.fn() }),
 }))
 
 // Real english copy, so the assertions below pin the whole heading and not a stub.

--- a/__tests__/screens/transaction-detail-heading.spec.tsx
+++ b/__tests__/screens/transaction-detail-heading.spec.tsx
@@ -83,51 +83,60 @@ const lightningSend = {
   initiationVia: { __typename: "InitiationViaLn", paymentHash: "c94e998a" },
 }
 
-const headingOf = (tree: ReturnType<typeof render>) =>
-  tree.UNSAFE_getAllByType("Text" as never).find((n) => n.props.type === "h2")
+// transactionHash === null is what marks an onchain send as still queued.
+const queuedOnChainSend = {
+  ...lightningSend,
+  settlementVia: {
+    __typename: "SettlementViaOnChain",
+    transactionHash: null,
+    arrivalInMempoolEstimatedAt: null,
+  },
+  initiationVia: { __typename: "InitiationViaOnChain", address: "bc1qexample" },
+}
+
+const renderHeading = (tx: unknown) => {
+  mockUseFragment.mockReturnValue({ data: tx })
+  const tree = render(<TransactionDetailScreen route={route} />)
+  const heading = tree
+    .UNSAFE_getAllByType("Text" as never)
+    .find((node) => node.props.type === "h2")
+
+  return { heading, tree }
+}
 
 // The heading lost its trailing word intermittently on Android: the Text was
 // measured as one line, then re-broken after "You" on a later layout pass, and
 // the wrapped word fell outside the already-fixed container height. Pinning it
-// to a single line makes that unrepresentable.
+// to a single line makes that unrepresentable; adjustsFontSizeToFit keeps a
+// long locale whole under font scaling rather than trading the drop for an
+// ellipsis.
 describe("TransactionDetailScreen heading", () => {
   beforeEach(() => jest.clearAllMocks())
 
-  it("renders the full spend copy, never a truncated prefix", () => {
-    mockUseFragment.mockReturnValue({ data: lightningSend })
+  const cases: Array<{ name: string; tx: unknown; copy: string }> = [
+    { name: "spend", tx: lightningSend, copy: "You spent" },
+    {
+      name: "receive",
+      tx: { ...lightningSend, direction: "RECEIVE", settlementAmount: 23 },
+      copy: "You received",
+    },
+    { name: "queued onchain send", tx: queuedOnChainSend, copy: "Sending" },
+  ]
 
-    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+  cases.forEach(({ name, tx, copy }) => {
+    it(`renders the full ${name} copy, never a truncated prefix`, () => {
+      const { heading, tree } = renderHeading(tx)
 
-    expect(heading?.props.children).toBe("You spent")
-  })
-
-  it("keeps the heading on a single line so a re-break cannot drop a word", () => {
-    mockUseFragment.mockReturnValue({ data: lightningSend })
-
-    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
-
-    expect(heading?.props.numberOfLines).toBe(1)
-  })
-
-  // One line alone would trade the dropped word for a tail ellipsis once the
-  // line genuinely doesn't fit; shrinking keeps a long locale whole.
-  it("shrinks rather than ellipsizing when the line cannot fit", () => {
-    mockUseFragment.mockReturnValue({ data: lightningSend })
-
-    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
-
-    expect(heading?.props.adjustsFontSizeToFit).toBe(true)
-  })
-
-  it("applies the same guarantees to the receive copy", () => {
-    mockUseFragment.mockReturnValue({
-      data: { ...lightningSend, direction: "RECEIVE", settlementAmount: 23 },
+      expect(heading?.props.children).toBe(copy)
+      tree.unmount()
     })
 
-    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+    it(`keeps the ${name} heading on one line, shrinking rather than clipping`, () => {
+      const { heading, tree } = renderHeading(tx)
 
-    expect(heading?.props.children).toBe("You received")
-    expect(heading?.props.numberOfLines).toBe(1)
-    expect(heading?.props.adjustsFontSizeToFit).toBe(true)
+      expect(heading?.props.numberOfLines).toBe(1)
+      expect(heading?.props.adjustsFontSizeToFit).toBe(true)
+      tree.unmount()
+    })
   })
 })

--- a/__tests__/screens/transaction-detail-heading.spec.tsx
+++ b/__tests__/screens/transaction-detail-heading.spec.tsx
@@ -109,7 +109,17 @@ describe("TransactionDetailScreen heading", () => {
     expect(heading?.props.numberOfLines).toBe(1)
   })
 
-  it("applies the same guarantee to the receive copy", () => {
+  // One line alone would trade the dropped word for a tail ellipsis once the
+  // line genuinely doesn't fit; shrinking keeps a long locale whole.
+  it("shrinks rather than ellipsizing when the line cannot fit", () => {
+    mockUseFragment.mockReturnValue({ data: lightningSend })
+
+    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+
+    expect(heading?.props.adjustsFontSizeToFit).toBe(true)
+  })
+
+  it("applies the same guarantees to the receive copy", () => {
     mockUseFragment.mockReturnValue({
       data: { ...lightningSend, direction: "RECEIVE", settlementAmount: 23 },
     })
@@ -118,5 +128,6 @@ describe("TransactionDetailScreen heading", () => {
 
     expect(heading?.props.children).toBe("You received")
     expect(heading?.props.numberOfLines).toBe(1)
+    expect(heading?.props.adjustsFontSizeToFit).toBe(true)
   })
 })

--- a/__tests__/screens/transaction-detail-heading.spec.tsx
+++ b/__tests__/screens/transaction-detail-heading.spec.tsx
@@ -1,0 +1,170 @@
+import React from "react"
+
+import { render } from "@testing-library/react-native"
+
+import { TransactionDetailScreen } from "@app/screens/transaction-detail-screen/transaction-detail-screen"
+
+jest.mock("@rn-vui/themed", () => {
+  const colors: Record<string, string> = {
+    grey5: "#f5f5f5",
+    primary: "#fc5805",
+    black: "#000",
+    white: "#fff",
+  }
+  return {
+    makeStyles:
+      (
+        fn: (
+          theme: { colors: Record<string, string> },
+          params: Record<string, unknown>,
+        ) => Record<string, object>,
+      ) =>
+      (params: Record<string, unknown> = {}) =>
+        fn({ colors }, params),
+    Text: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("Text", props, children),
+    useTheme: () => ({ theme: { colors, mode: "light" } }),
+  }
+})
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}))
+
+jest.mock("@app/components/screen", () => ({
+  Screen: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("View", { testID: "screen" }, children),
+}))
+
+jest.mock("@app/components/icon-transactions", () => ({ IconTransaction: () => null }))
+jest.mock("@app/components/wallet-summary", () => ({ WalletSummary: () => null }))
+jest.mock("@app/components/transaction-date", () => ({ TransactionDate: () => null }))
+jest.mock("@app/components/atomic/galoy-info", () => ({ GaloyInfo: () => null }))
+jest.mock("@app/components/atomic/galoy-primary-button", () => ({
+  GaloyPrimaryButton: () => null,
+}))
+jest.mock("@app/components/atomic/galoy-icon-button", () => ({
+  GaloyIconButton: () => null,
+}))
+jest.mock("@app/components/transaction-item", () => ({
+  useDescriptionDisplay: () => "some description",
+}))
+
+const mockUseFragment = jest.fn()
+jest.mock("@apollo/client", () => ({
+  ...jest.requireActual("@apollo/client"),
+  useFragment: () => mockUseFragment(),
+}))
+
+jest.mock("@app/graphql/generated", () => ({
+  TransactionFragmentDoc: {},
+  WalletCurrency: { Btc: "BTC", Usd: "USD" },
+  useTransactionListForDefaultAccountLazyQuery: () => [jest.fn()],
+  useHomeAuthedQuery: () => ({ data: undefined }),
+}))
+
+jest.mock("@app/hooks", () => ({
+  useAppConfig: () => ({
+    appConfig: {
+      galoyInstance: {
+        name: "Blink",
+        blockExplorer: "https://mempool.space/tx/",
+        sparkExplorer: "https://sparkscan.io/tx/",
+      },
+    },
+  }),
+  useClipboard: () => ({ copyToClipboard: jest.fn() }),
+  useTransactionSeenState: () => ({
+    latestBtcTxId: undefined,
+    latestUsdTxId: undefined,
+    markTxSeen: jest.fn(),
+  }),
+}))
+
+jest.mock("@app/hooks/use-display-currency", () => ({
+  useDisplayCurrency: () => ({
+    formatMoneyAmount: () => "1,000 sats",
+    formatCurrency: () => "$0.01",
+  }),
+}))
+
+jest.mock("@app/hooks/use-active-wallet", () => ({
+  useActiveWallet: () => ({ isSelfCustodial: false, wallets: [] }),
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  useNavigation: () => ({ goBack: jest.fn() }),
+}))
+
+jest.mock("@app/hooks/use-resolve-transaction-account", () => ({
+  useResolveTransactionAccount: () => ({ status: "resolved", retry: jest.fn() }),
+}))
+
+// Real english copy, so the assertions below pin the whole heading and not a stub.
+jest.mock("@app/i18n/i18n-react", () => {
+  const { i18nObject } = jest.requireActual("@app/i18n/i18n-util")
+  const { loadLocale } = jest.requireActual("@app/i18n/i18n-util.sync")
+  loadLocale("en")
+  return { useI18nContext: () => ({ LL: i18nObject("en"), locale: "en" }) }
+})
+
+const route = {
+  key: "transactionDetail",
+  name: "transactionDetail",
+  params: { txid: "tx-1" },
+} as never
+
+const lightningSend = {
+  __typename: "Transaction",
+  id: "tx-1",
+  status: "SUCCESS",
+  direction: "SEND",
+  memo: "Pay to catalyst@blink.sv",
+  createdAt: 1785589616,
+  settlementAmount: -23,
+  settlementFee: 2,
+  settlementDisplayAmount: "-0.01",
+  settlementDisplayFee: "0.00",
+  settlementCurrency: "BTC",
+  settlementDisplayCurrency: "USD",
+  settlementVia: { __typename: "SettlementViaLn", preImage: null },
+  initiationVia: { __typename: "InitiationViaLn", paymentHash: "c94e998a" },
+}
+
+const headingOf = (tree: ReturnType<typeof render>) =>
+  tree.UNSAFE_getAllByType("Text" as never).find((n) => n.props.type === "h2")
+
+// The heading lost its trailing word intermittently on Android: the Text was
+// measured as one line, then re-broken after "You" on a later layout pass, and
+// the wrapped word fell outside the already-fixed container height. Pinning it
+// to a single line makes that unrepresentable.
+describe("TransactionDetailScreen heading", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it("renders the full spend copy, never a truncated prefix", () => {
+    mockUseFragment.mockReturnValue({ data: lightningSend })
+
+    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+
+    expect(heading?.props.children).toBe("You spent")
+  })
+
+  it("keeps the heading on a single line so a re-break cannot drop a word", () => {
+    mockUseFragment.mockReturnValue({ data: lightningSend })
+
+    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+
+    expect(heading?.props.numberOfLines).toBe(1)
+  })
+
+  it("applies the same guarantee to the receive copy", () => {
+    mockUseFragment.mockReturnValue({
+      data: { ...lightningSend, direction: "RECEIVE", settlementAmount: 23 },
+    })
+
+    const heading = headingOf(render(<TransactionDetailScreen route={route} />))
+
+    expect(heading?.props.children).toBe("You received")
+    expect(heading?.props.numberOfLines).toBe(1)
+  })
+})

--- a/__tests__/screens/transaction-detail-row-actions.spec.tsx
+++ b/__tests__/screens/transaction-detail-row-actions.spec.tsx
@@ -5,37 +5,29 @@ import { Linking } from "react-native"
 
 import { TransactionDetailScreen } from "@app/screens/transaction-detail-screen/transaction-detail-screen"
 
-jest.mock("@rn-vui/themed", () => {
-  const colors: Record<string, string> = {
-    grey5: "#f5f5f5",
-    primary: "#fc5805",
-    black: "#000",
-    white: "#fff",
-  }
-  return {
-    makeStyles:
-      (
-        fn: (
-          theme: { colors: Record<string, string> },
-          params: Record<string, unknown>,
-        ) => Record<string, object>,
-      ) =>
-      (params: Record<string, unknown> = {}) =>
-        fn({ colors }, params),
-    Text: ({ children, ...props }: { children: React.ReactNode }) =>
-      React.createElement("Text", props, children),
-    useTheme: () => ({ theme: { colors, mode: "light" } }),
-  }
-})
-
-jest.mock("react-native-safe-area-context", () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
-}))
-
-jest.mock("@app/components/screen", () => ({
-  Screen: ({ children }: { children: React.ReactNode }) =>
-    React.createElement("View", { testID: "screen" }, children),
-}))
+jest.mock("@rn-vui/themed", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockThemedText(),
+)
+jest.mock("react-native-safe-area-context", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockSafeAreaInsets(),
+)
+jest.mock("@app/components/screen", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockScreen(),
+)
+// IconAction renders a GaloyIconButton; the shared mock reduces it to a plain
+// Pressable so the explorer / copy icons can be pressed by testID.
+jest.mock("@app/components/atomic/galoy-icon-button", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGaloyIconButton(),
+)
+jest.mock("@app/graphql/generated", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockGeneratedGraphql(),
+)
+jest.mock("@app/hooks/use-display-currency", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockDisplayCurrency(),
+)
+jest.mock("@react-navigation/native", () =>
+  jest.requireActual("../helpers/transaction-detail-mocks").mockNavigation(),
+)
 
 jest.mock("@app/components/icon-transactions", () => ({
   IconTransaction: () => null,
@@ -53,17 +45,6 @@ jest.mock("@app/components/atomic/galoy-info", () => ({
   GaloyInfo: () => null,
 }))
 
-// IconAction renders a GaloyIconButton; reduce it to a plain Pressable so the
-// explorer / copy icons can be pressed by testID without the themed internals.
-jest.mock("@app/components/atomic/galoy-icon-button", () => {
-  const ReactActual = jest.requireActual<typeof React>("react")
-  const { Pressable: RNPressable } = jest.requireActual("react-native")
-  return {
-    GaloyIconButton: ({ name, onPress }: { name: string; onPress: () => void }) =>
-      ReactActual.createElement(RNPressable, { testID: name, onPress }),
-  }
-})
-
 jest.mock("@app/components/transaction-item", () => ({
   useDescriptionDisplay: () => "some description",
 }))
@@ -80,43 +61,15 @@ jest.mock("@apollo/client", () => ({
   useFragment: () => mockUseFragment(),
 }))
 
-jest.mock("@app/graphql/generated", () => ({
-  TransactionFragmentDoc: {},
-  WalletCurrency: { Btc: "BTC", Usd: "USD" },
-  useTransactionListForDefaultAccountLazyQuery: () => [jest.fn()],
-  useHomeAuthedQuery: () => ({ data: undefined }),
-}))
-
-const galoyInstance = {
-  name: "Blink",
-  blockExplorer: "https://mempool.space/tx/",
-  sparkExplorer: "https://sparkscan.io/tx/",
-}
-
 const mockCopyToClipboard = jest.fn()
-jest.mock("@app/hooks", () => ({
-  useAppConfig: () => ({ appConfig: { galoyInstance } }),
-  useClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
-  useTransactionSeenState: () => ({
-    latestBtcTxId: undefined,
-    latestUsdTxId: undefined,
-    markTxSeen: jest.fn(),
-  }),
-}))
-
-jest.mock("@app/hooks/use-display-currency", () => ({
-  useDisplayCurrency: () => ({
-    formatMoneyAmount: () => "1,000 sats",
-    formatCurrency: () => "$1.00",
-  }),
-}))
+jest.mock("@app/hooks", () =>
+  jest
+    .requireActual("../helpers/transaction-detail-mocks")
+    .mockAppHooks({ getCopyToClipboard: () => mockCopyToClipboard }),
+)
 
 jest.mock("@app/hooks/use-active-wallet", () => ({
   useActiveWallet: () => ({ isSelfCustodial: false, wallets: [] }),
-}))
-
-jest.mock("@react-navigation/native", () => ({
-  useNavigation: () => ({ goBack: jest.fn() }),
 }))
 
 const LLText = () => ""

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -400,7 +400,14 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
               pending={false}
               onChain={settlementVia?.__typename === "SettlementViaOnChain"}
             />
-            <Text type="h2">{spendOrReceiveText}</Text>
+            {/* Pinned to one line: this heading is short in every locale, and
+                leaving it unbounded lets Android re-break it after the first
+                word on a re-layout. The container height is already fixed by
+                the first measure pass, so the wrapped word lands outside it and
+                is clipped — "You spent" silently renders as "You". */}
+            <Text type="h2" numberOfLines={1}>
+              {spendOrReceiveText}
+            </Text>
             <Text type="h1">{displayAmount}</Text>
           </View>
         </View>

--- a/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
+++ b/app/screens/transaction-detail-screen/transaction-detail-screen.tsx
@@ -400,12 +400,15 @@ export const TransactionDetailScreen: React.FC<Props> = ({ route }) => {
               pending={false}
               onChain={settlementVia?.__typename === "SettlementViaOnChain"}
             />
-            {/* Pinned to one line: this heading is short in every locale, and
-                leaving it unbounded lets Android re-break it after the first
-                word on a re-layout. The container height is already fixed by
-                the first measure pass, so the wrapped word lands outside it and
-                is clipped — "You spent" silently renders as "You". */}
-            <Text type="h2" numberOfLines={1}>
+            {/* Pinned to one line: leaving it unbounded lets Android re-break
+                it after the first word on a re-layout, and since the container
+                height is already fixed by the first measure pass the wrapped
+                word lands outside it and is clipped — "You spent" silently
+                renders as "You". Shrink rather than ellipsize when the line
+                genuinely doesn't fit, so a long locale (the longest is ms
+                "Anda dah belanjakan") stays whole under accessibility font
+                scaling instead of losing its tail. */}
+            <Text type="h2" numberOfLines={1} adjustsFontSizeToFit>
               {spendOrReceiveText}
             </Text>
             <Text type="h1">{displayAmount}</Text>


### PR DESCRIPTION
The heading intermittently rendered "You spent" as "You". It was not a copy problem: every locale returns the full string through the runtime, and the surrounding labels stayed intact in the broken frame, so LL was healthy rather than falling back.

The Text was measured as a single line, then re-broken after the first word on a later layout pass. Since the container height was already fixed by the first measure, the wrapped word landed outside it and was clipped — same height, missing word. It only hit this element because it was the one unbounded-line Text in the header.

Pin the heading to one line so the re-break cannot happen. The longest heading in any locale is 19 characters, so it fits without ellipsizing.