### PR TITLE
fix(send): trim whitespace from destination input before parsing

### DIFF
--- a/__tests__/payment-destination/resolve-destination.integration.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.integration.spec.ts
@@ -3,6 +3,7 @@ import { requestPayServiceParams } from "lnurl-pay"
 import { Network as mockSparkNetwork } from "@breeztech/breez-sdk-spark-react-native"
 
 import { Network } from "@app/graphql/generated"
+import { parseDestination } from "@app/screens/send-bitcoin-screen/payment-destination"
 import { resolveDestination } from "@app/screens/send-bitcoin-screen/payment-destination/resolve-destination"
 import { PaymentType } from "@blinkbitcoin/blink-client"
 
@@ -109,6 +110,46 @@ describe("resolveDestination (integration: real parser)", () => {
 
     expect(result.valid).toBe(true)
     expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+  })
+
+  it("resolves a lightning address with surrounding whitespace", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: null },
+    })
+
+    const result = await resolveDestination(
+      {
+        rawInput: "  esaudeveloper@blink.sv  ",
+        myWalletIds: ["my-wallet-id"],
+        bitcoinNetwork: Network.Mainnet,
+        lnurlDomains: [lnAddressHostname],
+        accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+      },
+      { sdk: null, network: mockSparkNetwork.Regtest },
+      lnAddressHostname,
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
+  })
+
+  it("trims input in parseDestination itself so direct callers (NFC) are covered", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+
+    const result = await parseDestination({
+      rawInput: "  esaudeveloper@blink.sv  ",
+      myWalletIds: ["my-wallet-id"],
+      bitcoinNetwork: Network.Mainnet,
+      lnurlDomains: [lnAddressHostname],
+      accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.valid && result.validDestination.paymentType).toBe(
+      PaymentType.Intraledger,
+    )
   })
 
   it("resolves a matching-network Spark address to a valid Spark destination", async () => {

--- a/__tests__/payment-destination/resolve-destination.integration.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.integration.spec.ts
@@ -119,7 +119,7 @@ describe("resolveDestination (integration: real parser)", () => {
 
     const result = await resolveDestination(
       {
-        rawInput: "  esaudeveloper@blink.sv  ",
+        rawInput: "\t esaudeveloper@blink.sv \n",
         myWalletIds: ["my-wallet-id"],
         bitcoinNetwork: Network.Mainnet,
         lnurlDomains: [lnAddressHostname],
@@ -131,25 +131,12 @@ describe("resolveDestination (integration: real parser)", () => {
 
     expect(result.valid).toBe(true)
     expect(result.valid && result.validDestination.paymentType).toBe(PaymentType.Lnurl)
-  })
-
-  it("trims input in parseDestination itself so direct callers (NFC) are covered", async () => {
-    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
-      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
-    })
-
-    const result = await parseDestination({
-      rawInput: "  esaudeveloper@blink.sv  ",
-      myWalletIds: ["my-wallet-id"],
-      bitcoinNetwork: Network.Mainnet,
-      lnurlDomains: [lnAddressHostname],
-      accountDefaultWalletQuery: accountDefaultWalletQuery as never,
-    })
-
-    expect(result.valid).toBe(true)
-    expect(result.valid && result.validDestination.paymentType).toBe(
-      PaymentType.Intraledger,
-    )
+    // no whitespace may leak into the resolved destination
+    const identifier =
+      result.valid && "lnurlParams" in result.validDestination
+        ? result.validDestination.lnurlParams.identifier
+        : undefined
+    expect(identifier).toBe("esaudeveloper@blink.sv")
   })
 
   it("resolves a matching-network Spark address to a valid Spark destination", async () => {
@@ -196,5 +183,30 @@ describe("resolveDestination (integration: real parser)", () => {
 
     expect(result.valid).toBe(false)
     expect(!result.valid && result.invalidReason).toBe("WrongNetwork")
+  })
+})
+
+describe("parseDestination (integration: real parser)", () => {
+  // parseDestination is also called directly, bypassing resolveDestination
+  // (e.g. modal-nfc.tsx), so its own trim is pinned here.
+  it("trims surrounding whitespace before parsing", async () => {
+    const accountDefaultWalletQuery = jest.fn().mockResolvedValue({
+      data: { accountDefaultWallet: { id: "recipient-wallet-id" } },
+    })
+
+    const result = await parseDestination({
+      rawInput: "  esaudeveloper@blink.sv  ",
+      myWalletIds: ["my-wallet-id"],
+      bitcoinNetwork: Network.Mainnet,
+      lnurlDomains: ["blink.sv"],
+      accountDefaultWalletQuery: accountDefaultWalletQuery as never,
+    })
+
+    expect(result.valid).toBe(true)
+    expect(
+      result.valid &&
+        result.validDestination.paymentType === PaymentType.Intraledger &&
+        result.validDestination.handle,
+    ).toBe("esaudeveloper")
   })
 })

--- a/__tests__/payment-destination/resolve-destination.spec.ts
+++ b/__tests__/payment-destination/resolve-destination.spec.ts
@@ -104,6 +104,20 @@ describe("resolveDestination", () => {
       expect(result).toBe(invalid)
     })
 
+    it("trims surrounding whitespace from the raw input before parsing", async () => {
+      const parsed = { valid: true, validDestination: { paymentType: "Lightning" } }
+      mockParseDestination.mockResolvedValue(parsed)
+
+      const result = await resolveDestination(
+        { ...baseParams, rawInput: "  lnbc1...  " },
+        { sdk: null, network: SparkNetwork.Regtest },
+        lnAddressHostname,
+      )
+
+      expect(mockParseDestination).toHaveBeenCalledWith(baseParams)
+      expect(result).toBe(parsed)
+    })
+
     it("does not attempt the Spark pre-check when sdk is null", async () => {
       mockParseDestination.mockResolvedValue({ valid: false })
 
@@ -221,6 +235,31 @@ describe("resolveDestination", () => {
       expect(mockParseDestination).toHaveBeenCalledWith({
         ...baseParams,
         rawInput: "esaudeveloper@blink.sv",
+      })
+    })
+
+    it("passes trimmed input to the Spark pre-check and the parser", async () => {
+      const parsed = { valid: true, validDestination: { paymentType: "Intraledger" } }
+
+      mockParseSparkAddress.mockResolvedValue(null)
+      mockParseDestination.mockResolvedValue(parsed)
+      mockResolveUsername.mockResolvedValue(parsed)
+      mockWrapDestination.mockReturnValue(parsed)
+
+      await resolveDestination(
+        { ...baseParams, rawInput: "  sparkrt1qabc  " },
+        { sdk: fakeSdk, network: SparkNetwork.Regtest },
+        lnAddressHostname,
+      )
+
+      expect(mockParseSparkAddress).toHaveBeenCalledWith(
+        fakeSdk,
+        "sparkrt1qabc",
+        SparkNetwork.Regtest,
+      )
+      expect(mockParseDestination).toHaveBeenCalledWith({
+        ...baseParams,
+        rawInput: "sparkrt1qabc",
       })
     })
 

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -725,6 +725,79 @@ describe("SendBitcoinDestinationScreen", () => {
     await flushEffects()
   })
 
+  it("trims pasted clipboard content before validating", async () => {
+    jest.mocked(Clipboard.getString).mockResolvedValueOnce("  clipboard  ")
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Intraledger,
+        handle: "clipboard",
+        walletId: "wallet-id",
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+
+    const searchResponder = getResponderByLabel(LL.SendBitcoinScreen.placeholder())
+    const pasteButton = within(searchResponder).getByText(LL.common.paste())
+    fireEvent.press(pasteButton)
+
+    await flushAsync()
+    await flushAsync()
+
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "clipboard" }),
+    )
+    // the input box shows the cleaned value, not the raw clipboard content
+    expect(screen.getByLabelText(LL.SendBitcoinScreen.placeholder()).props.value).toBe(
+      "clipboard",
+    )
+
+    await flushEffects()
+  })
+
+  it("trims a typed destination with surrounding whitespace when pressing next", async () => {
+    parseDestinationMock.mockResolvedValue({
+      valid: true,
+      destinationDirection: DestinationDirection.Send,
+      validDestination: {
+        valid: true,
+        paymentType: PaymentType.Intraledger,
+        handle: "clipboard",
+        walletId: "wallet-id",
+      },
+      createPaymentDetail: jest.fn(),
+    })
+
+    render(
+      <ContextForScreen>
+        <SendBitcoinDestinationScreen route={sendBitcoinDestination} />
+      </ContextForScreen>,
+    )
+
+    fireEvent.changeText(
+      screen.getByLabelText(LL.SendBitcoinScreen.placeholder()),
+      "  clipboard  ",
+    )
+    fireEvent.press(screen.getByLabelText(LL.common.next()))
+
+    await flushAsync()
+    await flushAsync()
+
+    expect(parseDestinationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ rawInput: "clipboard" }),
+    )
+
+    await flushEffects()
+  })
+
   it("navigates merchant choices to the merchant selection screen", async () => {
     const merchants = [
       {

--- a/__tests__/screens/send-destination.spec.tsx
+++ b/__tests__/screens/send-destination.spec.tsx
@@ -726,14 +726,16 @@ describe("SendBitcoinDestinationScreen", () => {
   })
 
   it("trims pasted clipboard content before validating", async () => {
-    jest.mocked(Clipboard.getString).mockResolvedValueOnce("  clipboard  ")
+    // distinct from the module mock's default "clipboard" so a missing Once
+    // override cannot satisfy the assertions below
+    jest.mocked(Clipboard.getString).mockResolvedValueOnce("\t paddedclip \n")
     parseDestinationMock.mockResolvedValue({
       valid: true,
       destinationDirection: DestinationDirection.Send,
       validDestination: {
         valid: true,
         paymentType: PaymentType.Intraledger,
-        handle: "clipboard",
+        handle: "paddedclip",
         walletId: "wallet-id",
       },
       createPaymentDetail: jest.fn(),
@@ -753,14 +755,15 @@ describe("SendBitcoinDestinationScreen", () => {
     await flushAsync()
 
     expect(parseDestinationMock).toHaveBeenCalledWith(
-      expect.objectContaining({ rawInput: "clipboard" }),
+      expect.objectContaining({ rawInput: "paddedclip" }),
     )
     // the input box shows the cleaned value, not the raw clipboard content
     expect(screen.getByLabelText(LL.SendBitcoinScreen.placeholder()).props.value).toBe(
-      "clipboard",
+      "paddedclip",
     )
 
     await flushEffects()
+    await settleModalAnimations()
   })
 
   it("trims a typed destination with surrounding whitespace when pressing next", async () => {
@@ -770,7 +773,7 @@ describe("SendBitcoinDestinationScreen", () => {
       validDestination: {
         valid: true,
         paymentType: PaymentType.Intraledger,
-        handle: "clipboard",
+        handle: "alice",
         walletId: "wallet-id",
       },
       createPaymentDetail: jest.fn(),
@@ -784,7 +787,7 @@ describe("SendBitcoinDestinationScreen", () => {
 
     fireEvent.changeText(
       screen.getByLabelText(LL.SendBitcoinScreen.placeholder()),
-      "  clipboard  ",
+      "  alice  ",
     )
     fireEvent.press(screen.getByLabelText(LL.common.next()))
 
@@ -792,10 +795,18 @@ describe("SendBitcoinDestinationScreen", () => {
     await flushAsync()
 
     expect(parseDestinationMock).toHaveBeenCalledWith(
-      expect.objectContaining({ rawInput: "clipboard" }),
+      expect.objectContaining({ rawInput: "alice" }),
     )
+    // the valid result must survive the reducer's unparsedDestination echo
+    // check even though state still holds the untrimmed typed value — the
+    // confirm-username modal appearing proves it was not silently dropped
+    expect(
+      await screen.findByText(
+        LL.SendBitcoinDestinationScreen.confirmUsernameModal.title(),
+      ),
+    ).toBeTruthy()
 
-    await flushEffects()
+    await settleModalAnimations()
   })
 
   it("navigates merchant choices to the merchant selection screen", async () => {

--- a/app/screens/send-bitcoin-screen/payment-destination/index.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/index.ts
@@ -35,8 +35,9 @@ export const parseDestination = async ({
   displayCurrency,
   preferLnurlForInternalHandles,
 }: ParseDestinationParams): Promise<ParseDestinationResult> => {
+  const destination = rawInput.trim()
   const parsedDestination = parsePaymentDestination({
-    destination: rawInput,
+    destination,
     network: bitcoinNetwork as NetworkGaloyClient,
     lnAddressDomains: lnurlDomains,
     inputSource,
@@ -105,7 +106,7 @@ export const parseDestination = async ({
       // BIP-21 unified URIs carrying a lightning=LNURL param end up here because
       // parsePaymentDestination only resolves bolt11 lightning params. Prefer the
       // lightning option and keep the onchain address as fallback.
-      const lnurl = getLnurlFromUnifiedUri(rawInput)
+      const lnurl = getLnurlFromUnifiedUri(destination)
       if (lnurl) {
         try {
           const lnurlDestination = await resolveLnurlDestination({

--- a/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
+++ b/app/screens/send-bitcoin-screen/payment-destination/resolve-destination.ts
@@ -24,12 +24,14 @@ export type SparkSession = {
  * parseDestination with account-aware resolution: a custodial sender re-tries a Blink
  * username that is not a custodial account as a lightning address over LNURL; a
  * self-custodial sender resolves and wraps through the connected SDK.
+ * Surrounding whitespace is trimmed off the raw input before any parsing.
  */
 export const resolveDestination = async (
-  params: ParseDestinationParams,
+  rawParams: ParseDestinationParams,
   session: SparkSession,
   lnAddressHostname: string,
 ): Promise<ParseDestinationResult> => {
+  const params = { ...rawParams, rawInput: rawParams.rawInput.trim() }
   const { sdk, network } = session
   if (!sdk) {
     const parsed = await parseDestination(params)

--- a/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
+++ b/app/screens/send-bitcoin-screen/send-bitcoin-destination-screen.tsx
@@ -616,7 +616,7 @@ const SendBitcoinDestinationScreen: React.FC<Props> = ({ route }) => {
     if (destinationState.destinationState === DestinationState.Validating) return
     onFocusedInput(InputType.Search)
     try {
-      const clipboard = await Clipboard.getString()
+      const clipboard = (await Clipboard.getString()).trim()
       updateMatchingContacts(clipboard)
       dispatchDestinationStateAction({
         type: SendBitcoinActions.SetUnparsedPastedDestination,


### PR DESCRIPTION
Closes #4073

## What

A destination entered with a leading or trailing space — ` user@blink.sv ` instead of `user@blink.sv` — was rejected as an invalid destination, with no hint about why. This happens easily when copying an address from a chat app that appends whitespace. Reported for both custodial and self-custodial sends.

## Why it broke

Every destination (typed, pasted, QR-scanned, deep-linked, NFC) funnels into `parsePaymentDestination()` from `@blinkbitcoin/blink-client`, which does not trim its input: a stray space makes payment-type detection fall through to `Unknown`. The self-custodial Spark path happened to trim internally, and trimming at the parse boundary is the existing convention elsewhere (`phone.ts`, `card-screen/utils/address.ts`) — this chain was the one boundary that missed it.

## How

- `parseDestination` trims `rawInput` before handing it to `parsePaymentDestination` (and to the BIP-21 unified-URI lookup). This single point also covers NFC, which calls `parseDestination` directly.
- `resolveDestination` normalizes `rawInput` at entry, so the Spark pre-check and the username re-parse callback see trimmed input by contract rather than by accident.
- `handlePaste` trims clipboard content before storing it, so the input box shows the cleaned value.

Typed input is deliberately **not** trimmed in state: the reducer drops validation results whose `unparsedDestination` echo doesn't match state (so the trim must live inside the resolvers), and the search field doubles as a multi-word contact search where trimming as you type would break entering a second word.

## Tests

- `resolve-destination.spec.ts`: trim assertions for both the custodial and self-custodial paths.
- `resolve-destination.integration.spec.ts` (real parser): `"  esaudeveloper@blink.sv  "` resolves as valid, plus a direct `parseDestination` case pinning the NFC path. Both fail without the fix.
- `send-destination.spec.tsx`: pasting `"  clipboard  "` validates the trimmed value and displays the cleaned string; typing a padded destination and pressing Next validates the trimmed value.