### PR TITLE
fix(send): show the send-completed time in the device timezone

### DIFF
--- a/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
@@ -22,6 +22,23 @@ import { ContextForScreen, ContextForScreenWithTheme } from "./helper"
 import { Linking, View, ViewStyle } from "react-native"
 import { light, dark } from "@app/rne-theme/colors"
 
+const screenshotState = { isTakingScreenshot: false }
+const mockCaptureAndShare = jest.fn()
+const mockNavigate = jest.fn()
+
+jest.mock("@app/hooks", () => ({
+  ...jest.requireActual("@app/hooks"),
+  useScreenshot: () => ({
+    isTakingScreenshot: screenshotState.isTakingScreenshot,
+    captureAndShare: mockCaptureAndShare,
+  }),
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}))
+
 jest.mock("react-native-view-shot", () => {
   return {
     __esModule: true,
@@ -92,6 +109,9 @@ describe("SendBitcoinCompletedScreen", () => {
   beforeEach(() => {
     loadLocale("en")
     LL = i18nObject("en")
+    screenshotState.isTakingScreenshot = false
+    mockCaptureAndShare.mockClear()
+    mockNavigate.mockClear()
   })
 
   it("renders the Success state correctly", async () => {
@@ -494,6 +514,125 @@ describe("SendBitcoinCompletedScreen", () => {
     })
 
     expect(screen.queryByText(LL.SendBitcoinScreen.noteLabel())).toBeNull()
+  })
+
+  describe("transaction time", () => {
+    const timedRoute = {
+      key: "sendBitcoinCompleted",
+      name: "sendBitcoinCompleted",
+      params: {
+        status: "SUCCESS",
+        currencyAmount: "$0.03",
+        satAmount: "25 SAT",
+        currencyFeeAmount: "$0.00",
+        satFeeAmount: "0 SAT",
+        destination: "alice",
+        paymentType: "lightning",
+        createdAt: 1747691078,
+      },
+    } as const
+
+    it("renders the time as a wall-clock date, never as an ISO string", async () => {
+      render(
+        <ContextForScreen>
+          <SuccessAction route={timedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      expect(screen.getByText(LL.SendBitcoinScreen.time())).toBeTruthy()
+      expect(screen.getByText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/)).toBeTruthy()
+      expect(screen.queryByText(/T\d{2}:\d{2}/)).toBeNull()
+    })
+
+    it("hides the time row when the payment carries no timestamp", async () => {
+      const untimedRoute = {
+        ...timedRoute,
+        params: { ...timedRoute.params, createdAt: undefined },
+      } as const
+
+      render(
+        <ContextForScreen>
+          <SuccessAction route={untimedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      expect(screen.queryByText(LL.SendBitcoinScreen.time())).toBeNull()
+    })
+
+    it("hides the type row when the payment carries no type", async () => {
+      const untypedRoute = {
+        ...timedRoute,
+        params: { ...timedRoute.params, paymentType: undefined },
+      } as const
+
+      render(
+        <ContextForScreen>
+          <SuccessAction route={untypedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      expect(screen.queryByText(LL.SendBitcoinScreen.type())).toBeNull()
+    })
+
+    it("goes back to the home stack from the close button", async () => {
+      render(
+        <ContextForScreen>
+          <SuccessAction route={timedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      fireEvent.press(screen.getByTestId("close"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("Primary")
+    })
+
+    it("shares the receipt from the share button", async () => {
+      render(
+        <ContextForScreen>
+          <SuccessAction route={timedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      fireEvent.press(screen.getByText(LL.common.share()))
+
+      expect(mockCaptureAndShare).toHaveBeenCalled()
+    })
+
+    it("drops the close button out of the capture while sharing", async () => {
+      screenshotState.isTakingScreenshot = true
+
+      render(
+        <ContextForScreen>
+          <SuccessAction route={timedRoute} />
+        </ContextForScreen>,
+      )
+
+      act(() => {
+        jest.advanceTimersByTime(2300)
+      })
+
+      expect(screen.queryByTestId("close")).toBeNull()
+    })
   })
 
   describe("ViewShot background color for screenshot", () => {

--- a/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
+++ b/__tests__/screens/send-bitcoin-completed-screen.spec.tsx
@@ -516,23 +516,23 @@ describe("SendBitcoinCompletedScreen", () => {
     expect(screen.queryByText(LL.SendBitcoinScreen.noteLabel())).toBeNull()
   })
 
-  describe("transaction time", () => {
-    const timedRoute = {
-      key: "sendBitcoinCompleted",
-      name: "sendBitcoinCompleted",
-      params: {
-        status: "SUCCESS",
-        currencyAmount: "$0.03",
-        satAmount: "25 SAT",
-        currencyFeeAmount: "$0.00",
-        satFeeAmount: "0 SAT",
-        destination: "alice",
-        paymentType: "lightning",
-        createdAt: 1747691078,
-      },
-    } as const
+  const timedRoute = {
+    key: "sendBitcoinCompleted",
+    name: "sendBitcoinCompleted",
+    params: {
+      status: "SUCCESS",
+      currencyAmount: "$0.03",
+      satAmount: "25 SAT",
+      currencyFeeAmount: "$0.00",
+      satFeeAmount: "0 SAT",
+      destination: "alice",
+      paymentType: "lightning",
+      createdAt: 1747691078,
+    },
+  } as const
 
-    it("renders the time as a wall-clock date, never as an ISO string", async () => {
+  describe("transaction time", () => {
+    it("renders the time as a wall-clock date", () => {
       render(
         <ContextForScreen>
           <SuccessAction route={timedRoute} />
@@ -545,10 +545,9 @@ describe("SendBitcoinCompletedScreen", () => {
 
       expect(screen.getByText(LL.SendBitcoinScreen.time())).toBeTruthy()
       expect(screen.getByText(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/)).toBeTruthy()
-      expect(screen.queryByText(/T\d{2}:\d{2}/)).toBeNull()
     })
 
-    it("hides the time row when the payment carries no timestamp", async () => {
+    it("hides the time row when the payment carries no timestamp", () => {
       const untimedRoute = {
         ...timedRoute,
         params: { ...timedRoute.params, createdAt: undefined },
@@ -566,8 +565,10 @@ describe("SendBitcoinCompletedScreen", () => {
 
       expect(screen.queryByText(LL.SendBitcoinScreen.time())).toBeNull()
     })
+  })
 
-    it("hides the type row when the payment carries no type", async () => {
+  describe("payment type", () => {
+    it("hides the type row when the payment carries no type", () => {
       const untypedRoute = {
         ...timedRoute,
         params: { ...timedRoute.params, paymentType: undefined },
@@ -585,8 +586,10 @@ describe("SendBitcoinCompletedScreen", () => {
 
       expect(screen.queryByText(LL.SendBitcoinScreen.type())).toBeNull()
     })
+  })
 
-    it("goes back to the home stack from the close button", async () => {
+  describe("receipt actions", () => {
+    it("goes back to the home stack from the close button", () => {
       render(
         <ContextForScreen>
           <SuccessAction route={timedRoute} />
@@ -602,7 +605,7 @@ describe("SendBitcoinCompletedScreen", () => {
       expect(mockNavigate).toHaveBeenCalledWith("Primary")
     })
 
-    it("shares the receipt from the share button", async () => {
+    it("shares the receipt from the share button", () => {
       render(
         <ContextForScreen>
           <SuccessAction route={timedRoute} />
@@ -618,7 +621,7 @@ describe("SendBitcoinCompletedScreen", () => {
       expect(mockCaptureAndShare).toHaveBeenCalled()
     })
 
-    it("drops the close button out of the capture while sharing", async () => {
+    it("drops the close button out of the capture while sharing", () => {
       screenshotState.isTakingScreenshot = true
 
       render(

--- a/__tests__/utils/date-device-timezone.spec.ts
+++ b/__tests__/utils/date-device-timezone.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment ./jest.timezone-environment
+ */
+
+import { formatUnixTimestampYMDHM } from "@app/utils/date"
+
+/**
+ * The sibling `date.spec.ts` pins a zone through the formatter's own `timezone` argument,
+ * which leaves the default path unguarded: on a UTC runner an expectation derived from the
+ * process zone is UTC either way, so a regression to a hardcoded UTC would still pass. This
+ * file runs under a process zone pinned to UTC-6 by `jest.timezone-environment.js`, so the
+ * wall clock below is six hours behind the timestamp and only holds while the default path
+ * really follows the device.
+ */
+describe("formatUnixTimestampYMDHM without an injected timezone", () => {
+  it("renders the device wall clock rather than UTC", () => {
+    const timestampSeconds = Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000)
+
+    expect(formatUnixTimestampYMDHM({ timestampSeconds })).toBe("2026-08-03 13:04")
+  })
+})

--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -435,9 +435,7 @@ describe("date utils", () => {
     })
 
     it("falls back to en-US when no locale is given", () => {
-      expect(formatDateFromNow({ years: 1 })).toBe(
-        formatDateFromNow({ years: 1, locale: "en-US" }),
-      )
+      expect(formatDateFromNow({ years: 1 })).toBe("Mar 12, 2027")
     })
   })
 

--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -294,14 +294,9 @@ describe("date utils", () => {
       expect(formatUnixTimestampYMDHM({ timestampSeconds, timezone })).toBe(expected)
     })
 
-    it("uses the device timezone when none is injected", () => {
-      const timestampSeconds = Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000)
-      const deviceTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-
-      expect(formatUnixTimestampYMDHM({ timestampSeconds })).toBe(
-        formatUnixTimestampYMDHM({ timestampSeconds, timezone: deviceTimezone }),
-      )
-    })
+    /** The device-zone default cannot be asserted here, where the process zone is UTC on
+     *  CI and any expectation built from it would compare UTC against UTC; that case lives
+     *  in `date-device-timezone.spec.ts`, which pins a non-UTC zone. */
   })
 
   describe("parseCardValidThru", () => {

--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -12,6 +12,7 @@ import {
   formatDuration,
   formatMonth,
   formatShortDate,
+  formatUnixTimestampYMDHM,
   getLastDayOfMonth,
   isSameDay,
   isToday,
@@ -201,6 +202,58 @@ describe("date utils", () => {
       expect(formatShortDate({ createdAt })).toMatch(/2024-06-10/)
 
       jest.useRealTimers()
+    })
+  })
+
+  describe("formatUnixTimestampYMDHM", () => {
+    it.each([
+      {
+        name: "keeps the UTC wall clock when the zone is UTC",
+        timestampSeconds: Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000),
+        timezone: "UTC",
+        expected: "2026-08-03 19:04",
+      },
+      {
+        name: "shifts back for a negative offset zone",
+        timestampSeconds: Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000),
+        timezone: "America/El_Salvador",
+        expected: "2026-08-03 13:04",
+      },
+      {
+        name: "rolls to the next day for a positive offset zone",
+        timestampSeconds: Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000),
+        timezone: "Asia/Tokyo",
+        expected: "2026-08-04 04:04",
+      },
+      {
+        name: "rolls back a day for a negative offset zone",
+        timestampSeconds: Math.floor(Date.parse("2024-01-01T00:30:00Z") / 1000),
+        timezone: "America/Los_Angeles",
+        expected: "2023-12-31 16:30",
+      },
+      {
+        name: "renders midnight as 00 and not 24",
+        timestampSeconds: Math.floor(Date.parse("2024-01-01T00:00:00Z") / 1000),
+        timezone: "UTC",
+        expected: "2024-01-01 00:00",
+      },
+      {
+        name: "pads single digit month, day, hour and minute",
+        timestampSeconds: Math.floor(Date.parse("2024-03-05T04:07:00Z") / 1000),
+        timezone: "UTC",
+        expected: "2024-03-05 04:07",
+      },
+    ])("returns $expected when it $name", ({ timestampSeconds, timezone, expected }) => {
+      expect(formatUnixTimestampYMDHM({ timestampSeconds, timezone })).toBe(expected)
+    })
+
+    it("uses the device timezone when none is injected", () => {
+      const timestampSeconds = Math.floor(Date.parse("2026-08-03T19:04:00Z") / 1000)
+      const deviceTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+      expect(formatUnixTimestampYMDHM({ timestampSeconds })).toBe(
+        formatUnixTimestampYMDHM({ timestampSeconds, timezone: deviceTimezone }),
+      )
     })
   })
 

--- a/__tests__/utils/date.spec.ts
+++ b/__tests__/utils/date.spec.ts
@@ -5,6 +5,7 @@ jest.mock("@app/utils/error-logging", () => ({
   reportError: (...args: readonly unknown[]) => mockReportError(...args),
 }))
 
+import { MASK_CHAR } from "@app/config/appinfo"
 import {
   formatCardValidThruDisplay,
   formatDateFromNow,
@@ -14,6 +15,7 @@ import {
   formatShortDate,
   formatUnixTimestampYMDHM,
   getLastDayOfMonth,
+  getTimeLeft,
   isSameDay,
   isToday,
   isYesterday,
@@ -205,6 +207,51 @@ describe("date utils", () => {
     })
   })
 
+  describe("getTimeLeft", () => {
+    const NOW = Date.parse("2024-06-10T12:00:00Z")
+    const SECOND = 1000
+    const MINUTE = 60 * SECOND
+    const HOUR = 60 * MINUTE
+    const DAY = 24 * HOUR
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(NOW)
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it.each([
+      {
+        name: "counts down days, hours, minutes and seconds",
+        until: NOW + 2 * DAY + 3 * HOUR + 4 * MINUTE + 5 * SECOND,
+        expected: "02:03:04:05",
+      },
+      {
+        name: "pads every segment to two digits",
+        until: NOW + MINUTE + SECOND,
+        expected: "00:00:01:01",
+      },
+      {
+        name: "returns all zeros the instant the window closes",
+        until: NOW,
+        expected: "00:00:00:00",
+      },
+    ])("returns $expected when it $name", ({ until, expected }) => {
+      expect(getTimeLeft({ after: NOW - DAY, until })).toBe(expected)
+    })
+
+    it("returns an empty string once the window has passed", () => {
+      expect(getTimeLeft({ after: NOW - 2 * DAY, until: NOW - DAY })).toBe("")
+    })
+
+    it("returns an empty string before the window opens", () => {
+      expect(getTimeLeft({ after: NOW + DAY, until: NOW + 2 * DAY })).toBe("")
+    })
+  })
+
   describe("formatUnixTimestampYMDHM", () => {
     it.each([
       {
@@ -307,6 +354,12 @@ describe("date utils", () => {
         formatCardValidThruDisplay(new Date("2031-01-15T12:00:00Z"), true, "*"),
       ).toBe("01/ 31")
     })
+
+    it("masks with the default mask character when none is given", () => {
+      expect(formatCardValidThruDisplay("2024-12-05", false)).toBe(
+        `${MASK_CHAR}${MASK_CHAR} / ${MASK_CHAR}${MASK_CHAR}`,
+      )
+    })
   })
 
   describe("getLastDayOfMonth", () => {
@@ -384,6 +437,12 @@ describe("date utils", () => {
 
     it("rolls months over into the following year", () => {
       expect(formatDateFromNow({ months: 18, locale: "en-US" })).toBe("Sep 12, 2027")
+    })
+
+    it("falls back to en-US when no locale is given", () => {
+      expect(formatDateFromNow({ years: 1 })).toBe(
+        formatDateFromNow({ years: 1, locale: "en-US" }),
+      )
     })
   })
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
@@ -151,6 +151,10 @@ const PaymentDetailsSection: React.FC<{
 }) => {
   const styles = useStyles()
 
+  const formattedTime = createdAt
+    ? formatUnixTimestampYMDHM({ timestampSeconds: createdAt })
+    : ""
+
   return (
     <>
       <View style={styles.successActionFieldContainer}>
@@ -185,9 +189,7 @@ const PaymentDetailsSection: React.FC<{
       <View style={styles.successActionFieldContainer}>
         <SuccessActionComponent
           title={LL.SendBitcoinScreen.time()}
-          text={
-            createdAt ? formatUnixTimestampYMDHM({ timestampSeconds: createdAt }) : ""
-          }
+          text={formattedTime}
           key="time"
           visible={Boolean(createdAt)}
         />

--- a/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx
@@ -185,7 +185,9 @@ const PaymentDetailsSection: React.FC<{
       <View style={styles.successActionFieldContainer}>
         <SuccessActionComponent
           title={LL.SendBitcoinScreen.time()}
-          text={createdAt ? formatUnixTimestampYMDHM(createdAt) : ""}
+          text={
+            createdAt ? formatUnixTimestampYMDHM({ timestampSeconds: createdAt }) : ""
+          }
           key="time"
           visible={Boolean(createdAt)}
         />

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -33,8 +33,6 @@ export const JULY_1_2024_12_AM_UTC_MINUS_6 = new Date(
 ).getTime()
 
 const secondsToDDMMSS = (totalSeconds: number) => {
-  if (totalSeconds < 0) return ""
-
   const days = Math.floor(totalSeconds / 86400) // There are 86400 seconds in a day
   const hours = Math.floor((totalSeconds - days * 86400) / 3600) // 3600 seconds in an hour
   const minutes = Math.floor((totalSeconds - days * 86400 - hours * 3600) / 60)

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -85,10 +85,13 @@ export const formatShortDate = ({
 /**
  * e.g. 1747691078 at UTC-6 -> "2025-05-19 15:44". Renders in the device timezone,
  * matching the transaction list and detail screens; `timezone` is only injected so tests
- * can pin a zone. Each half borrows the locale whose shape it needs, `en-CA` for the
- * `YYYY-MM-DD` order and `en-GB` for the 24 hour clock, and joining them here keeps the
- * result stable whatever separator a locale would pick; `hourCycle: "h23"` keeps midnight
- * as `00` rather than `24`.
+ * can pin a zone, so no production caller passes one and a malformed string never reaches
+ * `toLocaleTimeString`, which would throw a RangeError: give this the guard
+ * `formatDayAndMonth` carries if a backend zone ever arrives here. Each half borrows the
+ * locale whose shape it needs, `en-CA` for the `YYYY-MM-DD` order and `en-GB` for the 24
+ * hour clock, and joining them here keeps the result stable whatever separator a locale
+ * would pick; `en-GB` already defaults to `h23`, so `hourCycle` is not load-bearing and
+ * only guards a device ICU that would resolve it otherwise and render midnight as `24`.
  */
 export const formatUnixTimestampYMDHM = ({
   timestampSeconds,

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -85,11 +85,12 @@ export const formatShortDate = ({
 }
 
 /**
- * e.g. 1747691078 -> "2025-05-19 15:44". Renders in the device timezone, matching the
- * transaction list and detail screens; `timezone` is only injected so tests can pin a
- * zone. The two halves are formatted apart and joined here so the shape stays
- * `YYYY-MM-DD HH:mm` whatever separator the locale would pick, and `hourCycle: "h23"`
- * keeps midnight as `00` rather than `24`.
+ * e.g. 1747691078 at UTC-6 -> "2025-05-19 15:44". Renders in the device timezone,
+ * matching the transaction list and detail screens; `timezone` is only injected so tests
+ * can pin a zone. Each half borrows the locale whose shape it needs, `en-CA` for the
+ * `YYYY-MM-DD` order and `en-GB` for the 24 hour clock, and joining them here keeps the
+ * result stable whatever separator a locale would pick; `hourCycle: "h23"` keeps midnight
+ * as `00` rather than `24`.
  */
 export const formatUnixTimestampYMDHM = ({
   timestampSeconds,

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -56,9 +56,38 @@ export const getTimeLeft = ({ after, until }: { after: number; until: number }) 
   return secondsToDDMMSS(sLeft)
 }
 
-// e.g. 1747691078 -> "2025-05-19 15:44"
-export function formatUnixTimestampYMDHM(timestampInSeconds: number) {
-  return new Date(timestampInSeconds * 1000).toISOString().slice(0, 16).replace("T", " ")
+/**
+ * e.g. 1747691078 -> "2025-05-19 15:44". Renders in the device timezone, matching the
+ * transaction list and detail screens; `timezone` is only injected so tests can pin a
+ * zone. Parts are assembled by hand because the locale separator between date and time
+ * is not stable across ICU versions.
+ */
+export const formatUnixTimestampYMDHM = ({
+  timestampSeconds,
+  timezone,
+}: {
+  timestampSeconds: number
+  timezone?: string
+}): string => {
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: timezone,
+  }
+
+  const parts = new Intl.DateTimeFormat("en-CA", options).formatToParts(
+    new Date(timestampSeconds * 1000),
+  )
+  const partValue = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? ""
+
+  return `${partValue("year")}-${partValue("month")}-${partValue("day")} ${partValue(
+    "hour",
+  )}:${partValue("minute")}`
 }
 
 export const isSameDay = (a: Date, b: Date) =>

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -56,40 +56,6 @@ export const getTimeLeft = ({ after, until }: { after: number; until: number }) 
   return secondsToDDMMSS(sLeft)
 }
 
-/**
- * e.g. 1747691078 -> "2025-05-19 15:44". Renders in the device timezone, matching the
- * transaction list and detail screens; `timezone` is only injected so tests can pin a
- * zone. Parts are assembled by hand because the locale separator between date and time
- * is not stable across ICU versions.
- */
-export const formatUnixTimestampYMDHM = ({
-  timestampSeconds,
-  timezone,
-}: {
-  timestampSeconds: number
-  timezone?: string
-}): string => {
-  const options: Intl.DateTimeFormatOptions = {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hourCycle: "h23",
-    timeZone: timezone,
-  }
-
-  const parts = new Intl.DateTimeFormat("en-CA", options).formatToParts(
-    new Date(timestampSeconds * 1000),
-  )
-  const partValue = (type: Intl.DateTimeFormatPartTypes) =>
-    parts.find((part) => part.type === type)?.value ?? ""
-
-  return `${partValue("year")}-${partValue("month")}-${partValue("day")} ${partValue(
-    "hour",
-  )}:${partValue("minute")}`
-}
-
 export const isSameDay = (a: Date, b: Date) =>
   a.getFullYear() === b.getFullYear() &&
   a.getMonth() === b.getMonth() &&
@@ -116,6 +82,30 @@ export const formatShortDate = ({
   }
 
   return new Date(createdAt * 1000).toLocaleDateString("en-CA", options)
+}
+
+/**
+ * e.g. 1747691078 -> "2025-05-19 15:44". Renders in the device timezone, matching the
+ * transaction list and detail screens; `timezone` is only injected so tests can pin a
+ * zone. The two halves are formatted apart and joined here so the shape stays
+ * `YYYY-MM-DD HH:mm` whatever separator the locale would pick, and `hourCycle: "h23"`
+ * keeps midnight as `00` rather than `24`.
+ */
+export const formatUnixTimestampYMDHM = ({
+  timestampSeconds,
+  timezone,
+}: {
+  timestampSeconds: number
+  timezone?: string
+}): string => {
+  const time = new Date(timestampSeconds * 1000).toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone: timezone,
+  })
+
+  return `${formatShortDate({ createdAt: timestampSeconds, timezone })} ${time}`
 }
 
 export const formatDayAndMonth = ({

--- a/jest.timezone-environment.js
+++ b/jest.timezone-environment.js
@@ -1,0 +1,32 @@
+import { TestEnvironment as NodeEnvironment } from "jest-environment-node"
+
+const PINNED_TIMEZONE = "America/El_Salvador"
+
+/**
+ * Jest hands every spec a sandboxed copy of `process.env`, so a spec that assigns `TZ`
+ * itself never reaches the real environment and the process keeps whatever zone the runner
+ * exported, which is UTC on CI. Pinning a non-UTC zone out here, in the worker process that
+ * owns the real env, is what lets a spec assert that a formatter follows the device zone
+ * and still fail on a UTC runner. Opt in per file with
+ * `@jest-environment ./jest.timezone-environment`, expect the pinned zone rather than the
+ * runner's, and note that the zone is restored on teardown so later specs are untouched.
+ */
+export default class TimezoneEnvironment extends NodeEnvironment {
+  constructor(config, context) {
+    super(config, context)
+
+    this.runnerTimezone = process.env.TZ
+    process.env.TZ = PINNED_TIMEZONE
+    this.global.process.env.TZ = PINNED_TIMEZONE
+  }
+
+  async teardown() {
+    if (this.runnerTimezone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = this.runnerTimezone
+    }
+
+    await super.teardown()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -234,6 +234,7 @@
     "eslint-plugin-react-native": "^4.0.0",
     "jest": "^29.2.1",
     "jest-circus": "^29.4.1",
+    "jest-environment-node": "^29.7.0",
     "jest-transform-stub": "^2.0.0",
     "jest-ts-auto-mock": "^2.1.0",
     "jetifier": "^2.0.0",


### PR DESCRIPTION
## Summary

The send-completed receipt formatted its `Time` row through `formatUnixTimestampYMDHM`, which built the string from `toISOString()` and therefore always rendered UTC. Every other transaction surface already renders in the device timezone (`transaction-date.tsx` and `formatShortDate` both pass through `toLocaleString`/`toLocaleDateString` with no forced zone), so the receipt was the only screen disagreeing with the phone clock: a payment made at 13:10 local showed as 19:10.

This renders the row in the device timezone while keeping the `YYYY-MM-DD HH:mm` shape.

Closes #3896

## Changes

- `app/utils/date.ts`: `formatUnixTimestampYMDHM` now takes `{ timestampSeconds, timezone? }` and builds the string from two halves, `formatShortDate` for the date and `toLocaleTimeString` for the time, instead of slicing an ISO string. Reusing `formatShortDate` keeps the receipt on the exact date formatting the transaction list already ships, so the function moved below it in the file. Each half borrows the locale whose shape it needs, `en-CA` for the `YYYY-MM-DD` order and `en-GB` for the 24 hour clock, and the two are joined by hand so the result does not depend on the separator a locale would pick between date and time. `hourCycle: "h23"` keeps midnight as `00` rather than `24`. The optional `timezone` follows the convention already used by `formatShortDate` and `formatDayAndMonth` in the same module, so tests can pin a zone; production callers omit it and get the device zone. Separately, the unreachable `totalSeconds < 0` guard was dropped from `secondsToDDMMSS`: its only caller `getTimeLeft` already returns `""` whenever the window is closed, so the branch could never run and was the last thing keeping the module short of full coverage.
- `app/screens/send-bitcoin-screen/send-bitcoin-completed-screen.tsx`: updated the single call site to the object signature and pulled the ternary out of the JSX prop into a named `formattedTime`.
- `jest.timezone-environment.js`: a `jest-environment-node` subclass that pins the process timezone for a single spec file and restores the runner's zone on teardown. Jest hands every spec a proxy over a copy of `process.env`, so a spec that assigns `TZ` itself never reaches Node's real environment and neither `Date` nor `Intl` changes zone; pinning it out here, in the worker process that owns the real env, is what makes a device-timezone assertion fail on a UTC runner. `jest-environment-node` is declared in `package.json` because the environment imports it directly, at the `^29.7.0` already keyed in the lockfile, so `yarn.lock` is unchanged.
- `__tests__/utils/date-device-timezone.spec.ts`: the default path, opted into that environment through a `@jest-environment` docblock, so a `19:04Z` timestamp has to render as `13:04`. Keeping it in its own file leaves the pinned zone off the rest of the date suite, and doing it per file rather than through a `TZ=` prefix in the test script means the guard holds under a plain `yarn test`, which is what CI runs.
- `__tests__/utils/date.spec.ts`: seven cases for the formatter with the zone injected (UTC, negative and positive offsets, a day rollover in each direction, midnight and zero padding), plus the cases needed to cover the rest of the module: `getTimeLeft` across its countdown segments and both closed-window paths, the default mask character, and the default locale.
- `__tests__/screens/send-bitcoin-completed-screen.spec.tsx`: the time row renders a wall-clock date, the time and type rows disappear without their values, the close and share buttons fire, and the header drops out of the capture while sharing.

The regression guard is split across the two date specs on purpose. `date.spec.ts` pins a zone through the formatter's own argument, which covers the shape of the output but leaves the default path unguarded: CI resolves the process zone to UTC, so any expectation derived from it compares UTC against UTC and would keep passing even if the default regressed to a hardcoded UTC. `date-device-timezone.spec.ts` closes that hole by pinning a non-UTC process zone instead. With the default path regressed to a hardcoded UTC, it fails under `TZ=UTC` with `Expected "2026-08-03 13:04", Received "2026-08-03 19:04"` while all 75 injected-zone cases still pass, and a spec running after it in the same `--runInBand` process still sees `UTC`, so the pin does not leak. The screen spec asserts the rendered shape only, since a screen-level test cannot pin the process timezone.

## Test plan

- `yarn jest __tests__/utils/date.spec.ts __tests__/utils/date-device-timezone.spec.ts __tests__/screens/send-bitcoin-completed-screen.spec.tsx`: 96 passed, no console output, `date.ts` at 100% statements, branches, functions and lines
- `yarn jest __tests__/utils __tests__/screens/send-bitcoin-completed-screen.spec.tsx`: 563 passed across 35 suites, the wider run that covers every consumer of the module
- The same runs under `TZ=UTC`, to reproduce what CI resolves the process zone to
- `yarn tsc:check` and `eslint` on the changed files: clean. `yarn install --frozen-lockfile`: passes, `yarn.lock` untouched
- Device (Android emulator): sent a 100 sat Lightning payment before and after the change. The status bar clock in both screenshots is the ground truth.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="1080" height="2400" alt="3896-1-before" src="https://github.com/user-attachments/assets/8da33b94-08af-4e11-8023-b1b09d59942e" /> | <img width="1080" height="2400" alt="3896-2-after" src="https://github.com/user-attachments/assets/91db9b9e-d208-464e-b6f8-2ef27ac924f5" /> |

Compare each receipt against the status bar clock of that same screenshot. Before, the phone reads `1:04` while the receipt says `19:04`, six hours ahead because the emulator sits at UTC-6. After, the phone reads `1:10` and the receipt says `13:10`, the same wall clock.

The two columns are separate payments, so the minutes differ between them; the clock in each screenshot is the reference, not the other column.
