### PR TITLE
ci: run tests on small self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   check-code:
     name: Tests
-    runs-on: [self-hosted, blink, heavy]
+    runs-on: [self-hosted, blink, small]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -26,4 +26,6 @@ jobs:
       # failing tests in CI (see jest.setup-after-env.ts) and logs each retried
       # error, instead of silently re-running the whole job.
       - run: yarn test
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
         timeout-minutes: 20


### PR DESCRIPTION
## Problem

The blink-mobile Tests workflow shares the heavy self-hosted pool with long-running blink Nix, Docker, and Tilt jobs. PR test bursts can therefore wait for a heavy slot even though this job only runs Node/Yarn work.

## Fix

Route Tests to the new static four-runner small pool with the self-hosted, blink, and small labels. Each small runner has 4 vCPU and 8 GiB RAM, and one is placed on each host.

Keep Jest's V8 heap at 4 GiB explicitly. Node otherwise reduces its default heap from about 4.19 GiB on a heavy runner to about 2.19 GiB on an 8 GiB runner, despite the VM having sufficient free memory.

## Test plan

- [x] Parse the updated workflow YAML
- [x] Verify blink-ci-small-1 through blink-ci-small-4 completed cloud-init
- [x] Verify all four runners connected to GitHub, registered in the blink-ci group, and are listening for jobs
- [x] Verify all four runners use the blink,small labels
- [x] Verify this PR's Tests job ran successfully on blink-ci-small-4
- [x] Verify live memory headroom: 3.7 GiB available while Jest used about 3.3 GiB RSS
