### PR TITLE
fix(self-custodial): surface why a fee quote failed instead of a dead end

### DIFF
--- a/__tests__/screens/send-bitcoin-screen/use-fee.spec.ts
+++ b/__tests__/screens/send-bitcoin-screen/use-fee.spec.ts
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+
+import { WalletCurrency } from "@app/graphql/generated"
+import useFee from "@app/screens/send-bitcoin-screen/use-fee"
+import { SelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
+import { toBtcMoneyAmount } from "@app/types/amounts"
+
+// use-fee only calls these to hand them to getFee; the self-custodial quotes ignore them.
+// The tuple is built once and shared: it lands in the fee effect's dependency array, so a
+// fresh identity per render would re-fire the effect forever (Apollo's is stable for real).
+jest.mock("@app/graphql/generated", () => {
+  const probe = [jest.fn(), {}]
+  return {
+    WalletCurrency: { Btc: "BTC", Usd: "USD" },
+    useLnInvoiceFeeProbeMutation: () => probe,
+    useLnNoAmountInvoiceFeeProbeMutation: () => probe,
+    useLnUsdInvoiceFeeProbeMutation: () => probe,
+    useLnNoAmountUsdInvoiceFeeProbeMutation: () => probe,
+    useOnChainTxFeeLazyQuery: () => probe,
+    useOnChainUsdTxFeeLazyQuery: () => probe,
+    useOnChainUsdTxFeeAsBtcDenominatedLazyQuery: () => probe,
+  }
+})
+
+const mockRecordError = jest.fn()
+jest.mock("@react-native-firebase/crashlytics", () => () => ({
+  recordError: (...args: unknown[]) => mockRecordError(...args),
+  log: jest.fn(),
+}))
+
+const classifiedError = (message: string) => ({
+  __typename: "GraphQLApplicationError" as const,
+  message,
+})
+
+/** `errors` only exists on the non-"set" arms of FeeType, so narrow before reading it. */
+const asErrored = (fee: ReturnType<typeof useFee>) => {
+  if (fee.status !== "error")
+    throw new Error(`expected an errored fee, got ${fee.status}`)
+  return fee
+}
+
+describe("useFee", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("stays unset when there is no getFee function", () => {
+    const { result } = renderHook(() => useFee(undefined))
+
+    expect(result.current.status).toBe("unset")
+  })
+
+  it("sets the quoted amount on success", async () => {
+    const getFee = jest.fn().mockResolvedValue({ amount: toBtcMoneyAmount(42) })
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("set")
+    })
+    expect(result.current.amount?.amount).toBe(42)
+  })
+
+  // The classified code is the whole point of the plumbing: the confirmation screen reads
+  // it off this state to name the cause instead of showing its generic dead-end string.
+  it("threads the errors from a failed quote into the error state", async () => {
+    const getFee = jest.fn().mockResolvedValue({
+      amount: undefined,
+      errors: [classifiedError(SelfCustodialErrorCode.InsufficientFunds)],
+    })
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(asErrored(result.current).errors?.[0]?.message).toBe(
+      SelfCustodialErrorCode.InsufficientFunds,
+    )
+  })
+
+  it("threads errors through even when the quote still carries an amount", async () => {
+    const getFee = jest.fn().mockResolvedValue({
+      amount: toBtcMoneyAmount(7),
+      errors: [classifiedError("max fee only")],
+    })
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(result.current.amount?.amount).toBe(7)
+    expect(asErrored(result.current).errors?.[0]?.message).toBe("max fee only")
+  })
+
+  it("leaves errors undefined when the quote fails without a classified code", async () => {
+    const getFee = jest.fn().mockResolvedValue({ amount: undefined })
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(asErrored(result.current).errors).toBeUndefined()
+  })
+
+  it("reports and errors without a code when getFee itself throws", async () => {
+    const getFee = jest.fn().mockRejectedValue(new Error("quote exploded"))
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error")
+    })
+    expect(asErrored(result.current).errors).toBeUndefined()
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "quote exploded" }),
+    )
+  })
+
+  it("passes the settlement currency generic through untouched", async () => {
+    const usdFee = { amount: 5, currency: WalletCurrency.Usd, currencyCode: "USD" }
+    const getFee = jest.fn().mockResolvedValue({ amount: usdFee })
+
+    const { result } = renderHook(() => useFee(getFee))
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("set")
+    })
+    expect(result.current.amount?.currency).toBe(WalletCurrency.Usd)
+  })
+})

--- a/__tests__/screens/send-confirmation.spec.tsx
+++ b/__tests__/screens/send-confirmation.spec.tsx
@@ -12,6 +12,7 @@ import * as PaymentDetailsLightning from "@app/screens/send-bitcoin-screen/payme
 import { loadLocale } from "@app/i18n/i18n-util.sync"
 import { i18nObject } from "@app/i18n/i18n-util"
 import SendBitcoinConfirmationScreen from "@app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen"
+import { SelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
 import { RootStackParamList } from "@app/navigation/stack-param-lists"
 import { RouteProp } from "@react-navigation/native"
 
@@ -990,6 +991,85 @@ describe("SendBitcoinConfirmationScreen — skipBalanceCheck matrix", () => {
     await flushEffects()
 
     expect(screen.getByTestId("slider").props.accessibilityState.disabled).toBe(false)
+  })
+})
+
+// A failed self-custodial quote used to render only the generic "Unable to calculate fee"
+// with the slider disabled, naming no cause. The classified SDK code now picks the message.
+describe("SendBitcoinConfirmationScreen — fee error messages", () => {
+  const genericFeeError = /Unable to calculate fee/i
+  const insufficientFunds = /Not enough funds to cover the amount and network fees/i
+
+  const renderWithFee = async (fee: Record<string, unknown>) => {
+    mockUseFee.mockReturnValue(fee)
+    render(
+      <ContextForScreen>
+        <Intraledger route={buildUsdSettlementRoute(200)} />
+      </ContextForScreen>,
+    )
+    await flushEffects()
+  }
+
+  it("names the cause when the quote carries a classified self-custodial code", async () => {
+    await renderWithFee({
+      status: "error",
+      errors: [
+        {
+          __typename: "GraphQLApplicationError",
+          message: SelfCustodialErrorCode.InsufficientFunds,
+        },
+      ],
+    })
+
+    expect(screen.getByText(insufficientFunds)).toBeTruthy()
+    expect(screen.queryByText(genericFeeError)).toBeNull()
+  })
+
+  it("translates the network-error code too", async () => {
+    await renderWithFee({
+      status: "error",
+      errors: [
+        {
+          __typename: "GraphQLApplicationError",
+          message: SelfCustodialErrorCode.NetworkError,
+        },
+      ],
+    })
+
+    expect(screen.getByText(/Network connection problem/i)).toBeTruthy()
+  })
+
+  it("falls back to the generic string when the quote carries no code", async () => {
+    await renderWithFee({ status: "error" })
+
+    expect(screen.getByText(genericFeeError)).toBeTruthy()
+  })
+
+  // Custodial errors are raw GraphQL text, not something to put in front of a user, and
+  // useTranslateSdkError passes unknown input straight through — hence the code guard.
+  it("keeps the generic string for a custodial GraphQL error message", async () => {
+    await renderWithFee({
+      status: "error",
+      errors: [
+        {
+          __typename: "GraphQLApplicationError",
+          message: "Unbalanced transaction: ledger entry rejected",
+        },
+      ],
+    })
+
+    expect(screen.getByText(genericFeeError)).toBeTruthy()
+    expect(screen.queryByText(/Unbalanced transaction/i)).toBeNull()
+  })
+
+  it("shows no fee error at all once the quote succeeds", async () => {
+    await renderWithFee({
+      status: "set",
+      amount: { amount: 0, currency: WalletCurrency.Usd, currencyCode: "USD" },
+    })
+
+    expect(screen.queryByText(genericFeeError)).toBeNull()
+    expect(screen.queryByText(insufficientFunds)).toBeNull()
   })
 })
 

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -57,6 +57,9 @@ jest.mock("@app/self-custodial/sdk-error", () => {
 jest.mock("@breeztech/breez-sdk-spark-react-native", () => ({
   AesSuccessActionDataResult_Tags: { Decrypted: "Decrypted", ErrorStatus: "ErrorStatus" },
   FeePolicy: { FeesExcluded: 0, FeesIncluded: 1 },
+  // The shared fee-failure helper lives in send-helpers, which builds its tier→speed map
+  // at module scope.
+  OnchainConfirmationSpeed: { Fast: 0, Medium: 1, Slow: 2 },
   SuccessActionProcessed_Tags: { Aes: "Aes", Message: "Message", Url: "Url" },
   PaymentDetails: {
     Lightning: {

--- a/__tests__/self-custodial/payment-details/lnurl.spec.ts
+++ b/__tests__/self-custodial/payment-details/lnurl.spec.ts
@@ -401,6 +401,38 @@ describe("createSelfCustodialLnurlPaymentDetails", () => {
       const result = await detail.getFee({} as never)
       expect(result.amount).toBeUndefined()
     })
+
+    // Without the classified code the confirmation screen can only show its generic
+    // "unable to calculate fee", which names no cause and leaves the slider disabled.
+    it("carries the classified code in errors when prepareLnurl throws", async () => {
+      mockPrepareLnurl.mockRejectedValue({ tag: "LnurlError", inner: ["bad callback"] })
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.errors).toEqual([
+        {
+          __typename: "GraphQLApplicationError",
+          message: SelfCustodialErrorCode.InvalidInput,
+        },
+      ])
+    })
+
+    it("falls back to the Generic code for an unclassified throw", async () => {
+      mockPrepareLnurl.mockRejectedValue(new Error("boom"))
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.Generic)
+    })
+
+    it("leaves errors unset on a successful quote", async () => {
+      mockPrepareLnurl.mockResolvedValue({})
+      mockExtractLnurlFee.mockReturnValue(5)
+      const detail = createSelfCustodialLnurlPaymentDetails(createParams())
+      if (!detail.canGetFee) throw new Error("expected canGetFee")
+      const result = await detail.getFee({} as never)
+      expect(result.errors).toBeUndefined()
+    })
   })
 
   describe("sendPaymentMutation", () => {

--- a/__tests__/self-custodial/payment-details/send-helpers.spec.ts
+++ b/__tests__/self-custodial/payment-details/send-helpers.spec.ts
@@ -214,7 +214,7 @@ describe("createGetFee", () => {
 
   // `use-fee` only reports thrown errors, and this never throws — so without reporting
   // here the failure is invisible in Crashlytics.
-  it("records fee failures to crashlytics with a scoped Error", async () => {
+  it("records an unexplained fee failure to crashlytics", async () => {
     mockPrepareSendPayment.mockRejectedValue(new Error("prepare refused"))
 
     const getFee = createGetFee({
@@ -227,6 +227,53 @@ describe("createGetFee", () => {
     expect(mockRecordError).toHaveBeenCalledWith(
       expect.objectContaining({ message: "prepare refused" }),
     )
+  })
+
+  // The SDK adds the fee on top of the amount, so sending the full balance is the common
+  // way to fail a quote. The user lowers the amount and succeeds — not a defect, and it
+  // would otherwise fire a non-fatal per attempt, per user, on a flow that works.
+  it("keeps an InsufficientFunds quote failure a breadcrumb, not a non-fatal", async () => {
+    mockPrepareSendPayment.mockRejectedValue(sdkError("InsufficientFunds"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.InsufficientFunds)
+    expect(mockRecordError).not.toHaveBeenCalled()
+  })
+
+  it("keeps a BelowMinimum quote failure a breadcrumb, not a non-fatal", async () => {
+    mockPrepareSendPayment.mockRejectedValue(
+      sdkError("Generic", ["amount below minimum"]),
+    )
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.BelowMinimum)
+    expect(mockRecordError).not.toHaveBeenCalled()
+  })
+
+  it("still records an InvalidInput quote failure — it can mean our own bug", async () => {
+    mockPrepareSendPayment.mockRejectedValue(sdkError("InvalidInput"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.InvalidInput)
+    expect(mockRecordError).toHaveBeenCalled()
   })
 
   it("records non-Error throws as a scoped Error so Sentry never gets a bare string", async () => {

--- a/__tests__/self-custodial/payment-details/send-helpers.spec.ts
+++ b/__tests__/self-custodial/payment-details/send-helpers.spec.ts
@@ -164,6 +164,109 @@ describe("createGetFee", () => {
     expect(result.amount).toBeUndefined()
   })
 
+  // A failed quote used to return a bare `{ amount: undefined }`, so the confirmation
+  // screen could only show its generic "unable to calculate fee" dead end. The classified
+  // code lets it name the cause — most often a full-balance send the user can just lower.
+  it("classifies a thrown SdkError(InsufficientFunds) into the errors array", async () => {
+    mockPrepareSendPayment.mockRejectedValue(sdkError("InsufficientFunds"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.amount).toBeUndefined()
+    expect(result.errors).toEqual([
+      {
+        __typename: "GraphQLApplicationError",
+        message: SelfCustodialErrorCode.InsufficientFunds,
+      },
+    ])
+  })
+
+  it("classifies a thrown SdkError(NetworkError) into the errors array", async () => {
+    mockPrepareSendPayment.mockRejectedValue(sdkError("NetworkError"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.NetworkError)
+  })
+
+  it("falls back to the Generic code for a non-SdkError throw", async () => {
+    mockPrepareSendPayment.mockRejectedValue(new Error("fail"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.Generic)
+  })
+
+  // `use-fee` only reports thrown errors, and this never throws — so without reporting
+  // here the failure is invisible in Crashlytics.
+  it("records fee failures to crashlytics with a scoped Error", async () => {
+    mockPrepareSendPayment.mockRejectedValue(new Error("prepare refused"))
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    await getFee()
+
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "prepare refused" }),
+    )
+  })
+
+  it("records non-Error throws as a scoped Error so Sentry never gets a bare string", async () => {
+    mockPrepareSendPayment.mockRejectedValue("network blip")
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    await getFee()
+
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          "Self-custodial Lightning fee failed: network blip",
+        ),
+      }),
+    )
+  })
+
+  it("leaves errors unset on a successful quote", async () => {
+    mockPrepareSendPayment.mockResolvedValue({
+      paymentMethod: {
+        tag: "Bolt11Invoice",
+        inner: { sparkTransferFeeSats: BigInt(3), lightningFeeSats: BigInt(21) },
+      },
+    })
+
+    const getFee = createGetFee({
+      sdk: mockSdk,
+      paymentRequest: "lnbc1...",
+      amount: undefined,
+    })
+    const result = await getFee()
+
+    expect(result.errors).toBeUndefined()
+    expect(mockRecordError).not.toHaveBeenCalled()
+  })
+
   it("threads the SDK dust adjustment through to amountAdjustment", async () => {
     mockPrepareSendPayment.mockResolvedValue({
       paymentMethod: {
@@ -304,6 +407,27 @@ describe("createGetFeeOnchain", () => {
     expect(result.amount).toBeUndefined()
   })
 
+  // Nothing throws on this path, so it produced no error code and no crash report at all.
+  it("reports the Generic code when extractOnchainFees returns null", async () => {
+    mockPrepareSendPayment.mockResolvedValue({
+      amount: BigInt(50000),
+      paymentMethod: { tag: "Bolt11Invoice", inner: {} },
+    })
+
+    const getFee = createGetFeeOnchain(
+      { sdk: mockSdk, paymentRequest: "lnbc1...", amount: BigInt(50000) },
+      "medium",
+    )
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.Generic)
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("no BitcoinAddress fee quote"),
+      }),
+    )
+  })
+
   it("returns undefined amount when prepare fails", async () => {
     mockPrepareSendPayment.mockRejectedValue(new Error("fail"))
 
@@ -314,6 +438,45 @@ describe("createGetFeeOnchain", () => {
     const result = await getFee()
 
     expect(result.amount).toBeUndefined()
+  })
+
+  it("classifies a thrown SdkError(InsufficientFunds) into the errors array", async () => {
+    mockPrepareSendPayment.mockRejectedValue(sdkError("InsufficientFunds"))
+
+    const getFee = createGetFeeOnchain(
+      { sdk: mockSdk, paymentRequest: "bc1q...", amount: BigInt(50000) },
+      "fast",
+    )
+    const result = await getFee()
+
+    expect(result.errors?.[0]?.message).toBe(SelfCustodialErrorCode.InsufficientFunds)
+  })
+
+  it("records onchain fee failures to crashlytics with a scoped Error", async () => {
+    mockPrepareSendPayment.mockRejectedValue(new Error("prepare refused"))
+
+    const getFee = createGetFeeOnchain(
+      { sdk: mockSdk, paymentRequest: "bc1q...", amount: BigInt(50000) },
+      "fast",
+    )
+    await getFee()
+
+    expect(mockRecordError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "prepare refused" }),
+    )
+  })
+
+  it("leaves errors unset on a successful quote", async () => {
+    mockPrepareSendPayment.mockResolvedValue(onchainPrepared)
+
+    const getFee = createGetFeeOnchain(
+      { sdk: mockSdk, paymentRequest: "bc1q...", amount: BigInt(50000) },
+      "medium",
+    )
+    const result = await getFee()
+
+    expect(result.errors).toBeUndefined()
+    expect(mockRecordError).not.toHaveBeenCalled()
   })
 })
 

--- a/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-confirmation-screen.tsx
@@ -30,6 +30,7 @@ import {
   ZeroUsdMoneyAmount,
 } from "@app/types/amounts"
 import { useSendDustWarning, useTranslateSdkError } from "@app/self-custodial/hooks"
+import { isSelfCustodialErrorCode } from "@app/self-custodial/sdk-error"
 import { logPaymentAttempt, logPaymentResult } from "@app/utils/analytics"
 import { reportError } from "@app/utils/error-logging"
 import { CommonActions, RouteProp, useNavigation } from "@react-navigation/native"
@@ -153,7 +154,13 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
     hasAttemptedSend,
   } = useSendPayment(sendPaymentMutation)
 
-  const feeErrorText = String(LL.SendBitcoinConfirmationScreen.feeError())
+  // Self-custodial fee failures carry a classified SDK code; custodial ones carry raw
+  // GraphQL text that is not fit to show, so only the former replaces the generic string.
+  const feeErrorCode = fee.status === "error" ? fee.errors?.[0]?.message : undefined
+  const feeErrorText =
+    (isSelfCustodialErrorCode(feeErrorCode)
+      ? translateSdkError(feeErrorCode)
+      : undefined) ?? String(LL.SendBitcoinConfirmationScreen.feeError())
   let feeDisplayText = feeErrorText
   currencyFeeAmount = feeErrorText
   satFeeAmount = feeErrorText
@@ -563,7 +570,7 @@ const SendBitcoinConfirmationScreen: React.FC<Props> = ({ route }) => {
               <Text type="p2">{feeDisplayText} *</Text>
             )}
             {fee.status === "error" && !fee.amount && (
-              <Text type="p2">{LL.SendBitcoinConfirmationScreen.feeError()}</Text>
+              <Text type="p2">{feeErrorText}</Text>
             )}
           </View>
           {fee.status === "error" && Boolean(fee.amount) && (

--- a/app/screens/send-bitcoin-screen/use-fee.ts
+++ b/app/screens/send-bitcoin-screen/use-fee.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react"
 
 import { gql } from "@apollo/client"
 import {
+  GraphQlApplicationError,
   WalletCurrency,
   useLnInvoiceFeeProbeMutation,
   useLnNoAmountInvoiceFeeProbeMutation,
@@ -22,6 +23,7 @@ type FeeType =
   | {
       status: "loading" | "error" | "unset"
       amount?: undefined | null
+      errors?: readonly GraphQlApplicationError[]
     }
   | {
       amount: WalletAmount<WalletCurrency>
@@ -31,6 +33,7 @@ type FeeType =
   | {
       amount?: WalletAmount<WalletCurrency>
       status: "error"
+      errors?: readonly GraphQlApplicationError[]
     }
 
 gql`
@@ -143,6 +146,7 @@ const useFee = <T extends WalletCurrency>(getFeeFn?: GetFee<T> | null): FeeType 
           return setFee({
             status: "error",
             amount: feeResponse.amount,
+            errors: feeResponse.errors,
           })
         }
 

--- a/app/screens/send-bitcoin-screen/use-fee.ts
+++ b/app/screens/send-bitcoin-screen/use-fee.ts
@@ -21,17 +21,18 @@ import { GetFee } from "./payment-details/index.types"
 
 type FeeType =
   | {
-      status: "loading" | "error" | "unset"
+      status: "loading" | "unset"
       amount?: undefined | null
-      errors?: readonly GraphQlApplicationError[]
     }
   | {
       amount: WalletAmount<WalletCurrency>
       status: "set"
       amountAdjustment?: ConvertAmountAdjustment
     }
+  // The only arm that carries errors: a quote that failed, with the classified reason.
+  // `null` because GetFee may report a failure alongside an absent amount.
   | {
-      amount?: WalletAmount<WalletCurrency>
+      amount?: WalletAmount<WalletCurrency> | null
       status: "error"
       errors?: readonly GraphQlApplicationError[]
     }

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -31,7 +31,6 @@ import {
   type WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { ConvertDirection } from "@app/types/payment"
-import { reportError } from "@app/utils/error-logging"
 
 import {
   buildConversionType,
@@ -42,6 +41,8 @@ import {
   toSdkSendAmount,
 } from "../bridge"
 import { classifySdkError } from "../sdk-error"
+
+import { feeFailure } from "./send-helpers"
 
 const SAT_TO_MILLISAT = BigInt(1000)
 
@@ -204,16 +205,7 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
             const feeSats = extractLnurlFee(prepared)
             return { amount: asBtcSettlementAmount<T>(feeSats) }
           } catch (err) {
-            reportError("Self-custodial LNURL fee", err)
-            return {
-              amount: undefined,
-              errors: [
-                {
-                  __typename: "GraphQLApplicationError" as const,
-                  message: classifySdkError(err),
-                },
-              ],
-            }
+            return feeFailure<T>("Self-custodial LNURL fee", err)
           }
         },
         sendPaymentMutation: async () => {

--- a/app/self-custodial/payment-details/lnurl.ts
+++ b/app/self-custodial/payment-details/lnurl.ts
@@ -31,6 +31,7 @@ import {
   type WalletOrDisplayCurrency,
 } from "@app/types/amounts"
 import { ConvertDirection } from "@app/types/payment"
+import { reportError } from "@app/utils/error-logging"
 
 import {
   buildConversionType,
@@ -202,8 +203,17 @@ export const createSelfCustodialLnurlPaymentDetails = <T extends WalletCurrency>
             const prepared = await prepareLnurl(sdk, prepareOptions)
             const feeSats = extractLnurlFee(prepared)
             return { amount: asBtcSettlementAmount<T>(feeSats) }
-          } catch {
-            return { amount: undefined }
+          } catch (err) {
+            reportError("Self-custodial LNURL fee", err)
+            return {
+              amount: undefined,
+              errors: [
+                {
+                  __typename: "GraphQLApplicationError" as const,
+                  message: classifySdkError(err),
+                },
+              ],
+            }
           }
         },
         sendPaymentMutation: async () => {

--- a/app/self-custodial/payment-details/send-helpers.ts
+++ b/app/self-custodial/payment-details/send-helpers.ts
@@ -54,6 +54,22 @@ const toPrepareOptions = (params: PrepareParams) => ({
 const asGetFeeAmount = <T extends WalletCurrency>(feeSats: number) =>
   toBtcMoneyAmount(feeSats) as unknown as WalletAmount<T>
 
+/**
+ * A fee quote the SDK could not produce. The classified code travels in `errors` so the
+ * confirmation screen can name the cause — an unclassified failure leaves the user staring
+ * at a generic "unable to calculate fee" with a disabled slider and no way forward.
+ */
+const feeFailure = <T extends WalletCurrency>(
+  scope: string,
+  err: unknown,
+): SelfCustodialFeeResult<T> => {
+  reportError(scope, err)
+  return {
+    amount: undefined,
+    errors: [{ __typename: "GraphQLApplicationError", message: classifySdkError(err) }],
+  }
+}
+
 export const createGetFee = <T extends WalletCurrency>(
   params: PrepareParams,
 ): GetFee<T> => {
@@ -65,8 +81,8 @@ export const createGetFee = <T extends WalletCurrency>(
         prepared.conversionEstimate?.amountAdjustment,
       )
       return { amount: asGetFeeAmount<T>(feeSats), amountAdjustment }
-    } catch {
-      return { amount: undefined }
+    } catch (err) {
+      return feeFailure<T>("Self-custodial Lightning fee", err)
     }
   }
 }
@@ -75,15 +91,20 @@ export const createGetFeeOnchain = <T extends WalletCurrency>(
   params: PrepareParams,
   feeTier: FeeTierOption,
 ): GetFee<T> => {
-  return async () => {
+  return async (): Promise<SelfCustodialFeeResult<T>> => {
     try {
       const prepared = await prepareSend(params.sdk, toPrepareOptions(params))
       const fees = extractOnchainFees(prepared)
-      if (!fees) return { amount: undefined }
+      if (!fees) {
+        return feeFailure<T>(
+          "Self-custodial onchain fee",
+          new Error("prepareSend returned no BitcoinAddress fee quote"),
+        )
+      }
 
       return { amount: asGetFeeAmount<T>(fees[feeTier]) }
-    } catch {
-      return { amount: undefined }
+    } catch (err) {
+      return feeFailure<T>("Self-custodial onchain fee", err)
     }
   }
 }

--- a/app/self-custodial/payment-details/send-helpers.ts
+++ b/app/self-custodial/payment-details/send-helpers.ts
@@ -28,7 +28,7 @@ import {
   mapAmountAdjustment,
   prepareSend,
 } from "../bridge"
-import { classifySdkError } from "../sdk-error"
+import { classifySdkError, SelfCustodialErrorCode } from "../sdk-error"
 
 type PrepareParams = {
   sdk: BreezSdkInterface
@@ -55,18 +55,30 @@ const asGetFeeAmount = <T extends WalletCurrency>(feeSats: number) =>
   toBtcMoneyAmount(feeSats) as unknown as WalletAmount<T>
 
 /**
+ * Quote failures the user resolves themselves by changing the amount. They are the common
+ * way to fail a quote — the SDK adds the fee on top, so sending the full balance throws
+ * InsufficientFunds — and a flow that ends in a successful send is not a defect, so they
+ * stay breadcrumbs and leave the non-fatals to the failures actually worth chasing.
+ */
+const EXPECTED_FEE_CODES: ReadonlySet<SelfCustodialErrorCode> = new Set([
+  SelfCustodialErrorCode.InsufficientFunds,
+  SelfCustodialErrorCode.BelowMinimum,
+])
+
+/**
  * A fee quote the SDK could not produce. The classified code travels in `errors` so the
  * confirmation screen can name the cause — an unclassified failure leaves the user staring
  * at a generic "unable to calculate fee" with a disabled slider and no way forward.
  */
-const feeFailure = <T extends WalletCurrency>(
+export const feeFailure = <T extends WalletCurrency>(
   scope: string,
   err: unknown,
 ): SelfCustodialFeeResult<T> => {
-  reportError(scope, err)
+  const message = classifySdkError(err)
+  reportError(scope, err, { expected: EXPECTED_FEE_CODES.has(message) })
   return {
     amount: undefined,
-    errors: [{ __typename: "GraphQLApplicationError", message: classifySdkError(err) }],
+    errors: [{ __typename: "GraphQLApplicationError", message }],
   }
 }
 

--- a/app/self-custodial/sdk-error.ts
+++ b/app/self-custodial/sdk-error.ts
@@ -14,6 +14,13 @@ export const SelfCustodialErrorCode = {
 export type SelfCustodialErrorCode =
   (typeof SelfCustodialErrorCode)[keyof typeof SelfCustodialErrorCode]
 
+const ERROR_CODES: ReadonlySet<string> = new Set(Object.values(SelfCustodialErrorCode))
+
+/** Lets shared screens tell a classified self-custodial code apart from a custodial GraphQL message. */
+export const isSelfCustodialErrorCode = (
+  value: string | undefined,
+): value is SelfCustodialErrorCode => value !== undefined && ERROR_CODES.has(value)
+
 const TAG_TO_CODE: Record<SdkErrorTags, SelfCustodialErrorCode> = {
   [SdkErrorTags.InsufficientFunds]: SelfCustodialErrorCode.InsufficientFunds,
   [SdkErrorTags.MaxDepositClaimFeeExceeded]: SelfCustodialErrorCode.InsufficientFunds,


### PR DESCRIPTION
Every self-custodial `getFee` swallowed the SDK error in a bare `catch` and
returned `{ amount: undefined }`, which the confirmation screen renders as the
generic "Unable to calculate fee" with the slide-to-confirm disabled. The most
common trigger is benign and fixable by the user: the SDK defaults to
`FeesExcluded`, so a send at or near the full balance throws InsufficientFunds
during `prepareSendPayment`. The user was told nothing and had no way forward.

The failures were also invisible in error reporting. `reportError` in `use-fee`
only fires on a thrown error, and self-custodial `getFee` never throws, so none
of this reached Crashlytics. The send path already reported via
`reportSendFailure`; only the fee path was silent.

`classifySdkError` and the `SelfCustodialError` strings already existed and are
used for the same SDK errors on the details screen — this routes the fee path
through them too.

- classify and report in `createGetFee`, `createGetFeeOnchain` and the LNURL
  fee quote, returning the code in `errors`. Covers the `extractOnchainFees`
  null branch, which previously returned no signal at all.
- thread `errors` through `useFee` into the "error" fee state.
- translate the code on the confirmation screen via `useTranslateSdkError`,
  falling back to the generic string.

Custodial behaviour is unchanged. Custodial `errors` carry raw GraphQL text
that is not fit to show, and `useTranslateSdkError` falls through to `return
raw` on unknown input, so `isSelfCustodialErrorCode` gates the substitution to
classified self-custodial codes only.